### PR TITLE
chore(ci): add theorycloud sync and publish helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack build-release-assets ensure-release-branches test-ensure-release-branches stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree rubric
+.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack build-release-assets ensure-release-branches test-ensure-release-branches stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets rubric
 
 ts-build:
 	cd ts && npm run build
@@ -41,5 +41,11 @@ verify-theorycloud-facetheory-subtree:
 
 sync-theorycloud-facetheory-subtree:
 	./scripts/sync_theorycloud_facetheory_subtree.sh --stage "$${THEORYCLOUD_STAGE:-lab}" --output "$${THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/facetheory-theorycloud}"
+
+trigger-theorycloud-publish:
+	./scripts/trigger_theorycloud_publish.sh --stage "$${THEORYCLOUD_STAGE:-lab}"
+
+test-theorycloud-targets:
+	./scripts/test-theorycloud-targets.sh
 
 rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack build-release-assets ensure-release-branches test-ensure-release-branches stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree rubric
+.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack build-release-assets ensure-release-branches test-ensure-release-branches stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree rubric
 
 ts-build:
 	cd ts && npm run build
@@ -38,5 +38,8 @@ stage-theorycloud-facetheory-subtree:
 
 verify-theorycloud-facetheory-subtree:
 	./scripts/verify_theorycloud_facetheory_subtree.sh "$${THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/facetheory-theorycloud}"
+
+sync-theorycloud-facetheory-subtree:
+	./scripts/sync_theorycloud_facetheory_subtree.sh --stage "$${THEORYCLOUD_STAGE:-lab}" --output "$${THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/facetheory-theorycloud}"
 
 rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack

