### PR TITLE
[codex] chore(ci): switch theorycloud publisher to no-vars roles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,18 @@ jobs:
           bash -n scripts/sync_theorycloud_facetheory_subtree.sh
           bash -n scripts/trigger_theorycloud_publish.sh
           bash -n scripts/test-theorycloud-targets.sh
+      - name: Verify no-vars publisher workflow contract
+        run: |
+          set -euo pipefail
+
+          workflow=".github/workflows/theorycloud-facetheory-subtree-publish.yml"
+          grep -Fq 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-FaceTheory-lab-Publisher' "${workflow}"
+          grep -Fq 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-FaceTheory-live-Publisher' "${workflow}"
+
+          if grep -Fq 'vars.THEORYCLOUD_AWS_ROLE_ARN_' "${workflow}"; then
+            echo "theorycloud-subtree: FAIL (publisher workflow still references vars-based role selection)" >&2
+            exit 1
+          fi
       - name: Verify subtree staging + provenance
         run: |
           bash scripts/stage_theorycloud_facetheory_subtree.sh --output /tmp/facetheory-theorycloud

--- a/.github/workflows/theorycloud-facetheory-subtree-publish.yml
+++ b/.github/workflows/theorycloud-facetheory-subtree-publish.yml
@@ -39,28 +39,59 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
-      THEORYCLOUD_STAGE: ${{ github.ref_name == 'premain' && 'lab' || github.ref_name == 'main' && 'live' || '' }}
-      AWS_ROLE_ARN: ${{ github.ref_name == 'premain' && vars.THEORYCLOUD_AWS_ROLE_ARN_LAB || github.ref_name == 'main' && vars.THEORYCLOUD_AWS_ROLE_ARN_LIVE || '' }}
-      THEORYCLOUD_PUBLISH_REASON: ${{ format('github:{0}:{1}', github.repository, github.ref_name) }}
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout protected branch head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
+      - name: Resolve no-vars stage rollout configuration
+        run: |
+          set -euo pipefail
+
+          case "${GITHUB_REF_NAME}" in
+            premain)
+              {
+                printf 'THEORYCLOUD_STAGE=lab\n'
+                printf 'AWS_ROLE_ARN=%s\n' 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-FaceTheory-lab-Publisher'
+              } >> "${GITHUB_ENV}"
+              ;;
+            main)
+              {
+                printf 'THEORYCLOUD_STAGE=live\n'
+                printf 'AWS_ROLE_ARN=%s\n' 'arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-FaceTheory-live-Publisher'
+              } >> "${GITHUB_ENV}"
+              ;;
+            *)
+              echo "unsupported protected branch ref: ${GITHUB_REF_NAME}" >&2
+              exit 1
+              ;;
+          esac
+
+          printf 'THEORYCLOUD_PUBLISH_REASON=%s\n' "github:${GITHUB_REPOSITORY}:${GITHUB_REF_NAME}" >> "${GITHUB_ENV}"
+
       - name: Validate publish workflow configuration
         run: |
           set -euo pipefail
 
-          : "${AWS_REGION:?missing vars.AWS_REGION (or default)}"
+          : "${AWS_REGION:?missing AWS region}"
           : "${THEORYCLOUD_STAGE:?missing stage resolution}"
-          : "${AWS_ROLE_ARN:?missing stage-scoped AWS role ARN}"
+          : "${AWS_ROLE_ARN:?missing literal stage-scoped AWS role ARN}"
 
           case "${THEORYCLOUD_STAGE}" in
             lab|live) ;;
             *)
               echo "unsupported theorycloud stage: ${THEORYCLOUD_STAGE}" >&2
