### PR TITLE
[codex] bump AppTheory to v0.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Add the framework peers that match your adapter surface:
 
 Optional companion packages from pinned GitHub releases:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-cdk-0.22.0.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz`
 
 ## Quickstart

--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -7,8 +7,8 @@ This file records the currently pinned versions and the exact install strings we
 
 ## Pins
 
-- AppTheory (TypeScript): `v0.22.0`
-- AppTheory (CDK): `v0.22.0`
+- AppTheory (TypeScript): `v0.24.0`
+- AppTheory (CDK): `v0.24.0`
 - TableTheory (TypeScript): `v1.5.3`
 
 ## Install (npm)
@@ -16,7 +16,7 @@ This file records the currently pinned versions and the exact install strings we
 ```bash
   # AppTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz
 
   # TableTheory (TS)
 npm install --save-exact \
@@ -24,7 +24,7 @@ npm install --save-exact \
 
   # AppTheory CDK (only for infra projects)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-cdk-0.22.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz
 ```
 
 ## package.json Snippet (Pinned)
@@ -35,7 +35,7 @@ registry installs:
 ```json
 {
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz"
   },
   "overrides": {

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -92,7 +92,7 @@ patterns:
     solution: "Use exact release asset URLs documented in the compatibility pins."
     correct_example: |
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz
       npm install --save-exact \
         https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz
     anti_patterns:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ These are only required if your application uses the corresponding integration s
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz
 
 npm install --save-exact \
   https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz

--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -9,8 +9,8 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1005.0",
         "@aws-sdk/client-s3": "^3.1005.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-cdk-0.22.0.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
@@ -2459,9 +2459,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "0.22.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz",
-      "integrity": "sha512-qNY4TGRSpRw7HDh647t8EZSSaSsdQu/m23zibQCH1hVJptxn3ohGUg/mVBuZkLkwkiQvctv192Rm4u8M1jnduw==",
+      "version": "0.24.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
+      "integrity": "sha512-jjbOD6Bfo32f+aB/YrVQnPrfQmNBTo+emXRGUA2+3jhNTgAmVLtnHLf19ujLR5ZS0f1MUp3/AyNXQaOBTTDmEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "0.22.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-cdk-0.22.0.tgz",
-      "integrity": "sha512-dpdQluzdy+0S26SJy22x2UR3ju3KzFxajD34FcwCHjG1LXIOV5HBpp2QwxuWH9TKdxV84MCFqiv120lEz4CI/w==",
+      "version": "0.24.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
+      "integrity": "sha512-UVq5y1oORDQ+MEDE0pPK5b7uBP8YB2kMstXBIiXsyCIZHkkGAwaOWktspIOZFxy9b9dJ0rU7obprSlb1J+h/iw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssg-isr-site/package.json
+++ b/infra/apptheory-ssg-isr-site/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1005.0",
     "@aws-sdk/client-s3": "^3.1005.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-cdk-0.22.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-cdk-0.22.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
         "constructs": "10.6.0",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "0.22.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-cdk-0.22.0.tgz",
-      "integrity": "sha512-dpdQluzdy+0S26SJy22x2UR3ju3KzFxajD34FcwCHjG1LXIOV5HBpp2QwxuWH9TKdxV84MCFqiv120lEz4CI/w==",
+      "version": "0.24.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
+      "integrity": "sha512-UVq5y1oORDQ+MEDE0pPK5b7uBP8YB2kMstXBIiXsyCIZHkkGAwaOWktspIOZFxy9b9dJ0rU7obprSlb1J+h/iw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,7 +12,7 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-cdk-0.22.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",
     "constructs": "10.6.0",

--- a/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
+++ b/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
@@ -355,34 +355,6 @@
         "SsrFunctionServiceRoleF0484DAB"
       ]
     },