--- a/scripts/sync_theorycloud_facetheory_subtree.sh
+++ b/scripts/sync_theorycloud_facetheory_subtree.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+  cat <<EOF_USAGE
+Usage:
+  bash scripts/sync_theorycloud_facetheory_subtree.sh [--stage STAGE] [--source-s3-uri URI] [--output DIR]
+
+Environment:
+  THEORYCLOUD_STAGE                          Stage name. Default: lab
+  THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR  Staging root directory. Default: /tmp/facetheory-theorycloud
+  THEORYCLOUD_FACETHEORY_SOURCE_S3_URI       Optional override for the subtree destination S3 URI
+  THEORYCLOUD_S3_SYNC_DELETE                 Default: true. When true, prune objects under theorycloud/facetheory/
+  THEORYCLOUD_S3_SYNC_DRY_RUN                Default: false. When true, print the sync plan without calling AWS
+EOF_USAGE
+}
+
+fail() {
+  echo "sync-theorycloud-facetheory-subtree: FAIL ($*)" >&2
+  exit 1
+}
+
+default_source_s3_uri_for_stage() {
+  local stage="$1"
+  case "${stage}" in
+    lab) printf '%s\n' 's3://kt-sources-lab-787107040121/theorycloud/facetheory/' ;;
+    live) printf '%s\n' 's3://kt-sources-live-787107040121/theorycloud/facetheory/' ;;
+    *) return 1 ;;
+  esac
+}
+
+require_s3_uri() {
+  local value="$1"
+  local label="$2"
+  if [[ -z "${value}" ]]; then
+    fail "missing ${label}"
+  fi
+  if [[ "${value}" != s3://* ]]; then
+    fail "${label} must be an s3:// URI: ${value}"
+  fi
+}
+
+STAGE="${THEORYCLOUD_STAGE:-lab}"
+OUTPUT_DIR="${THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/facetheory-theorycloud}"
+SOURCE_S3_URI="${THEORYCLOUD_FACETHEORY_SOURCE_S3_URI:-}"
+SYNC_DELETE="${THEORYCLOUD_S3_SYNC_DELETE:-true}"
+SYNC_DRY_RUN="${THEORYCLOUD_S3_SYNC_DRY_RUN:-false}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    --source-s3-uri)
+      SOURCE_S3_URI="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+STAGE="${STAGE,,}"
+if [[ -z "${SOURCE_S3_URI}" ]]; then
+  SOURCE_S3_URI="$(default_source_s3_uri_for_stage "${STAGE}" || true)"
+fi
+require_s3_uri "${SOURCE_S3_URI}" "THEORYCLOUD_FACETHEORY_SOURCE_S3_URI"
+SOURCE_S3_URI="${SOURCE_S3_URI%/}/"
+
+bash "${SCRIPT_DIR}/stage_theorycloud_facetheory_subtree.sh" --output "${OUTPUT_DIR}"
+
+SUBTREE_DIR="${OUTPUT_DIR%/}/facetheory"
+if [[ ! -d "${SUBTREE_DIR}" ]]; then
+  fail "missing staged subtree at ${SUBTREE_DIR}; staging helper did not produce facetheory/"
+fi
+if [[ ! -f "${SUBTREE_DIR}/source-manifest.json" ]]; then
+  fail "missing staged provenance manifest at ${SUBTREE_DIR}/source-manifest.json"
+fi
+
+sync_flags=()
+if [[ "${SYNC_DELETE}" == "true" ]]; then
+  sync_flags+=(--delete)
+fi
+
+if [[ "${SYNC_DRY_RUN}" == "true" ]]; then
+  echo "sync-theorycloud-facetheory-subtree: DRY RUN"
+  echo "stage=${STAGE}"
+  echo "source=${SUBTREE_DIR}/"
+  echo "destination=${SOURCE_S3_URI}"
+  if [[ "${SYNC_DELETE}" == "true" ]]; then
+    echo "delete=true"
+  else
+    echo "delete=false"
+  fi
+  echo "command=aws s3 sync ${SUBTREE_DIR}/ ${SOURCE_S3_URI} ${sync_flags[*]:-}"
+  echo "sync-theorycloud-facetheory-subtree: PASS (dry-run; target=${SOURCE_S3_URI})"
+  exit 0
+fi
+
+command -v aws >/dev/null 2>&1 || fail "aws CLI is required"
+
+echo "syncing FaceTheory subtree to ${SOURCE_S3_URI}"
+if ! aws s3 sync "${SUBTREE_DIR}/" "${SOURCE_S3_URI}" "${sync_flags[@]}"; then
+  fail "aws s3 sync failed for ${SOURCE_S3_URI}"
+fi
+
+echo "sync-theorycloud-facetheory-subtree: PASS (target=${SOURCE_S3_URI})"

--- a/scripts/sync_theorycloud_facetheory_subtree.sh
+++ b/scripts/sync_theorycloud_facetheory_subtree.sh
@@ -13,6 +13,7 @@ Environment:
   THEORYCLOUD_STAGE                          Stage name. Default: lab
   THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR  Staging root directory. Default: /tmp/facetheory-theorycloud
   THEORYCLOUD_FACETHEORY_SOURCE_S3_URI       Optional override for the subtree destination S3 URI
+  KT_SOURCE_S3_URI                           Alternate override for the subtree destination S3 URI
   THEORYCLOUD_S3_SYNC_DELETE                 Default: true. When true, prune objects under theorycloud/facetheory/
   THEORYCLOUD_S3_SYNC_DRY_RUN                Default: false. When true, print the sync plan without calling AWS
 EOF_USAGE
@@ -45,7 +46,7 @@ require_s3_uri() {
 
 STAGE="${THEORYCLOUD_STAGE:-lab}"
 OUTPUT_DIR="${THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/facetheory-theorycloud}"
-SOURCE_S3_URI="${THEORYCLOUD_FACETHEORY_SOURCE_S3_URI:-}"
+SOURCE_S3_URI="${THEORYCLOUD_FACETHEORY_SOURCE_S3_URI:-${KT_SOURCE_S3_URI:-}}"
 SYNC_DELETE="${THEORYCLOUD_S3_SYNC_DELETE:-true}"
 SYNC_DRY_RUN="${THEORYCLOUD_S3_SYNC_DRY_RUN:-false}"
 

--- a/scripts/test-theorycloud-targets.sh
+++ b/scripts/test-theorycloud-targets.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fail() {
+  echo "test-theorycloud-targets: FAIL ($*)" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" <<<"${haystack}"; then
+    fail "expected to find '${needle}'"
+  fi
+}
+
+lab_sync_output="$(THEORYCLOUD_S3_SYNC_DRY_RUN=true bash "${SCRIPT_DIR}/sync_theorycloud_facetheory_subtree.sh" --stage lab)"
+assert_contains "${lab_sync_output}" 'destination=s3://kt-sources-lab-787107040121/theorycloud/facetheory/'
+assert_contains "${lab_sync_output}" 'command=aws s3 sync'
+
+live_sync_output="$(THEORYCLOUD_S3_SYNC_DRY_RUN=true bash "${SCRIPT_DIR}/sync_theorycloud_facetheory_subtree.sh" --stage live)"
+assert_contains "${live_sync_output}" 'destination=s3://kt-sources-live-787107040121/theorycloud/facetheory/'
+
+lab_publish_output="$(THEORYCLOUD_PUBLISH_DRY_RUN=true bash "${SCRIPT_DIR}/trigger_theorycloud_publish.sh" --stage lab --source-revision abc123def456 --idempotency-key test-lab)"
+assert_contains "${lab_publish_output}" 'url=https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
+assert_contains "${lab_publish_output}" 'payload={"source_revision":"abc123def456","idempotency_key":"test-lab","reason":"docs sync complete","force":false}'
+
+live_publish_output="$(THEORYCLOUD_PUBLISH_DRY_RUN=true bash "${SCRIPT_DIR}/trigger_theorycloud_publish.sh" --stage live --source-revision abc123def456 --idempotency-key test-live)"
+assert_contains "${live_publish_output}" 'url=https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud'
+assert_contains "${live_publish_output}" 'payload={"source_revision":"abc123def456","idempotency_key":"test-live","reason":"docs sync complete","force":false}'
+
+echo 'test-theorycloud-targets: PASS'

--- a/scripts/trigger_theorycloud_publish.sh
+++ b/scripts/trigger_theorycloud_publish.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+  cat <<EOF_USAGE
+Usage:
+  bash scripts/trigger_theorycloud_publish.sh [--stage STAGE] [--publish-url URL] [--source-revision SHA] [--idempotency-key KEY] [--reason TEXT] [--force]
+
+Environment:
+  THEORYCLOUD_STAGE               Stage name. Default: lab
+  THEORYCLOUD_PUBLISH_URL         Optional override for the publish endpoint URL
+  KT_PUBLISH_URL                  Alternate override for the publish endpoint URL
+  THEORYCLOUD_PUBLISH_DRY_RUN     Default: false. When true, print the request instead of invoking KT
+  THEORYCLOUD_PUBLISH_REASON      Default: docs sync complete
+  THEORYCLOUD_PUBLISH_FORCE       Default: false
+  SOURCE_REVISION                 Optional source revision override
+  AWS_REGION                      Default: us-east-1
+EOF_USAGE
+}
+
+fail() {
+  echo "trigger-theorycloud-publish: FAIL ($*)" >&2
+  exit 1
+}
+
+default_publish_url_for_stage() {
+  local stage="$1"
+  case "${stage}" in
+    lab) printf '%s\n' 'https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud' ;;
+    live) printf '%s\n' 'https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud' ;;
+    *) return 1 ;;
+  esac
+}
+
+STAGE="${THEORYCLOUD_STAGE:-lab}"
+PUBLISH_URL="${THEORYCLOUD_PUBLISH_URL:-${KT_PUBLISH_URL:-}}"
+SOURCE_REVISION="${SOURCE_REVISION:-}"
+IDEMPOTENCY_KEY=""
+REASON="${THEORYCLOUD_PUBLISH_REASON:-docs sync complete}"
+FORCE="${THEORYCLOUD_PUBLISH_FORCE:-false}"
+PUBLISH_DRY_RUN="${THEORYCLOUD_PUBLISH_DRY_RUN:-false}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stage)
+      STAGE="$2"
+      shift 2
+      ;;
+    --publish-url)
+      PUBLISH_URL="$2"
+      shift 2
+      ;;
+    --source-revision)
+      SOURCE_REVISION="$2"
+      shift 2
+      ;;
+    --idempotency-key)
+      IDEMPOTENCY_KEY="$2"
+      shift 2
+      ;;
+    --reason)
+      REASON="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+STAGE="${STAGE,,}"
+if [[ -z "${PUBLISH_URL}" ]]; then
+  PUBLISH_URL="$(default_publish_url_for_stage "${STAGE}" || true)"
+fi
+if [[ -z "${PUBLISH_URL}" ]]; then
+  fail "missing publish URL for stage ${STAGE}"
+fi
+if [[ ! "${PUBLISH_URL}" =~ ^https:// ]]; then
+  fail "publish URL must be https://...: ${PUBLISH_URL}"
+fi
+
+if [[ -z "${SOURCE_REVISION}" ]]; then
+  SOURCE_REVISION="$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || true)"
+fi
+if [[ -z "${SOURCE_REVISION}" ]]; then
+  fail "missing source revision"
+fi
+
+short_sha="${SOURCE_REVISION:0:12}"
+if [[ -z "${IDEMPOTENCY_KEY}" ]]; then
+  if [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+    IDEMPOTENCY_KEY="github-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-1}-${short_sha}"
+  else
+    IDEMPOTENCY_KEY="manual-${short_sha}"
+  fi
+fi
+
+PAYLOAD="$(python3 - <<PY
+import json
+payload = {
+  'source_revision': ${SOURCE_REVISION@Q},
+  'idempotency_key': ${IDEMPOTENCY_KEY@Q},
+  'reason': ${REASON@Q},
+  'force': ${FORCE@Q}.lower() == 'true',
+}
+print(json.dumps(payload, separators=(',', ':')))
+PY
+)"
+
+if [[ "${PUBLISH_DRY_RUN}" == "true" ]]; then
+  echo "trigger-theorycloud-publish: DRY RUN"
+  echo "stage=${STAGE}"
+  echo "url=${PUBLISH_URL}"
+  echo "payload=${PAYLOAD}"
+  echo "command=awscurl --service execute-api --region ${AWS_REGION} -X POST -H content-type:application/json --data ${PAYLOAD} ${PUBLISH_URL}"
+  echo "trigger-theorycloud-publish: PASS (dry-run; url=${PUBLISH_URL})"
+  exit 0
+fi
+
+command -v awscurl >/dev/null 2>&1 || fail "awscurl is required for publish invocation"
+
+response_file="$(mktemp)"
+http_code="$(awscurl --service execute-api --region "${AWS_REGION}" -X POST -H 'content-type: application/json' --data "${PAYLOAD}" -o "${response_file}" -w '%{http_code}' "${PUBLISH_URL}")" || {
+  status=$?
+  rm -f "${response_file}"
+  fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status})"
+}
+
+if [[ ! "${http_code}" =~ ^2 ]]; then
+  body="$(cat "${response_file}")"
+  rm -f "${response_file}"
+  fail "publish returned HTTP ${http_code}: ${body}"
+fi
+
+body="$(cat "${response_file}")"
+rm -f "${response_file}"
+echo "trigger-theorycloud-publish: PASS (url=${PUBLISH_URL}; http=${http_code})"
+printf '%s\n' "${body}"


