### PR TITLE
[codex] restore Stitch shell SSR navigation fallbacks

### DIFF
--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -321,6 +321,7 @@ Why this is correct:
 - Shared data contracts and semantic variants come from the framework-neutral `stitch-admin` and `stitch-shell` subpaths.
 - Visual primitives come from the matching framework adapter path.
 - The same conceptual primitives now exist across React, Vue, and Svelte, so porting a control-plane screen does not require redesigning the UI contract.
+- For shells and page frames, `path` remains the source of truth for SSR-safe anchor navigation, while `onNavigate` is only an optional interception layer for hydrated routers.
 
 **INCORRECT**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -148,6 +148,8 @@ const logs: LogEntry[] = [
 
 Use the shared contract subpaths for data shape and semantic variants. Use the adapter-matched subpaths for actual components. That keeps the React, Vue, and Svelte surfaces in lockstep instead of letting one host drift into framework-local shapes.
 
+For control-plane navigation, treat `path` as the SSR-safe baseline contract for nav items and breadcrumbs. Use `onNavigate` only as an optional client-side interception hook; if a host never hydrates, links with `path` must still work as normal anchors.
+
 ## Static Generation Quickstart
 
 Package consumers should call `buildSsgSite()` directly. The repository-local CLI remains available in the reference bundle if you want to study or adapt the example flow.

--- a/ts/src/react/stitch-shell/page-frame.ts
+++ b/ts/src/react/stitch-shell/page-frame.ts
@@ -15,23 +15,22 @@ export function Breadcrumb(props: BreadcrumbProps): React.ReactElement | null {
   if (items.length === 0) return null;
 
   const antItems = items.map((node) => {
-    if (node.path !== undefined && onNavigate) {
-      return {
-        key: node.key,
-        title: h(
-          'a',
-          {
-            onClick: (event: React.MouseEvent) => {
-              event.preventDefault();
-              onNavigate(node);
-            },
-            href: node.path,
-          },
-          node.label,
-        ),
+    if (node.path === undefined) return { key: node.key, title: node.label };
+
+    const anchorProps: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
+      href: node.path,
+    };
+    if (onNavigate !== undefined) {
+      anchorProps.onClick = (event) => {
+        event.preventDefault();
+        onNavigate(node);
       };
     }
-    return { key: node.key, title: node.label };
+
+    return {
+      key: node.key,
+      title: h('a', anchorProps, node.label),
+    };
   });
 
   return h(AntBreadcrumb, {

--- a/ts/src/react/stitch-shell/shell.ts
+++ b/ts/src/react/stitch-shell/shell.ts
@@ -8,35 +8,46 @@ const h = React.createElement;
 
 type MenuItemType = NonNullable<MenuProps['items']>[number];
 
-function navToMenuItems(items: NavItem[]): MenuItemType[] {
+function renderNavLabel(
+  item: NavItem,
+  onNavigate: ((path: string, key: string) => void) | undefined,
+): React.ReactNode {
+  const path = item.path;
+  if (path === undefined) return item.label;
+
+  const anchorProps: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
+    href: path,
+  };
+  if (onNavigate !== undefined) {
+    anchorProps.onClick = (event) => {
+      event.preventDefault();
+      onNavigate(path, item.key);
+    };
+  }
+
+  return h('a', anchorProps, item.label);
+}
+
+function navToMenuItems(
+  items: NavItem[],
+  onNavigate: ((path: string, key: string) => void) | undefined,
+): MenuItemType[] {
   const out: MenuItemType[] = [];
   for (const item of items) {
     if (item.hidden) continue;
     const children =
       item.children && item.children.length > 0
-        ? navToMenuItems(item.children)
+        ? navToMenuItems(item.children, onNavigate)
         : undefined;
     const menuItem: Record<string, unknown> = {
       key: item.key,
-      label: item.label,
+      label: renderNavLabel(item, onNavigate),
     };
     if (item.icon !== undefined) menuItem.icon = item.icon;
     if (children && children.length > 0) menuItem.children = children;
     out.push(menuItem as unknown as MenuItemType);
   }
   return out;
-}
-
-function flattenKeyToPath(items: NavItem[]): Map<string, string> {
-  const map = new Map<string, string>();
-  const walk = (list: NavItem[]) => {
-    for (const item of list) {
-      if (item.path !== undefined) map.set(item.key, item.path);
-      if (item.children) walk(item.children);
-    }
-  };
-  walk(items);
-  return map;
 }
 
 export interface SidebarProps {
@@ -55,18 +66,11 @@ export function Sidebar(props: SidebarProps): React.ReactElement {
   const { nav, activeKey, openKeys, collapsed, onNavigate, brand, footer } =
     props;
 
-  const items = React.useMemo(() => navToMenuItems(nav), [nav]);
-  const keyToPath = React.useMemo(() => flattenKeyToPath(nav), [nav]);
-
-  const handleClick: MenuProps['onClick'] = (info) => {
-    const path = keyToPath.get(String(info.key));
-    if (path !== undefined && onNavigate) onNavigate(path, String(info.key));
-  };
+  const items = React.useMemo(() => navToMenuItems(nav, onNavigate), [nav, onNavigate]);
 
   const menuProps: MenuProps = {
     mode: 'inline',
     items,
-    onClick: handleClick,
     style: { borderInlineEnd: 'none', background: 'transparent' },
   };
   if (activeKey !== undefined) menuProps.selectedKeys = [activeKey];
@@ -224,6 +228,7 @@ export function Shell(props: ShellProps): React.ReactElement {
     Layout,
     {
       className: 'facetheory-stitch-shell',
+      hasSider: true,
       style: { minHeight: '100vh' },
     },
     h(Sidebar, sidebarProps),

--- a/ts/src/svelte/stitch-shell/Breadcrumb.svelte
+++ b/ts/src/svelte/stitch-shell/Breadcrumb.svelte
@@ -16,10 +16,14 @@
         >
       {/if}
 
-      {#if node.path && onNavigate}
+      {#if node.path}
         <a
           href={node.path}
-          on:click|preventDefault={() => onNavigate?.(node)}
+          on:click={(event) => {
+            if (!onNavigate) return;
+            event.preventDefault();
+            onNavigate(node);
+          }}
         >
           {node.label}
         </a>

--- a/ts/src/vue/stitch-shell/page-frame.ts
+++ b/ts/src/vue/stitch-shell/page-frame.ts
@@ -44,15 +44,19 @@ export const Breadcrumb = defineComponent({
                 '›',
               )
             : null,
-          node.path !== undefined && props.onNavigate
+          node.path !== undefined
             ? h(
                 'a',
                 {
                   href: node.path,
-                  onClick: (event: MouseEvent) => {
-                    event.preventDefault();
-                    props.onNavigate?.(node);
-                  },
+                  ...(props.onNavigate !== undefined
+                    ? {
+                        onClick: (event: MouseEvent) => {
+                          event.preventDefault();
+                          props.onNavigate?.(node);
+                        },
+                      }
+                    : {}),
                 },
                 node.label,
               )

--- a/ts/test/unit/stitch-shell.test.ts
+++ b/ts/test/unit/stitch-shell.test.ts
@@ -117,6 +117,7 @@ test('Shell renders sidebar, topbar, and content region', async () => {
     }),
   );
   assert.ok(body.includes('facetheory-stitch-shell'));
+  assert.ok(body.includes('ant-layout-has-sider'));
   assert.ok(body.includes('facetheory-stitch-sidebar'));
   assert.ok(body.includes('facetheory-stitch-topbar'));
   assert.ok(body.includes('hello world'));
@@ -140,7 +141,21 @@ test('Shell hides nav items marked hidden', async () => {
   assert.ok(!sidebarSlice.includes('Settings'));
 });
 
-test('PageFrame renders breadcrumb, title, description, actions, and body', async () => {
+test('Shell renders anchor nav items when no client navigation handler is provided', async () => {
+  const body = await renderSSR(
+    h(Shell, {
+      nav: sampleNav,
+      activeKey: '/dashboard',
+      openKeys: ['partners-group'],
+      children: h('div', null, 'content'),
+    }),
+  );
+  assert.ok(body.includes('href="/dashboard"'));
+  assert.ok(body.includes('href="/partners"'));
+  assert.ok(body.includes('href="/partners/new"'));
+});
+
+test('PageFrame renders breadcrumb anchors without a client navigation handler', async () => {
   const body = await renderSSR(
     h(PageFrame, {
       breadcrumbs: [
@@ -156,6 +171,8 @@ test('PageFrame renders breadcrumb, title, description, actions, and body', asyn
   );
   assert.ok(body.includes('facetheory-stitch-page-frame'));
   assert.ok(body.includes('facetheory-stitch-breadcrumb'));
+  assert.ok(body.includes('href="/"'));
+  assert.ok(body.includes('href="/partners"'));
   assert.ok(body.includes('Acme Corp'));
   assert.ok(body.includes('Partner details and security posture'));
   assert.ok(body.includes('Edit'));

--- a/ts/test/unit/vite-ssr-svelte-example.test.ts
+++ b/ts/test/unit/vite-ssr-svelte-example.test.ts
@@ -58,6 +58,9 @@ test(
       `unexpected html: ${body.slice(0, 220)}`,
     );
     assert.ok(body.includes('facetheory-stitch-shell'));
+    assert.ok(body.includes('href="/"'));
+    assert.ok(body.includes('href="/dashboard"'));
+    assert.ok(body.includes('href="/partners"'));
     assert.ok(body.includes('facetheory-stitch-auth-card'));
     assert.ok(body.includes('facetheory-stitch-callout-warning'));
     assert.ok(body.includes('facetheory-stitch-tabs'));

--- a/ts/test/unit/vue-stitch-shell.test.ts
+++ b/ts/test/unit/vue-stitch-shell.test.ts
@@ -125,6 +125,8 @@ test('vue stitch-shell: PageFrame and section primitives render tokenized conten
 
   assert.ok(body.includes('facetheory-stitch-page-frame'));
   assert.ok(body.includes('facetheory-stitch-breadcrumb'));
+  assert.ok(body.includes('href="/"'));
+  assert.ok(body.includes('href="/partners"'));
   assert.ok(body.includes('facetheory-stitch-section'));
   assert.ok(body.includes('facetheory-stitch-summary-strip'));
   assert.ok(body.includes('facetheory-stitch-stat-card'));


### PR DESCRIPTION
## Summary
- restore SSR-safe Stitch shell navigation by making nav items and breadcrumbs degrade to real anchors when a host does not hydrate
- force the React shell into sider layout so Ant Design SSR renders the sidebar/content split correctly
- add React, Vue, and Svelte regression coverage plus docs guidance for the `path` versus `onNavigate` contract

## Why
Issue #39 reported that SSR-only control-plane hosts rendered the React sidebar incorrectly and produced dead nav and breadcrumb links without hydration. The shell contract had drifted toward client-router interception instead of keeping plain anchor navigation as the baseline behavior.

## Impact
- React `Shell` now renders with `hasSider` so SSR apps get the correct left sidebar layout
- React, Vue, and Svelte breadcrumbs now keep `path` links alive without requiring a hydrated navigation handler
- React sidebar items now render anchor labels and only intercept clicks when `onNavigate` is provided
- the docs now state that `path` is the SSR-safe source of truth and `onNavigate` is optional enhancement behavior

## Validation
- `cd ts && npm run lint`
- `cd ts && npm run typecheck`
- `cd ts && npm test`
- `cd ts && npm run build`