-    "SsrFunctioninvokefunctionurlBB9A2B69": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunctionUrl",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "SsrFunctionD22C6F1E",
-            "Arn"
-          ]
-        },
-        "FunctionUrlAuthType": "NONE",
-        "Principal": "*"
-      }
-    },
-    "SsrFunctioninvokefunctionCE3E5B81": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "SsrFunctionD22C6F1E",
-            "Arn"
-          ]
-        },
-        "InvokedViaFunctionUrl": true,
-        "Principal": "*"
-      }
-    },
     "AssetsDeploymentImmutableAwsCliLayer40CE6A61": {
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
@@ -683,6 +655,13 @@
             }
           ]
         },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
+            }
+          ]
+        },
         "PublicAccessBlockConfiguration": {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,
@@ -807,7 +786,7 @@
     "SiteSsrUrl2D74149D": {
       "Type": "AWS::Lambda::Url",
       "Properties": {
-        "AuthType": "NONE",
+        "AuthType": "AWS_IAM",
         "InvokeMode": "RESPONSE_STREAM",
         "TargetFunctionArn": {
           "Fn::GetAtt": [
@@ -827,16 +806,14 @@
           "HeadersConfig": {
             "HeaderBehavior": "whitelist",
             "Headers": [
-              "accept",
-              "accept-language",
-              "cache-control",
-              "host",
-              "if-none-match",
-              "user-agent",
-              "x-forwarded-for",
-              "x-forwarded-proto",
               "cloudfront-forwarded-proto",
               "cloudfront-viewer-address",
+              "x-apptheory-original-host",
+              "x-facetheory-original-host",
+              "x-apptheory-original-uri",
+              "x-facetheory-original-uri",
+              "x-request-id",
+              "x-tenant-id",
               "x-facetheory-tenant"
             ]
           },
@@ -844,6 +821,135 @@
           "QueryStringsConfig": {
             "QueryStringBehavior": "all"
           }
+        }
+      }
+    },
+    "SiteSsrViewerRequestFunction103872E5": {
+      "Type": "AWS::CloudFront::Function",
+      "Properties": {
+        "AutoPublish": true,
+        "FunctionCode": "function handler(event) {\n\t  var request = event.request;\n\t  var headers = request.headers;\n\t  var uri = request.uri || '/';\n\t  var requestIdHeader = headers['x-request-id'];\n\t  var requestId = requestIdHeader && requestIdHeader.value ? requestIdHeader.value.trim() : '';\n\n\t  if (!requestId) {\n\t    requestId = event.context && event.context.requestId ? String(event.context.requestId).trim() : '';\n\t  }\n\n\t  if (!requestId) {\n\t    requestId = 'req_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);\n\t  }\n\n\t  headers['x-request-id'] = { value: requestId };\n\t  headers['x-apptheory-original-uri'] = { value: uri };\n\t  headers['x-facetheory-original-uri'] = { value: uri };\n\n\t  if (headers.host && headers.host.value) {\n\t    headers['x-apptheory-original-host'] = { value: headers.host.value };\n\t    headers['x-facetheory-original-host'] = { value: headers.host.value };\n\t  }\n\n\t  if ('ssr-only' === 'ssg-isr') {\n\t    var directS3Prefixes = [\n\t      '/_facetheory/data',\n      '/assets',\n      '/.vite'\n\t    ];\n\t    var isDirectS3Path = false;\n\n\t    for (var i = 0; i < directS3Prefixes.length; i++) {\n\t      var prefix = directS3Prefixes[i];\n\t      if (uri === prefix || uri.startsWith(prefix + '/')) {\n\t        isDirectS3Path = true;\n\t        break;\n\t      }\n\t    }\n\n\t    if (!isDirectS3Path) {\n\t      var lastSlash = uri.lastIndexOf('/');\n\t      var lastSegment = lastSlash >= 0 ? uri.substring(lastSlash + 1) : uri;\n\n\t      if (lastSegment.indexOf('.') === -1) {\n\t        request.uri = uri.endsWith('/') ? uri + 'index.html' : uri + '/index.html';\n\t      }\n\t    }\n\t  }\n\n\t  return request;\n\t}",
+        "FunctionConfig": {
+          "Comment": "FaceTheory viewer-request edge context for SSR site",
+          "Runtime": "cloudfront-js-2.0"
+        },
+        "Name": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::Region"
+              },
+              "FaceTheoryAppTherRequestFunction4DEF6843"
+            ]
+          ]
+        }
+      }
+    },
+    "SiteSsrViewerResponseFunction3CF15787": {
+      "Type": "AWS::CloudFront::Function",
+      "Properties": {
+        "AutoPublish": true,
+        "FunctionCode": "function handler(event) {\n\t  var request = event.request;\n\t  var response = event.response;\n\t  var requestIdHeader = request.headers['x-request-id'];\n\t  var requestId = requestIdHeader && requestIdHeader.value ? requestIdHeader.value.trim() : '';\n\n\t  if (!requestId) {\n\t    requestId = event.context && event.context.requestId ? String(event.context.requestId).trim() : '';\n\t  }\n\n\t  if (requestId) {\n\t    response.headers = response.headers || {};\n\t    if (!response.headers['x-request-id']) {\n\t      response.headers['x-request-id'] = { value: requestId };\n\t    }\n\t  }\n\n\t  return response;\n\t}",
+        "FunctionConfig": {
+          "Comment": "FaceTheory viewer-response request-id echo for SSR site",
+          "Runtime": "cloudfront-js-2.0"
+        },
+        "Name": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::Region"
+              },
+              "FaceTheoryAppTheResponseFunction39325CE9"
+            ]
+          ]
+        }
+      }
+    },
+    "SiteResponseHeadersPolicy5F343E8C": {
+      "Type": "AWS::CloudFront::ResponseHeadersPolicy",
+      "Properties": {
+        "ResponseHeadersPolicyConfig": {
+          "Comment": "FaceTheory baseline security headers (CSP stays origin-defined)",
+          "CustomHeadersConfig": {
+            "Items": [
+              {
+                "Header": "permissions-policy",
+                "Override": true,
+                "Value": "camera=(), microphone=(), geolocation=()"
+              }
+            ]
+          },
+          "Name": "FaceTheoryAppTheorySsrSiteResponseHeadersPolicy26FEC031",
+          "SecurityHeadersConfig": {
+            "ContentTypeOptions": {
+              "Override": true
+            },
+            "FrameOptions": {
+              "FrameOption": "DENY",
+              "Override": true
+            },
+            "ReferrerPolicy": {
+              "Override": true,
+              "ReferrerPolicy": "strict-origin-when-cross-origin"
+            },
+            "StrictTransportSecurity": {
+              "AccessControlMaxAgeSec": 63072000,
+              "IncludeSubdomains": true,
+              "Override": true,
+              "Preload": true
+            },
+            "XSSProtection": {
+              "ModeBlock": true,
+              "Override": true,
+              "Protection": true
+            }
+          }
+        }
+      }
+    },
+    "SiteDistributionOrigin1FunctionUrlOriginAccessControlFF5C1633": {
+      "Type": "AWS::CloudFront::OriginAccessControl",
+      "Properties": {
+        "OriginAccessControlConfig": {
+          "Name": "FaceTheoryAppTheorySsrSiteDinctionUrlOriginAccessControl506FC69E",
+          "OriginAccessControlOriginType": "lambda",
+          "SigningBehavior": "always",
+          "SigningProtocol": "sigv4"
+        }
+      }
+    },
+    "SiteDistributionOrigin1InvokeFromApiForFaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA468D34E14C": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunctionUrl",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SiteSsrUrl2D74149D",
+            "FunctionArn"
+          ]
+        },
+        "Principal": "cloudfront.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":cloudfront::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":distribution/",
+              {
+                "Ref": "SiteDistribution390DED28"
+              }
+            ]
+          ]
         }
       }
     },
