### PR TITLE
chore(ci): verify theorycloud subtree publishing path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,3 +129,29 @@ jobs:
         run: cd ts && npm ci
       - name: Run full rubric
         run: make rubric
+
+
+  theorycloud-subtree:
+    name: TheoryCloud subtree publishing path
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Verify helper shell syntax
+        run: |
+          bash -n scripts/stage_theorycloud_facetheory_subtree.sh
+          bash -n scripts/verify_theorycloud_facetheory_subtree.sh
+          bash -n scripts/sync_theorycloud_facetheory_subtree.sh
+          bash -n scripts/trigger_theorycloud_publish.sh
+          bash -n scripts/test-theorycloud-targets.sh
+      - name: Verify subtree staging + provenance
+        run: |
+          bash scripts/stage_theorycloud_facetheory_subtree.sh --output /tmp/facetheory-theorycloud
+          bash scripts/verify_theorycloud_facetheory_subtree.sh /tmp/facetheory-theorycloud
+      - name: Verify sync/publish helper dry runs
+        run: |
+          THEORYCLOUD_S3_SYNC_DRY_RUN=true bash scripts/sync_theorycloud_facetheory_subtree.sh --stage lab
+          THEORYCLOUD_S3_SYNC_DRY_RUN=true bash scripts/sync_theorycloud_facetheory_subtree.sh --stage live
+          THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --stage lab --source-revision abc123def456 --idempotency-key ci-lab
+          THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --stage live --source-revision abc123def456 --idempotency-key ci-live
+      - name: Verify shared rollout target fixtures
+        run: bash scripts/test-theorycloud-targets.sh


### PR DESCRIPTION
## Milestone
KB3 — Verify subtree staging output, provenance shape, and helper-script health in repository CI.

## Linear
FaceTheory — TheoryCloud Shared-Subtree Publishing Rollout / KB3 — subtree-ci-guards / THE-110

## Render modes and adapters affected
None. This is CI guardrail work only.

## Determinism impact
Preserves determinism. No render, hydration, head, style, or adapter path changed.

## Backward compatibility
Additive. CI coverage only.

## Tasks
- [x] THE-110 Verify subtree staging and helper integrity in CI

## Validation
- [x] `make rubric`
- [x] `bash -n scripts/stage_theorycloud_facetheory_subtree.sh scripts/verify_theorycloud_facetheory_subtree.sh scripts/sync_theorycloud_facetheory_subtree.sh scripts/trigger_theorycloud_publish.sh scripts/test-theorycloud-targets.sh`
- [x] `bash scripts/stage_theorycloud_facetheory_subtree.sh --output /tmp/facetheory-theorycloud`
- [x] `bash scripts/verify_theorycloud_facetheory_subtree.sh /tmp/facetheory-theorycloud`
- [x] `THEORYCLOUD_S3_SYNC_DRY_RUN=true bash scripts/sync_theorycloud_facetheory_subtree.sh --stage lab`
- [x] `THEORYCLOUD_S3_SYNC_DRY_RUN=true bash scripts/sync_theorycloud_facetheory_subtree.sh --stage live`
- [x] `THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --stage lab --source-revision abc123def456 --idempotency-key ci-lab`
- [x] `THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --stage live --source-revision abc123def456 --idempotency-key ci-live`
- [x] `bash scripts/test-theorycloud-targets.sh`

## Cross-repo coordination
Consumes the shared-subtree rollout contract from KnowledgeTheory #12 / PR #13, but the CI guardrails themselves are FaceTheory-local.
