### PR TITLE
[codex] align FaceTheory with AppTheory v0.24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Add the framework peers that match your adapter surface:
 
 Optional companion packages from pinned GitHub releases:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz`
 
 ## Quickstart

--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -20,6 +20,11 @@ SSR/SSG/ISR.
 AppTheory CDK ships `AppTheorySsrSite`, which implements this topology and wires recommended environment variables onto
 your SSR Lambda function.
 
+When using `AppTheorySsrSite` in `ssg-isr` mode:
+- use `staticPathPatterns` for cacheable extensionless HTML sections that should stay on S3
+- use `directS3PathPatterns` for raw object/data paths such as `/.vite/*` and `/_facetheory/data/*`
+- use `ssrPathPatterns` for same-origin dynamic routes that must bypass the S3-primary origin group and go straight to Lambda
+
 Reference example (FaceTheory repo):
 - `infra/apptheory-ssr-site/`
 - `infra/apptheory-ssg-isr-site/` (SSG origin-group + ISR example)

--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -7,8 +7,8 @@ This file records the currently pinned versions and the exact install strings we
 
 ## Pins
 
-- AppTheory (TypeScript): `v0.24.0`
-- AppTheory (CDK): `v0.24.0`
+- AppTheory (TypeScript): `v0.24.1`
+- AppTheory (CDK): `v0.24.1`
 - TableTheory (TypeScript): `v1.5.3`
 
 ## Install (npm)
@@ -16,7 +16,7 @@ This file records the currently pinned versions and the exact install strings we
 ```bash
   # AppTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz
 
   # TableTheory (TS)
 npm install --save-exact \
@@ -24,7 +24,7 @@ npm install --save-exact \
 
   # AppTheory CDK (only for infra projects)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz
 ```
 
 ## package.json Snippet (Pinned)
@@ -35,7 +35,7 @@ registry installs:
 ```json
 {
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz"
   },
   "overrides": {

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -92,7 +92,7 @@ patterns:
     solution: "Use exact release asset URLs documented in the compatibility pins."
     correct_example: |
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz
       npm install --save-exact \
         https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz
     anti_patterns:

--- a/docs/cdk/aws-deployment.md
+++ b/docs/cdk/aws-deployment.md
@@ -56,6 +56,7 @@ Requirements:
 - rewrite extensionless paths to S3 HTML keys
 - preserve the original viewer path for Lambda failover routing
 - keep SSR cache headers explicit and conservative
+- when using `AppTheorySsrSite`, treat `staticPathPatterns` as HTML sections, `directS3PathPatterns` as raw data/object paths, and `ssrPathPatterns` as Lambda-only dynamic routes
 
 ### Strategy B: Explicit Static Behaviors
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ These are only required if your application uses the corresponding integration s
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz
 
 npm install --save-exact \
   https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz

--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -9,8 +9,8 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1005.0",
         "@aws-sdk/client-s3": "^3.1005.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
@@ -2459,9 +2459,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "0.24.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
-      "integrity": "sha512-jjbOD6Bfo32f+aB/YrVQnPrfQmNBTo+emXRGUA2+3jhNTgAmVLtnHLf19ujLR5ZS0f1MUp3/AyNXQaOBTTDmEQ==",
+      "version": "0.24.1",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
+      "integrity": "sha512-VW2Y5jpKyI0JRVzQCmImynjKZ6n6nC4hXbhSWKxXCM+5DkVLkjbgdg68VzG5lvqmtegPmf9X1ho5phILHYADAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "0.24.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
-      "integrity": "sha512-UVq5y1oORDQ+MEDE0pPK5b7uBP8YB2kMstXBIiXsyCIZHkkGAwaOWktspIOZFxy9b9dJ0rU7obprSlb1J+h/iw==",
+      "version": "0.24.1",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
+      "integrity": "sha512-xjWZ3nzX+Ccv5hlqEd89T7Jfr/8VIuoa4PxIyO1Y5jFyW2qCJ2piopOlOb/r6copcW/zcY2OLLvUMl39ie6d4g==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssg-isr-site/package.json
+++ b/infra/apptheory-ssg-isr-site/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1005.0",
     "@aws-sdk/client-s3": "^3.1005.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
         "constructs": "10.6.0",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "0.24.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
-      "integrity": "sha512-UVq5y1oORDQ+MEDE0pPK5b7uBP8YB2kMstXBIiXsyCIZHkkGAwaOWktspIOZFxy9b9dJ0rU7obprSlb1J+h/iw==",
+      "version": "0.24.1",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
+      "integrity": "sha512-xjWZ3nzX+Ccv5hlqEd89T7Jfr/8VIuoa4PxIyO1Y5jFyW2qCJ2piopOlOb/r6copcW/zcY2OLLvUMl39ie6d4g==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,7 +12,7 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",
     "constructs": "10.6.0",

--- a/infra/apptheory-ssr-site/src/stack.ts
+++ b/infra/apptheory-ssr-site/src/stack.ts
@@ -108,7 +108,9 @@ exports.handler = awslambda.streamifyResponse(async (event, responseStream, cont
       assetsKeyPrefix: 'assets',
       // Vite commonly emits `.vite/manifest.json` in the client build output.
       assetsManifestKey: '.vite/manifest.json',
-      staticPathPatterns: ['/.vite/*', '/_facetheory/data/*'],
+      // Raw object/data paths stay on direct S3 behaviors; `staticPathPatterns` is now for
+      // extensionless HTML sections in AppTheorySsrSite.
+      directS3PathPatterns: ['/.vite/*', '/_facetheory/data/*'],
       // FaceTheory multi-tenant header (optional).
       ssrForwardHeaders: ['x-facetheory-tenant'],
       enableLogging: true,

--- a/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
+++ b/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
@@ -355,6 +355,39 @@
         "SsrFunctionServiceRoleF0484DAB"
       ]
     },
+    "SsrFunctionAllowCloudFrontInvokeFunctionViaUrl8D4F8C8A": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SsrFunctionD22C6F1E",
+            "Arn"
+          ]
+        },
+        "InvokedViaFunctionUrl": true,
+        "Principal": "cloudfront.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":cloudfront::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":distribution/",
+              {
+                "Ref": "SiteDistribution390DED28"
+              }
+            ]
+          ]
+        }
+      }
+    },
     "AssetsDeploymentImmutableAwsCliLayer40CE6A61": {
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
@@ -824,11 +857,80 @@
         }
       }
     },
+    "SiteHtmlOriginRequestPolicy308D38C5": {
+      "Type": "AWS::CloudFront::OriginRequestPolicy",
+      "Properties": {
+        "OriginRequestPolicyConfig": {
+          "CookiesConfig": {
+            "CookieBehavior": "none"
+          },
+          "HeadersConfig": {
+            "HeaderBehavior": "whitelist",
+            "Headers": [
+              "cloudfront-forwarded-proto",
+              "cloudfront-viewer-address",
+              "x-apptheory-original-host",
+              "x-facetheory-original-host",
+              "x-apptheory-original-uri",
+              "x-facetheory-original-uri",
+              "x-request-id",
+              "x-tenant-id",
+              "x-facetheory-tenant"
+            ]
+          },
+          "Name": "FaceTheoryAppTheorySsrSiteHtmlOriginRequestPolicy46FBEFF3",
+          "QueryStringsConfig": {
+            "QueryStringBehavior": "all"
+          }
+        }
+      }
+    },
+    "SiteHtmlCachePolicy2B4843D5": {
+      "Type": "AWS::CloudFront::CachePolicy",
+      "Properties": {
+        "CachePolicyConfig": {
+          "Comment": "FaceTheory HTML cache policy keyed by query strings and stable public variant headers",
+          "DefaultTTL": 0,
+          "MaxTTL": 31536000,
+          "MinTTL": 0,
+          "Name": {
+            "Fn::Join": [
+              "",
+              [
+                "FaceTheoryAppTheorySsrSiteHtmlCachePolicyAF6B8BB0-",
+                {
+                  "Ref": "AWS::Region"
+                }
+              ]
+            ]
+          },
+          "ParametersInCacheKeyAndForwardedToOrigin": {
+            "CookiesConfig": {
+              "CookieBehavior": "none"
+            },
+            "EnableAcceptEncodingBrotli": true,
+            "EnableAcceptEncodingGzip": true,
+            "HeadersConfig": {
+              "HeaderBehavior": "whitelist",
+              "Headers": [
+                "x-apptheory-original-host",
+                "x-facetheory-original-host",
+                "x-tenant-id",
+                "x-facetheory-tenant"
+              ]
+            },
+            "QueryStringsConfig": {
+              "QueryStringBehavior": "all"
+            }
+          }
+        }
+      }
+    },
     "SiteSsrViewerRequestFunction103872E5": {
       "Type": "AWS::CloudFront::Function",
       "Properties": {
         "AutoPublish": true,
-        "FunctionCode": "function handler(event) {\n\t  var request = event.request;\n\t  var headers = request.headers;\n\t  var uri = request.uri || '/';\n\t  var requestIdHeader = headers['x-request-id'];\n\t  var requestId = requestIdHeader && requestIdHeader.value ? requestIdHeader.value.trim() : '';\n\n\t  if (!requestId) {\n\t    requestId = event.context && event.context.requestId ? String(event.context.requestId).trim() : '';\n\t  }\n\n\t  if (!requestId) {\n\t    requestId = 'req_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);\n\t  }\n\n\t  headers['x-request-id'] = { value: requestId };\n\t  headers['x-apptheory-original-uri'] = { value: uri };\n\t  headers['x-facetheory-original-uri'] = { value: uri };\n\n\t  if (headers.host && headers.host.value) {\n\t    headers['x-apptheory-original-host'] = { value: headers.host.value };\n\t    headers['x-facetheory-original-host'] = { value: headers.host.value };\n\t  }\n\n\t  if ('ssr-only' === 'ssg-isr') {\n\t    var directS3Prefixes = [\n\t      '/_facetheory/data',\n      '/assets',\n      '/.vite'\n\t    ];\n\t    var isDirectS3Path = false;\n\n\t    for (var i = 0; i < directS3Prefixes.length; i++) {\n\t      var prefix = directS3Prefixes[i];\n\t      if (uri === prefix || uri.startsWith(prefix + '/')) {\n\t        isDirectS3Path = true;\n\t        break;\n\t      }\n\t    }\n\n\t    if (!isDirectS3Path) {\n\t      var lastSlash = uri.lastIndexOf('/');\n\t      var lastSegment = lastSlash >= 0 ? uri.substring(lastSlash + 1) : uri;\n\n\t      if (lastSegment.indexOf('.') === -1) {\n\t        request.uri = uri.endsWith('/') ? uri + 'index.html' : uri + '/index.html';\n\t      }\n\t    }\n\t  }\n\n\t  return request;\n\t}",
+        "FunctionCode": "function handler(event) {\n\t  var request = event.request;\n\t  var headers = request.headers;\n\t  var uri = request.uri || '/';\n\t  var requestIdHeader = headers['x-request-id'];\n\t  var requestId = requestIdHeader && requestIdHeader.value ? requestIdHeader.value.trim() : '';\n\n\t  if (!requestId) {\n\t    requestId = event.context && event.context.requestId ? String(event.context.requestId).trim() : '';\n\t  }\n\n\t  if (!requestId) {\n\t    requestId = 'req_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);\n\t  }\n\n\t  headers['x-request-id'] = { value: requestId };\n\t  headers['x-apptheory-original-uri'] = { value: uri };\n\t  headers['x-facetheory-original-uri'] = { value: uri };\n\n\t  if (headers.host && headers.host.value) {\n\t    headers['x-apptheory-original-host'] = { value: headers.host.value };\n\t    headers['x-facetheory-original-host'] = { value: headers.host.value };\n\t  }\n\n\t  if ('ssr-only' === 'ssg-isr') {\n\t    var rawS3Prefixes = [\n\t      '/_facetheory/data',\n      '/assets',\n      '/.vite'\n\t    ];\n\t    var lambdaPassthroughPrefixes = [\n\t      \n\t    ];\n\t    var isLambdaPassthroughPath = false;\n\n\t    for (var i = 0; i < lambdaPassthroughPrefixes.length; i++) {\n\t      var prefix = lambdaPassthroughPrefixes[i];\n\t      if (uri === prefix || uri.startsWith(prefix + '/')) {\n\t        isLambdaPassthroughPath = true;\n\t        break;\n\t      }\n\t    }\n\n\t    if (!isLambdaPassthroughPath) {\n\t      var isRawS3Path = false;\n\n\t      for (var j = 0; j < rawS3Prefixes.length; j++) {\n\t        var rawPrefix = rawS3Prefixes[j];\n\t        if (uri === rawPrefix || uri.startsWith(rawPrefix + '/')) {\n\t          isRawS3Path = true;\n\t          break;\n\t        }\n\t      }\n\n\t      var lastSlash = uri.lastIndexOf('/');\n\t      var lastSegment = lastSlash >= 0 ? uri.substring(lastSlash + 1) : uri;\n\n\t      if (!isRawS3Path && lastSegment.indexOf('.') === -1) {\n\t        request.uri = uri.endsWith('/') ? uri + 'index.html' : uri + '/index.html';\n\t      }\n\t    }\n\t  }\n\n\t  return request;\n\t}",
         "FunctionConfig": {
           "Comment": "FaceTheory viewer-request edge context for SSR site",
           "Runtime": "cloudfront-js-2.0"
@@ -1032,7 +1134,77 @@
                   }
                 }
               ],
+              "PathPattern": "assets",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsrSiteDistributionOrigin27438863E",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
               "PathPattern": ".vite/*",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsrSiteDistributionOrigin27438863E",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
+              "PathPattern": ".vite",
               "ResponseHeadersPolicyId": {
                 "Ref": "SiteResponseHeadersPolicy5F343E8C"
               },
@@ -1073,6 +1245,41 @@
               },
               "TargetOriginId": "FaceTheoryAppTheorySsrSiteDistributionOrigin27438863E",
               "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
+              "PathPattern": "_facetheory/data",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsrSiteDistributionOrigin27438863E",
+              "ViewerProtocolPolicy": "redirect-to-https"
             }
           ],
           "DefaultCacheBehavior": {
@@ -1085,7 +1292,7 @@
               "POST",
               "DELETE"
             ],
-            "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
+            "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
             "Compress": true,
             "FunctionAssociations": [
               {

--- a/ts/README.md
+++ b/ts/README.md
@@ -19,8 +19,8 @@ Install the peers that match your adapter surface:
 
 Optional companion packages:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-cdk-0.24.0.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz`
 
 ## Minimal App

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -15,7 +15,7 @@
         "@emotion/server": "^11.11.0",
         "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^24.12.0",
@@ -4406,9 +4406,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "0.24.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
-      "integrity": "sha512-jjbOD6Bfo32f+aB/YrVQnPrfQmNBTo+emXRGUA2+3jhNTgAmVLtnHLf19ujLR5ZS0f1MUp3/AyNXQaOBTTDmEQ==",
+      "version": "0.24.1",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
+      "integrity": "sha512-VW2Y5jpKyI0JRVzQCmImynjKZ6n6nC4hXbhSWKxXCM+5DkVLkjbgdg68VzG5lvqmtegPmf9X1ho5phILHYADAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -190,7 +190,7 @@
     "@emotion/server": "^11.11.0",
     "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.0/theory-cloud-apptheory-0.24.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^24.12.0",


### PR DESCRIPTION
## Summary
- bump FaceTheory to AppTheory `v0.24.1` across runtime, infra, and documented release pins
- align the SSR reference stack with AppTheory's updated routing contract by using `directS3PathPatterns` for raw object and data paths
- refresh deployment guidance and the SSR infra snapshot for the upstream SSR/ISR changes

## Why
AppTheory `v0.24.1` changed the `AppTheorySsrSite` routing model around SSR, SSG, and ISR behavior selection. FaceTheory needed a small infra alignment so the reference SSR stack continues to route `/.vite/*` and `/_facetheory/data/*` correctly under the new contract.

## Impact
- keeps FaceTheory's AppTheory integration current at `v0.24.1`
- preserves correct routing semantics for the SSR reference stack
- leaves the core FaceTheory runtime unchanged because no adapter changes were required by the upstream release

## Validation
- `cd ts && npm run lint`
- `cd ts && npm run typecheck`
- `cd ts && npm test`
- `cd ts && npm run build`
- `cd infra/apptheory-ssr-site && npm test`
- `cd infra/apptheory-ssg-isr-site && npm test`