@@ -869,9 +975,32 @@
                 "HEAD",
                 "OPTIONS"
               ],
-              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
               "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
               "PathPattern": "assets/*",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
               "TargetOriginId": "FaceTheoryAppTheorySsrSiteDistributionOrigin27438863E",
               "ViewerProtocolPolicy": "redirect-to-https"
             },
@@ -881,9 +1010,32 @@
                 "HEAD",
                 "OPTIONS"
               ],
-              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
               "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
               "PathPattern": ".vite/*",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
               "TargetOriginId": "FaceTheoryAppTheorySsrSiteDistributionOrigin27438863E",
               "ViewerProtocolPolicy": "redirect-to-https"
             },
@@ -893,9 +1045,32 @@
                 "HEAD",
                 "OPTIONS"
               ],
-              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
               "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
               "PathPattern": "_facetheory/data/*",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
               "TargetOriginId": "FaceTheoryAppTheorySsrSiteDistributionOrigin27438863E",
               "ViewerProtocolPolicy": "redirect-to-https"
             }
@@ -910,10 +1085,33 @@
               "POST",
               "DELETE"
             ],
-            "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+            "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
             "Compress": true,
+            "FunctionAssociations": [
+              {
+                "EventType": "viewer-request",
+                "FunctionARN": {
+                  "Fn::GetAtt": [
+                    "SiteSsrViewerRequestFunction103872E5",
+                    "FunctionARN"
+                  ]
+                }
+              },
+              {
+                "EventType": "viewer-response",
+                "FunctionARN": {
+                  "Fn::GetAtt": [
+                    "SiteSsrViewerResponseFunction3CF15787",
+                    "FunctionARN"
+                  ]
+                }
+              }
+            ],
             "OriginRequestPolicyId": {
               "Ref": "SiteSsrOriginRequestPolicyF6A13560"
+            },
+            "ResponseHeadersPolicyId": {
+              "Ref": "SiteResponseHeadersPolicy5F343E8C"
             },
             "TargetOriginId": "FaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA46",
             "ViewerProtocolPolicy": "redirect-to-https"
