### PR TITLE
[codex] chore(ci): publish facetheory theorycloud subtree on protected merges

### DIFF
--- a/.github/workflows/theorycloud-facetheory-subtree-publish.yml
+++ b/.github/workflows/theorycloud-facetheory-subtree-publish.yml
@@ -1,0 +1,99 @@
+name: FaceTheory TheoryCloud subtree publish
+
+on:
+  push:
+    branches:
+      - premain
+      - main
+    paths:
+      - "docs/README.md"
+      - "docs/_contract.yaml"
+      - "docs/_concepts.yaml"
+      - "docs/_patterns.yaml"
+      - "docs/_decisions.yaml"
+      - "docs/getting-started.md"
+      - "docs/api-reference.md"
+      - "docs/core-patterns.md"
+      - "docs/testing-guide.md"
+      - "docs/troubleshooting.md"
+      - "docs/migration-guide.md"
+      - "docs/cdk/**"
+      - "docs/migration/**"
+      - "docs/llm-faq/**"
+      - "scripts/stage_theorycloud_facetheory_subtree.sh"
+      - "scripts/verify_theorycloud_facetheory_subtree.sh"
+      - "scripts/sync_theorycloud_facetheory_subtree.sh"
+      - "scripts/trigger_theorycloud_publish.sh"
+      - "scripts/test-theorycloud-targets.sh"
+      - ".github/workflows/theorycloud-facetheory-subtree-publish.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: facetheory-theorycloud-subtree-publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      THEORYCLOUD_STAGE: ${{ github.ref_name == 'premain' && 'lab' || github.ref_name == 'main' && 'live' || '' }}
+      AWS_ROLE_ARN: ${{ github.ref_name == 'premain' && vars.THEORYCLOUD_AWS_ROLE_ARN_LAB || github.ref_name == 'main' && vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE || '' }}
+      THEORYCLOUD_PUBLISH_REASON: ${{ format('github:{0}:{1}', github.repository, github.ref_name) }}
+    steps:
+      - name: Checkout protected branch head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate publish workflow configuration
+        run: |
+          set -euo pipefail
+
+          : "${AWS_REGION:?missing vars.AWS_REGION (or default)}"
+          : "${THEORYCLOUD_STAGE:?missing stage resolution}"
+          : "${AWS_ROLE_ARN:?missing stage-scoped AWS role ARN}"
+
+          case "${THEORYCLOUD_STAGE}" in
+            lab|live) ;;
+            *)
+              echo "unsupported theorycloud stage: ${THEORYCLOUD_STAGE}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Assume stage-scoped theorycloud publish role
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: facetheory-${{ github.ref_name }}-${{ github.run_id }}
+
+      - name: Install awscurl
+        run: |
+          set -euo pipefail
+
+          python3 -m pip install --user --upgrade pip
+          python3 -m pip install --user awscurl
+          printf '%s\n' "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Sync FaceTheory subtree into shared theorycloud source state
+        run: |
+          set -euo pipefail
+
+          bash scripts/sync_theorycloud_facetheory_subtree.sh \
+            --stage "${THEORYCLOUD_STAGE}" \
+            --output /tmp/facetheory-theorycloud
+
+      - name: Trigger shared theorycloud publish
+        env:
+          SOURCE_REVISION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          bash scripts/trigger_theorycloud_publish.sh \
+            --stage "${THEORYCLOUD_STAGE}" \
+            --source-revision "${SOURCE_REVISION}"


### PR DESCRIPTION
## What changed
- added a dedicated `.github/workflows/theorycloud-facetheory-subtree-publish.yml` workflow for FaceTheory's shared-subtree rollout path
- wired the workflow to run only on post-merge pushes to `premain` and `main` when canonical FaceTheory docs or the subtree publish helpers change
- mapped `premain -> lab` and `main -> live`, then assumed the corresponding stage-scoped OIDC role before syncing `theorycloud/facetheory/` and triggering shared `theorycloud` publish
- pinned `actions/checkout` and `aws-actions/configure-aws-credentials`, and installed `awscurl` for the IAM-authenticated publish call

## Why it changed
THE-111 requires the dedicated protected-branch workflow file that KT #12 can trust in IAM for FaceTheory's shared-subtree publishing path. The existing CI helpers can already stage, sync, and trigger publish, but there was no repo-local workflow that executed that flow automatically after approved merges to `premain` or `main`.

## Impact
- approved merges to protected `premain` can now refresh the FaceTheory subtree in `lab`
- approved merges to protected `main` can now refresh the FaceTheory subtree in `live`
- the workflow fails loudly when the stage mapping or stage-specific AWS role variables are missing
- no render, adapter, ISR, or hydration behavior changes

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/theorycloud-facetheory-subtree-publish.yml"); puts "workflow-yaml: PASS"'`
- `make rubric`

## Follow-up
- external prerequisites from KT #12 still need to be present for end-to-end runs: branch protections, lab/live OIDC roles, and the shared `theorycloud` publish path
- THE-112 will document the rollout prerequisites and variable names in `docs/development-guidelines.md`
