### PR TITLE
[codex] align FaceTheory with AppTheory v0.24.3 and TableTheory v1.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Add the framework peers that match your adapter surface:
 
 Optional companion packages from pinned GitHub releases:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz`
-- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-cdk-0.24.3.tgz`
+- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz`
 
 ## Quickstart
 

--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -7,24 +7,24 @@ This file records the currently pinned versions and the exact install strings we
 
 ## Pins
 
-- AppTheory (TypeScript): `v0.24.2`
-- AppTheory (CDK): `v0.24.2`
-- TableTheory (TypeScript): `v1.5.3`
+- AppTheory (TypeScript): `v0.24.3`
+- AppTheory (CDK): `v0.24.3`
+- TableTheory (TypeScript): `v1.5.4`
 
 ## Install (npm)
 
 ```bash
   # AppTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz
 
   # TableTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz
 
   # AppTheory CDK (only for infra projects)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-cdk-0.24.3.tgz
 ```
 
 ## package.json Snippet (Pinned)
@@ -35,12 +35,12 @@ registry installs:
 ```json
 {
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz"
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz"
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz"
     }
   }
 }

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -92,9 +92,9 @@ patterns:
     solution: "Use exact release asset URLs documented in the compatibility pins."
     correct_example: |
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz
       npm install --save-exact \
-        https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz
+        https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz
     anti_patterns:
       - name: "Floating registry installs"
         why: "The repo validates against explicit pinned combinations."

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,10 +39,10 @@ These are only required if your application uses the corresponding integration s
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz
 
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz
 ```
 
 Use AppTheory when you want its Lambda Function URL runtime as the AWS entrypoint. Use TableTheory when you want the documented production ISR metadata store adapter.

--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -9,9 +9,9 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1005.0",
         "@aws-sdk/client-s3": "^3.1005.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-cdk-0.24.3.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
         "constructs": "10.6.0",
@@ -2459,23 +2459,23 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "0.24.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
-      "integrity": "sha512-jkGAPqz058jcgnx2aIp52nb50Z4RLtiIgHBhMI8bYHue01xd+5lSlJyatIZRue8g3V9kPpIlXm7IKg0wTE40QA==",
+      "version": "0.24.3",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz",
+      "integrity": "sha512-/2+CO5VV9vaNvLLdyiyo1LORSDeVwhpS6p+3KPDjSeOmIUe084DiW+tgR2Bhk69ZhR7X2GKkA1R79oKmJoY8Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz"
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz"
       },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "0.24.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
-      "integrity": "sha512-vHGBPqnp0KOM1gumaUoUhQhb7ykoNdBSxz9oSRuDwRFVcsBnJ9IwkjGG94Ut9IWCgAPEsMnmQFqFkhvU6uw/fA==",
+      "version": "0.24.3",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-cdk-0.24.3.tgz",
+      "integrity": "sha512-PVN2xJcA0elt/Kss1FMelTGeDrcOiuDAuxpPtfD66UxRSg3c3SplAOC6wp/cnPSOeBJM9Pix6QykOhTlF+Mi9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2487,9 +2487,9 @@
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "1.5.3",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
-      "integrity": "sha512-B3jS/BlM56HsOcX7foBkNFmn8QO1tO6KIyaseX33snAMF2LLJ7W5sfXFTyaItsu+hn1aDeNzlYZSdVfQehWmag==",
+      "version": "1.5.4",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz",
+      "integrity": "sha512-Z3gG6X2ki1bSGYR1nFpFHMzJjA2QmHQuKfYDVLAOL4XtjtLpCgXZWB42ugmrZGnLP+jaX9WTp3BmGJry+VeOGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/infra/apptheory-ssg-isr-site/package.json
+++ b/infra/apptheory-ssg-isr-site/package.json
@@ -14,9 +14,9 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1005.0",
     "@aws-sdk/client-s3": "^3.1005.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-cdk-0.24.3.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",
     "constructs": "10.6.0",

--- a/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
+++ b/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
@@ -509,7 +509,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "f8d2c52d12faeb94ae89981ff0657a457c023756259daf8f16d7574ceffbd76d.zip"
+          "S3Key": "8e8a1b9ee52ca091a25f3f88f2965d5895994dfc8be048107d49d351331e03c6.zip"
         },
         "Environment": {
           "Variables": {

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-cdk-0.24.3.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
         "constructs": "10.6.0",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "0.24.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
-      "integrity": "sha512-vHGBPqnp0KOM1gumaUoUhQhb7ykoNdBSxz9oSRuDwRFVcsBnJ9IwkjGG94Ut9IWCgAPEsMnmQFqFkhvU6uw/fA==",
+      "version": "0.24.3",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-cdk-0.24.3.tgz",
+      "integrity": "sha512-PVN2xJcA0elt/Kss1FMelTGeDrcOiuDAuxpPtfD66UxRSg3c3SplAOC6wp/cnPSOeBJM9Pix6QykOhTlF+Mi9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,7 +12,7 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-cdk-0.24.3.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",
     "constructs": "10.6.0",

--- a/ts/README.md
+++ b/ts/README.md
@@ -19,9 +19,9 @@ Install the peers that match your adapter surface:
 
 Optional companion packages:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-cdk-0.24.2.tgz`
-- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-cdk-0.24.3.tgz`
+- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz`
 
 ## Minimal App
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -15,8 +15,8 @@
         "@emotion/server": "^11.11.0",
         "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
@@ -4406,23 +4406,23 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "0.24.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
-      "integrity": "sha512-jkGAPqz058jcgnx2aIp52nb50Z4RLtiIgHBhMI8bYHue01xd+5lSlJyatIZRue8g3V9kPpIlXm7IKg0wTE40QA==",
+      "version": "0.24.3",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz",
+      "integrity": "sha512-/2+CO5VV9vaNvLLdyiyo1LORSDeVwhpS6p+3KPDjSeOmIUe084DiW+tgR2Bhk69ZhR7X2GKkA1R79oKmJoY8Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz"
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz"
       },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "1.5.3",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
-      "integrity": "sha512-B3jS/BlM56HsOcX7foBkNFmn8QO1tO6KIyaseX33snAMF2LLJ7W5sfXFTyaItsu+hn1aDeNzlYZSdVfQehWmag==",
+      "version": "1.5.4",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz",
+      "integrity": "sha512-Z3gG6X2ki1bSGYR1nFpFHMzJjA2QmHQuKfYDVLAOL4XtjtLpCgXZWB42ugmrZGnLP+jaX9WTp3BmGJry+VeOGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -190,8 +190,8 @@
     "@emotion/server": "^11.11.0",
     "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.2/theory-cloud-apptheory-0.24.2.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v0.24.3/theory-cloud-apptheory-0.24.3.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
@@ -214,7 +214,7 @@
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.3/theory-cloud-tabletheory-ts-1.5.3.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.5.4/theory-cloud-tabletheory-ts-1.5.4.tgz"
     }
   }
 }


### PR DESCRIPTION
## Summary
- bump FaceTheory’s pinned AppTheory release from `v0.24.2` to `v0.24.3`
- bump FaceTheory’s pinned TableTheory release from `v1.5.3` to `v1.5.4`
- refresh the ts and infra lockfiles against the published upstream artifacts and update the supported install/docs surfaces

## Why
Both upstream projects published newer releases. AppTheory `v0.24.3` is now the latest published AppTheory release, and TableTheory `v1.5.4` is now the latest published TableTheory release. FaceTheory pins these dependencies to exact GitHub release tarballs, so the repo needed a coordinated pin refresh. 

## Impact
- keeps FaceTheory aligned with the current published AppTheory and TableTheory assets
- preserves the documented compatibility contract in the README, getting-started guide, and upstream pin matrix
- updates the SSG/ISR reference snapshot to match the new dependency pair; no FaceTheory runtime code changes were required

## Validation
- `cd ts && npm run lint`
- `cd ts && npm run typecheck`
- `cd ts && npm test`
- `cd ts && npm run build`
- `cd infra/apptheory-ssr-site && npm test`
- `cd infra/apptheory-ssg-isr-site && npm test`