@@ -954,7 +1152,13 @@
                   }
                 ]
               },
-              "Id": "FaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA46"
+              "Id": "FaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA46",
+              "OriginAccessControlId": {
+                "Fn::GetAtt": [
+                  "SiteDistributionOrigin1FunctionUrlOriginAccessControlFF5C1633",
+                  "Id"
+                ]
+              }
             },
             {
               "DomainName": {

--- a/ts/README.md
+++ b/ts/README.md
@@ -19,8 +19,8 @@ Install the peers that match your adapter surface:
 
 Optional companion packages:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-cdk-0.22.0.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz`
 
 ## Minimal App

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -15,7 +15,7 @@
         "@emotion/server": "^11.11.0",
         "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^24.12.0",
@@ -4406,9 +4406,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "0.22.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz",
-      "integrity": "sha512-qNY4TGRSpRw7HDh647t8EZSSaSsdQu/m23zibQCH1hVJptxn3ohGUg/mVBuZkLkwkiQvctv192Rm4u8M1jnduw==",
+      "version": "0.24.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
+      "integrity": "sha512-jjbOD6Bfo32f+aB/YrVQnPrfQmNBTo+emXRGUA2+3jhNTgAmVLtnHLf19ujLR5ZS0f1MUp3/AyNXQaOBTTDmEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -190,7 +190,7 @@
     "@emotion/server": "^11.11.0",
     "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.22.0/theory-cloud-apptheory-0.22.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^24.12.0",


### PR DESCRIPTION
## Summary
- bump FaceTheory's AppTheory runtime and CDK pins from `v0.22.0` to `v0.24.0`
- refresh the checked-in lockfiles and AppTheory install docs to match the new release assets
- update the `apptheory-ssr-site` snapshot for the `AppTheorySsrSite` template changes in `v0.24.0`

## Why
`v0.24.0` is the current published AppTheory release as of April 12, 2026, and FaceTheory should validate against that release instead of the older `v0.22.0` tarballs.

## Validation
- `cd ts && npm run lint && npm run typecheck && npm test && npm run build`
- `cd infra/apptheory-ssr-site && npm test`
- `cd infra/apptheory-ssg-isr-site && npm test`
