### PR TITLE
chore(ci): bootstrap premain and staging from main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @aron23 @dumpsterfire513
+*       @aron23 @dumpsterfire513 @paytheory

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @aron23 @dumpsterfire513

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: scripts/verify-ts-pack.sh
 
   rubric:
-    name: Rubric
+    name: rubric
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-branch-bootstrap.yml
+++ b/.github/workflows/release-branch-bootstrap.yml
@@ -1,0 +1,26 @@
+name: Release branch bootstrap
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-branch-bootstrap-main
+  cancel-in-progress: false
+
+jobs:
+  ensure-release-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Ensure premain and staging exist
+        run: scripts/ensure-release-branches.sh --publish

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ ts/*.tgz
 
 reference/
 .theory/
+
+.codex/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack build-release-assets rubric
+.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack build-release-assets ensure-release-branches test-ensure-release-branches rubric
 
 ts-build:
 	cd ts && npm run build
@@ -26,5 +26,11 @@ verify-ts-pack:
 
 build-release-assets:
 	./scripts/build-release-assets.sh "$$(./scripts/read-version.sh)" dist
+
+ensure-release-branches:
+	./scripts/ensure-release-branches.sh
+
+test-ensure-release-branches:
+	./scripts/test-ensure-release-branches.sh
 
 rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack

--- a/scripts/ensure-release-branches.sh
+++ b/scripts/ensure-release-branches.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "${repo_root}"
+
+remote="${GIT_REMOTE:-origin}"
+main_branch="${MAIN_BRANCH:-main}"
+read -r -a target_branches <<< "${TARGET_BRANCHES:-premain staging}"
+publish="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --publish)
+      publish="true"
+      ;;
+    --dry-run)
+      publish="false"
+      ;;
+    --remote)
+      shift
+      remote="${1:-}"
+      ;;
+    --main-branch)
+      shift
+      main_branch="${1:-}"
+      ;;
+    --targets)
+      shift
+      read -r -a target_branches <<< "${1:-}"
+      ;;
+    *)
+      echo "ensure-release-branches: FAIL (unknown argument: $1)"
+      exit 1
+      ;;
+  esac
+  shift || true
+done
+
+if [[ ! -d .git ]]; then
+  echo "ensure-release-branches: FAIL (repo root ${repo_root} is not a git repository)"
+  exit 1
+fi
+
+if [[ -z "${remote}" ]]; then
+  echo "ensure-release-branches: FAIL (missing remote)"
+  exit 1
+fi
+
+if [[ -z "${main_branch}" ]]; then
+  echo "ensure-release-branches: FAIL (missing main branch)"
+  exit 1
+fi
+
+if [[ "${#target_branches[@]}" -eq 0 ]]; then
+  echo "ensure-release-branches: FAIL (no target branches configured)"
+  exit 1
+fi
+
+if ! git remote get-url "${remote}" >/dev/null 2>&1; then
+  echo "ensure-release-branches: FAIL (missing git remote ${remote})"
+  exit 1
+fi
+
+if ! git fetch "${remote}" "${main_branch}" --force >/dev/null 2>&1; then
+  echo "ensure-release-branches: FAIL (unable to fetch ${remote}/${main_branch})"
+  exit 1
+fi
+
+source_ref="refs/remotes/${remote}/${main_branch}"
+if ! git show-ref --verify --quiet "${source_ref}"; then
+  echo "ensure-release-branches: FAIL (missing ${source_ref})"
+  exit 1
+fi
+
+source_commit="$(git rev-parse "${source_ref}")"
+created=()
+existing=()
+would_create=()
+
+for target_branch in "${target_branches[@]}"; do
+  if [[ -z "${target_branch}" ]]; then
+    continue
+  fi
+
+  if [[ "${target_branch}" == "${main_branch}" ]]; then
+    echo "ensure-release-branches: SKIP (${target_branch} matches ${main_branch})"
+    existing+=("${target_branch}")
+    continue
+  fi
+
+  existing_commit="$(git ls-remote --heads "${remote}" "${target_branch}" | awk 'NR == 1 { print $1 }')"
+  if [[ -n "${existing_commit}" ]]; then
+    echo "ensure-release-branches: exists ${target_branch} (${existing_commit})"
+    existing+=("${target_branch}")
+    continue
+  fi
+
+  if [[ "${publish}" == "true" ]]; then
+    git push "${remote}" "${source_ref}:refs/heads/${target_branch}" >/dev/null
+    echo "ensure-release-branches: created ${target_branch} from ${main_branch} (${source_commit})"
+    created+=("${target_branch}")
+  else
+    echo "ensure-release-branches: would create ${target_branch} from ${main_branch} (${source_commit})"
+    would_create+=("${target_branch}")
+  fi
+done
+
+created_summary="${created[*]:-none}"
+existing_summary="${existing[*]:-none}"
+would_create_summary="${would_create[*]:-none}"
+mode="dry-run"
+if [[ "${publish}" == "true" ]]; then
+  mode="publish"
+fi
+
+echo "ensure-release-branches: PASS (${mode}; source=${main_branch}@${source_commit}; created=${created_summary}; existing=${existing_summary}; would_create=${would_create_summary})"

--- a/scripts/test-ensure-release-branches.sh
+++ b/scripts/test-ensure-release-branches.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${repo_root}/scripts/ensure-release-branches.sh"
+
+fail() {
+  echo "test-ensure-release-branches: FAIL ($*)"
+  exit 1
+}
+
+setup_repo() {
+  local label="$1"
+  local base_dir="$2"
+  local remote_dir="${base_dir}/${label}-remote.git"
+  local work_dir="${base_dir}/${label}-work"
+
+  git init --bare "${remote_dir}" >/dev/null 2>&1
+  git clone "${remote_dir}" "${work_dir}" >/dev/null 2>&1
+  git -C "${work_dir}" config user.name "FaceTheory Test"
+  git -C "${work_dir}" config user.email "facetheory-test@example.com"
+  git -C "${work_dir}" checkout -b main >/dev/null 2>&1
+
+  printf '%s\n' "initial" > "${work_dir}/README.md"
+  git -C "${work_dir}" add README.md
+  git -C "${work_dir}" commit -m "test: seed main" >/dev/null 2>&1
+  git -C "${work_dir}" push -u origin main >/dev/null 2>&1
+
+  printf '%s\n%s\n' "${remote_dir}" "${work_dir}"
+}
+
+run_publish() {
+  local work_dir="$1"
+  REPO_ROOT="${work_dir}" bash "${script_path}" --publish >/dev/null
+}
+
+run_dry_run() {
+  local work_dir="$1"
+  REPO_ROOT="${work_dir}" bash "${script_path}" >/dev/null
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+# Dry run reports success without creating branches.
+mapfile -t repo_a < <(setup_repo dryrun "${tmpdir}")
+remote_a="${repo_a[0]}"
+work_a="${repo_a[1]}"
+run_dry_run "${work_a}"
+if git -C "${work_a}" ls-remote --exit-code --heads origin premain >/dev/null 2>&1; then
+  fail "dry-run unexpectedly created premain"
+fi
+if git -C "${work_a}" ls-remote --exit-code --heads origin staging >/dev/null 2>&1; then
+  fail "dry-run unexpectedly created staging"
+fi
+
+# Publish creates both missing release branches from main.
+mapfile -t repo_b < <(setup_repo publish "${tmpdir}")
+remote_b="${repo_b[0]}"
+work_b="${repo_b[1]}"
+run_publish "${work_b}"
+main_sha_b="$(git ls-remote --heads "${remote_b}" main | awk 'NR == 1 { print $1 }')"
+premain_sha_b="$(git ls-remote --heads "${remote_b}" premain | awk 'NR == 1 { print $1 }')"
+staging_sha_b="$(git ls-remote --heads "${remote_b}" staging | awk 'NR == 1 { print $1 }')"
+[[ -n "${premain_sha_b}" ]] || fail "publish did not create premain"
+[[ -n "${staging_sha_b}" ]] || fail "publish did not create staging"
+[[ "${premain_sha_b}" == "${main_sha_b}" ]] || fail "premain was not created from main"
+[[ "${staging_sha_b}" == "${main_sha_b}" ]] || fail "staging was not created from main"
+
+# Existing branches are left untouched on rerun.
+first_premain_sha_b="${premain_sha_b}"
+first_staging_sha_b="${staging_sha_b}"
+run_publish "${work_b}"
+second_premain_sha_b="$(git ls-remote --heads "${remote_b}" premain | awk 'NR == 1 { print $1 }')"
+second_staging_sha_b="$(git ls-remote --heads "${remote_b}" staging | awk 'NR == 1 { print $1 }')"
+[[ "${second_premain_sha_b}" == "${first_premain_sha_b}" ]] || fail "premain changed on rerun"
+[[ "${second_staging_sha_b}" == "${first_staging_sha_b}" ]] || fail "staging changed on rerun"
+
+# A pre-existing staging branch pointing elsewhere is preserved.
+mapfile -t repo_c < <(setup_repo preserve "${tmpdir}")
+remote_c="${repo_c[0]}"
+work_c="${repo_c[1]}"
+first_main_sha_c="$(git -C "${work_c}" rev-parse HEAD)"
+git -C "${work_c}" push origin "${first_main_sha_c}:refs/heads/staging" >/dev/null 2>&1
+printf '%s\n' "follow-up" >> "${work_c}/README.md"
+git -C "${work_c}" add README.md
+ git -C "${work_c}" commit -m "test: advance main" >/dev/null 2>&1
+ git -C "${work_c}" push origin main >/dev/null 2>&1
+run_publish "${work_c}"
+latest_main_sha_c="$(git ls-remote --heads "${remote_c}" main | awk 'NR == 1 { print $1 }')"
+staging_sha_c="$(git ls-remote --heads "${remote_c}" staging | awk 'NR == 1 { print $1 }')"
+premain_sha_c="$(git ls-remote --heads "${remote_c}" premain | awk 'NR == 1 { print $1 }')"
+[[ "${staging_sha_c}" == "${first_main_sha_c}" ]] || fail "existing staging branch was rewritten"
+[[ "${premain_sha_c}" == "${latest_main_sha_c}" ]] || fail "premain was not created from latest main"
+
+echo "test-ensure-release-branches: PASS"


### PR DESCRIPTION
## Milestone
RB1 — Ensure `premain` and `staging` exist by creating them from `main` when missing.

## Linear
FaceTheory — TheoryCloud Shared-Subtree Publishing Rollout / RB1 — branch-bootstrap / THE-106

## Render modes and adapters affected
None. This is release-infra/bootstrap work only.

## Determinism impact
Preserves determinism. No render, hydration, head, style, or adapter surface changed.

## Backward compatibility
Additive. No package/runtime contract change.

## Tasks
- [x] THE-106 Bootstrap missing premain and staging from main

## Validation
- [x] `make rubric`
- [x] `bash scripts/test-ensure-release-branches.sh`

## Cross-repo coordination
Depends operationally on the broader theorycloud rollout contract, but this commit is repo-local only.
