### PR TITLE
[codex] align FaceTheory with AppTheory v0.24.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Add the framework peers that match your adapter surface:
 
 Optional companion packages from pinned GitHub releases:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz`
 
 ## Quickstart

--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -7,8 +7,8 @@ This file records the currently pinned versions and the exact install strings we
 
 ## Pins
 
-- AppTheory (TypeScript): `v0.24.1`
-- AppTheory (CDK): `v0.24.1`
+- AppTheory (TypeScript): `v0.24.2`
+- AppTheory (CDK): `v0.24.2`
 - TableTheory (TypeScript): `v1.5.3`
 
 ## Install (npm)
@@ -16,7 +16,7 @@ This file records the currently pinned versions and the exact install strings we
 ```bash
   # AppTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz
 
   # TableTheory (TS)
 npm install --save-exact \
@@ -24,7 +24,7 @@ npm install --save-exact \
 
   # AppTheory CDK (only for infra projects)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz
 ```
 
 ## package.json Snippet (Pinned)
@@ -35,7 +35,7 @@ registry installs:
 ```json
 {
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz"
   },
   "overrides": {

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -92,7 +92,7 @@ patterns:
     solution: "Use exact release asset URLs documented in the compatibility pins."
     correct_example: |
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz
       npm install --save-exact \
         https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz
     anti_patterns:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ These are only required if your application uses the corresponding integration s
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz
 
 npm install --save-exact \
   https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz

--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -9,8 +9,8 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1005.0",
         "@aws-sdk/client-s3": "^3.1005.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
@@ -2459,9 +2459,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "0.24.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
-      "integrity": "sha512-VW2Y5jpKyI0JRVzQCmImynjKZ6n6nC4hXbhSWKxXCM+5DkVLkjbgdg68VzG5lvqmtegPmf9X1ho5phILHYADAw==",
+      "version": "0.24.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
+      "integrity": "sha512-jkGAPqz058jcgnx2aIp52nb50Z4RLtiIgHBhMI8bYHue01xd+5lSlJyatIZRue8g3V9kPpIlXm7IKg0wTE40QA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "0.24.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
-      "integrity": "sha512-xjWZ3nzX+Ccv5hlqEd89T7Jfr/8VIuoa4PxIyO1Y5jFyW2qCJ2piopOlOb/r6copcW/zcY2OLLvUMl39ie6d4g==",
+      "version": "0.24.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
+      "integrity": "sha512-vHGBPqnp0KOM1gumaUoUhQhb7ykoNdBSxz9oSRuDwRFVcsBnJ9IwkjGG94Ut9IWCgAPEsMnmQFqFkhvU6uw/fA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssg-isr-site/package.json
+++ b/infra/apptheory-ssg-isr-site/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1005.0",
     "@aws-sdk/client-s3": "^3.1005.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
         "constructs": "10.6.0",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "0.24.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
-      "integrity": "sha512-xjWZ3nzX+Ccv5hlqEd89T7Jfr/8VIuoa4PxIyO1Y5jFyW2qCJ2piopOlOb/r6copcW/zcY2OLLvUMl39ie6d4g==",
+      "version": "0.24.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
+      "integrity": "sha512-vHGBPqnp0KOM1gumaUoUhQhb7ykoNdBSxz9oSRuDwRFVcsBnJ9IwkjGG94Ut9IWCgAPEsMnmQFqFkhvU6uw/fA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,7 +12,7 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",
     "constructs": "10.6.0",

--- a/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
+++ b/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
@@ -355,7 +355,21 @@
         "SsrFunctionServiceRoleF0484DAB"
       ]
     },
-    "SsrFunctionAllowCloudFrontInvokeFunctionViaUrl8D4F8C8A": {
+    "SsrFunctioninvokefunctionurlBB9A2B69": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunctionUrl",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SsrFunctionD22C6F1E",
+            "Arn"
+          ]
+        },
+        "FunctionUrlAuthType": "NONE",
+        "Principal": "*"
+      }
+    },
+    "SsrFunctioninvokefunctionCE3E5B81": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -366,26 +380,7 @@
           ]
         },
         "InvokedViaFunctionUrl": true,