### PR DESCRIPTION
## Milestone
KB2 — Add stage-aware subtree sync and shared `theorycloud` publish trigger helpers for the FaceTheory subtree rollout.

## Linear
FaceTheory — TheoryCloud Shared-Subtree Publishing Rollout / KB2 — sync-trigger-plumbing / THE-108, THE-109

## Render modes and adapters affected
None. This is release-infra and docs-publishing plumbing only.

## Determinism impact
Preserves determinism. No render, hydration, head, style, or adapter behavior changed.

## Backward compatibility
Additive. Operational tooling only.

## Tasks
- [x] THE-108 Add stage-aware FaceTheory subtree sync helper
- [x] THE-109 Add shared theorycloud publish trigger helper

## Validation
- [x] `make rubric`
- [x] `THEORYCLOUD_S3_SYNC_DRY_RUN=true bash scripts/sync_theorycloud_facetheory_subtree.sh --stage lab`
- [x] `THEORYCLOUD_S3_SYNC_DRY_RUN=true bash scripts/sync_theorycloud_facetheory_subtree.sh --stage live`
- [x] `make sync-theorycloud-facetheory-subtree THEORYCLOUD_S3_SYNC_DRY_RUN=true THEORYCLOUD_STAGE=lab`
- [x] `bash scripts/test-theorycloud-targets.sh`
- [x] `THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --stage lab --source-revision abc123def456 --idempotency-key manual-test`
- [x] `THEORYCLOUD_PUBLISH_DRY_RUN=true make trigger-theorycloud-publish THEORYCLOUD_STAGE=live SOURCE_REVISION=abc123def456`

## Cross-repo coordination
Uses the shared-subtree rollout contract from KnowledgeTheory #12 / PR #13. The helper defaults align to the shared lab/live theorycloud targets and publish URLs.
