### PR TITLE
[codex] fail main PRs that would skip release-please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,65 +22,21 @@ jobs:
           fetch-depth: 0
       - name: Verify user-facing conventional commits exist
         run: |
-          set -euo pipefail
-
           git fetch origin premain staging --force
-          range="origin/premain..origin/staging"
+          scripts/verify-release-readiness.sh origin/premain origin/staging prerelease
 
-          echo "Checking commits in ${range}..."
-          if git log --format=%s "${range}" | grep -Eq '^(feat|fix|perf)(\([^)]+\))?(!)?: '; then
-            echo "prerelease-ready: OK"
-            exit 0
-          fi
-
-          mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMR origin/premain...origin/staging)
-          if [[ "${#changed_files[@]}" -gt 0 ]]; then
-            release_sync_only="true"
-            for path in "${changed_files[@]}"; do
-              case "${path}" in
-                .github/workflows/* \
-                | .release-please-manifest*.json \
-                | release-please-config*.json \
-                | VERSION \
-                | CHANGELOG.md \
-                | README.md \
-                | Makefile \
-                | .gitignore \
-                | docs/README.md \
-                | docs/api-reference.md \
-                | docs/getting-started.md \
-                | scripts/build-release-assets.sh \
-                | scripts/generate-checksums.sh \
-                | scripts/read-version.sh \
-                | scripts/render-release-notes.sh \
-                | scripts/verify-release-branch.sh \
-                | scripts/verify-ts-pack.sh \
-                | scripts/verify-version-alignment.sh \
-                | ts/README.md \
-                | ts/package-lock.json \
-                | ts/package.json)
-                  ;;
-                *)
-                  release_sync_only="false"
-                  break
-                  ;;
-              esac
-            done
-
-            if [[ "${release_sync_only}" == "true" ]]; then
-              echo "prerelease-ready: OK (release sync only change)"
-              printf '%s\n' "${changed_files[@]}"
-              exit 0
-            fi
-          fi
-
-          echo "prerelease-ready: FAIL"
-          echo "No user-facing conventional commits (feat:/fix:/perf:) found in ${range}."
-          echo "release-please will skip, so no new prerelease tag will be cut."
-          echo
-          echo "Commit subjects:"
-          git log --format=%s "${range}" || true
-          exit 1
+  release-readiness:
+    name: Release readiness (PR -> main)
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Verify user-facing conventional commits exist
+        run: |
+          git fetch origin "${{ github.event.pull_request.base.ref }}" --force
+          scripts/verify-release-readiness.sh "origin/${{ github.event.pull_request.base.ref }}" HEAD release
 
   version-alignment:
     name: Version alignment

--- a/scripts/verify-release-readiness.sh
+++ b/scripts/verify-release-readiness.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+base_ref="${1:-}"
+head_ref="${2:-}"
+context_label="${3:-release}"
+
+if [[ -z "${base_ref}" || -z "${head_ref}" ]]; then
+  echo "${context_label}-readiness: FAIL (usage: scripts/verify-release-readiness.sh <base-ref> <head-ref> [context-label])"
+  exit 1
+fi
+
+range="${base_ref}..${head_ref}"
+diff_range="${base_ref}...${head_ref}"
+
+echo "Checking commits in ${range}..."
+if git log --format=%s "${range}" | grep -Eq '^(feat|fix|perf)(\([^)]+\))?(!)?: '; then
+  echo "${context_label}-readiness: OK"
+  exit 0
+fi
+
+mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMR "${diff_range}")
+if [[ "${#changed_files[@]}" -gt 0 ]]; then
+  release_sync_only="true"
+  for path in "${changed_files[@]}"; do
+    case "${path}" in
+      .github/workflows/* \
+      | .release-please-manifest*.json \
+      | release-please-config*.json \
+      | VERSION \
+      | CHANGELOG.md \
+      | README.md \
+      | Makefile \
+      | .gitignore \
+      | docs/README.md \
+      | docs/api-reference.md \
+      | docs/getting-started.md \
+      | scripts/build-release-assets.sh \
+      | scripts/generate-checksums.sh \
+      | scripts/read-version.sh \
+      | scripts/render-release-notes.sh \
+      | scripts/verify-release-branch.sh \
+      | scripts/verify-release-readiness.sh \
+      | scripts/verify-ts-pack.sh \
+      | scripts/verify-version-alignment.sh \
+      | ts/README.md \
+      | ts/package-lock.json \
+      | ts/package.json)
+        ;;
+      *)
+        release_sync_only="false"
+        break
+        ;;
+    esac
+  done
+
+  if [[ "${release_sync_only}" == "true" ]]; then
+    echo "${context_label}-readiness: OK (release sync only change)"
+    printf '%s\n' "${changed_files[@]}"
+    exit 0
+  fi
+fi
+
+echo "${context_label}-readiness: FAIL"
+echo "No user-facing conventional commits (feat:/fix:/perf:) found in ${range}."
+echo "release-please will skip, so no new release PR will be cut."
+echo
+echo "Commit subjects:"
+git log --format=%s "${range}" || true
+exit 1


### PR DESCRIPTION
## Summary
- add a reusable `scripts/verify-release-readiness.sh` helper for release-please readiness checks
- reuse that helper for the existing `staging -> premain` prerelease gate
- add a new CI gate for PRs into `main` so release-skipping changes fail before merge

## Why
PR #34 merged cleanly, but it used a `chore:` commit subject, so the `Release PR (main)` workflow ran and then skipped creating a release PR. This change makes that failure mode visible in CI before merge instead of after the fact.

## Validation
- `./scripts/verify-release-readiness.sh e76cf63598b0340e8d056dfda155b52c3acadd43 0ad1f46f6c02f37b17cc13dc79f154d4a78912f9 release` (expected fail for the merged AppTheory `chore:` bump)
- `./scripts/verify-release-readiness.sh 5269214b7c233306c170dab26c9c995116267848 c86f9714c8dcb649999a482171cdabb6abc1c38b release` (expected pass for a releasable `feat:` range)
- `./scripts/verify-release-readiness.sh c86f9714c8dcb649999a482171cdabb6abc1c38b 498bd1c494da62acae6a933949b32e336a603325 release` (expected pass for release-sync-only churn)
- `bash -n scripts/verify-release-readiness.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml: OK"'`
- `git diff --check`