+              exit 1
+              ;;
+          esac
+
+          case "${THEORYCLOUD_STAGE}:${AWS_ROLE_ARN}" in
+            lab:arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-FaceTheory-lab-Publisher) ;;
+            live:arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-FaceTheory-live-Publisher) ;;
+            *)
+              echo "unexpected role binding for stage ${THEORYCLOUD_STAGE}: ${AWS_ROLE_ARN}" >&2
               exit 1
               ;;
           esac

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -31,7 +31,10 @@ This document is contract-only.
 - That workflow path is part of the IAM trust contract. Do not rename or move it without coordinating the matching OIDC trust-policy update first.
 - Approved merges are enforced by repository protections on `premain` and `main`; the workflow intentionally runs on post-merge `push`, not `pull_request.closed`.
 - Stage mapping is fixed: `premain -> lab` and `main -> live`.
-- Required repository variables for the workflow are `THEORYCLOUD_AWS_ROLE_ARN_LAB` and `THEORYCLOUD_AWS_ROLE_ARN_LIVE`. `AWS_REGION` may be set explicitly, but the workflow defaults to `us-east-1`.
+- No GitHub repo variables are required for normal publish operation. The workflow binds the stage-scoped publisher roles directly:
+  - `premain -> arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-FaceTheory-lab-Publisher`
+  - `main -> arn:aws:iam::787107040121:role/KnowledgeTheory-TheoryCloud-FaceTheory-live-Publisher`
+- The workflow uses a literal `AWS_REGION=us-east-1`.
 - The workflow and helper scripts are the source of truth for the FaceTheory shared-subtree path. The generic KnowledgeTheory workflow/template docs are not authoritative here because they still describe the older `<prefix>/docs/` publish shape.
 - FaceTheory syncs only `theorycloud/facetheory/` with docs-root-relative content and a subtree `source-manifest.json`; it must never upload `theorycloud/facetheory/docs/...`.
 - External rollout prerequisites live outside this repo: KT #12 stage-scoped OIDC roles, S3 permissions restricted to `theorycloud/facetheory/`, and execute-api invoke permissions only for `POST /v1/internal/publish/theorycloud`.


### PR DESCRIPTION
## What changed
- switched `.github/workflows/theorycloud-facetheory-subtree-publish.yml` from repo-vars role selection to the settled no-vars KT contract
- bound the FaceTheory lab/live publisher role ARNs directly in the workflow based on protected branch name (`premain -> lab`, `main -> live`)
- made the workflow self-contained with literal `AWS_REGION=us-east-1`
- added a CI contract check that fails if the publisher workflow regresses back to vars-based role selection
- updated `docs/development-guidelines.md` so maintainer guidance matches the no-vars contract

## Why it changed
FaceTheory #53 follows KT's finalized shared-subtree rollout contract. The existing publisher workflow still depended on `THEORYCLOUD_AWS_ROLE_ARN_LAB` / `...LIVE` repo vars, but KT #14 settled the steady state on literal stable role ARNs and KT #17 provisioned the lab/live publisher roles. FaceTheory currently has no Actions variables configured, so the old workflow would fail if promoted unchanged.

## Impact
- no render, SSR, adapter, or ISR behavior changes
- the publisher workflow remains post-merge `push` on protected `premain` / `main`
- subtree sync and shared publish destinations remain unchanged
- maintainer docs and CI now enforce the repo-local no-vars contract

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/theorycloud-facetheory-subtree-publish.yml"); YAML.load_file(".github/workflows/ci.yml"); puts "workflow-yaml: PASS"'`
- `bash scripts/test-theorycloud-targets.sh`
- `make rubric`
- `if rg -n "THEORYCLOUD_AWS_ROLE_ARN_LAB|THEORYCLOUD_AWS_ROLE_ARN_LIVE|vars.THEORYCLOUD_AWS_ROLE_ARN_" -S .; then exit 1; else echo "no-vars-role-references: PASS"; fi`

## Follow-up
- this gets FaceTheory ready for the first real `premain -> lab` publisher run once promoted from `staging`
- issue #53 is not fully closed until that live lab run succeeds end-to-end

Refs #53