-        "Principal": "cloudfront.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition"
-              },
-              ":cloudfront::",
-              {
-                "Ref": "AWS::AccountId"
-              },
-              ":distribution/",
-              {
-                "Ref": "SiteDistribution390DED28"
-              }
-            ]
-          ]
-        }
+        "Principal": "*"
       }
     },
     "AssetsDeploymentImmutableAwsCliLayer40CE6A61": {
@@ -819,7 +814,7 @@
     "SiteSsrUrl2D74149D": {
       "Type": "AWS::Lambda::Url",
       "Properties": {
-        "AuthType": "AWS_IAM",
+        "AuthType": "NONE",
         "InvokeMode": "RESPONSE_STREAM",
         "TargetFunctionArn": {
           "Fn::GetAtt": [
@@ -1009,49 +1004,6 @@
               "Protection": true
             }
           }
-        }
-      }
-    },
-    "SiteDistributionOrigin1FunctionUrlOriginAccessControlFF5C1633": {
-      "Type": "AWS::CloudFront::OriginAccessControl",
-      "Properties": {
-        "OriginAccessControlConfig": {
-          "Name": "FaceTheoryAppTheorySsrSiteDinctionUrlOriginAccessControl506FC69E",
-          "OriginAccessControlOriginType": "lambda",
-          "SigningBehavior": "always",
-          "SigningProtocol": "sigv4"
-        }
-      }
-    },
-    "SiteDistributionOrigin1InvokeFromApiForFaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA468D34E14C": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunctionUrl",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "SiteSsrUrl2D74149D",
-            "FunctionArn"
-          ]
-        },
-        "Principal": "cloudfront.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:",
-              {
-                "Ref": "AWS::Partition"
-              },
-              ":cloudfront::",
-              {
-                "Ref": "AWS::AccountId"
-              },
-              ":distribution/",
-              {
-                "Ref": "SiteDistribution390DED28"
-              }
-            ]
-          ]
         }
       }
     },
@@ -1359,13 +1311,7 @@
                   }
                 ]
               },
-              "Id": "FaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA46",
-              "OriginAccessControlId": {
-                "Fn::GetAtt": [
-                  "SiteDistributionOrigin1FunctionUrlOriginAccessControlFF5C1633",
-                  "Id"
-                ]
-              }
+              "Id": "FaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA46"
             },
             {
               "DomainName": {

--- a/ts/README.md
+++ b/ts/README.md
@@ -19,8 +19,8 @@ Install the peers that match your adapter surface:
 
 Optional companion packages:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-cdk-0.24.1.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz`
 
 ## Minimal App

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -15,7 +15,7 @@
         "@emotion/server": "^11.11.0",
         "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^24.12.0",
@@ -4406,9 +4406,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "0.24.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
-      "integrity": "sha512-VW2Y5jpKyI0JRVzQCmImynjKZ6n6nC4hXbhSWKxXCM+5DkVLkjbgdg68VzG5lvqmtegPmf9X1ho5phILHYADAw==",
+      "version": "0.24.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
+      "integrity": "sha512-jkGAPqz058jcgnx2aIp52nb50Z4RLtiIgHBhMI8bYHue01xd+5lSlJyatIZRue8g3V9kPpIlXm7IKg0wTE40QA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -190,7 +190,7 @@
     "@emotion/server": "^11.11.0",
     "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.1/theory-cloud-apptheory-0.24.1.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^24.12.0",


### PR DESCRIPTION
## Summary
- bump FaceTheory's AppTheory runtime and CDK pins from `v0.24.1` to `v0.24.2`
- refresh the ts and infra lockfiles against the published `v0.24.2` release artifacts
- update the documented install strings and compatibility pins, and refresh the SSR-site snapshot for the upstream CDK change

## Why
AppTheory `v0.24.2` is the latest published upstream release. The only upstream code delta from `v0.24.1` to `v0.24.2` is a CDK fix to make SSR-site write routes browser-safe, so FaceTheory primarily needed a version bump plus a refreshed `AppTheorySsrSite` snapshot.

## Impact
- keeps FaceTheory aligned with the latest published AppTheory release assets
- updates the reference SSR stack snapshot to match the new AppTheory CDK synthesis
- does not require FaceTheory runtime or adapter code changes beyond the dependency upgrade

## Validation
- `cd ts && npm run lint`
- `cd ts && npm run typecheck`
- `cd ts && npm test`
- `cd ts && npm run build`
- `cd infra/apptheory-ssr-site && npm test`
- `cd infra/apptheory-ssg-isr-site && npm test`
