### PR TITLE
[codex] fix(ci): use awscurl-compatible publish invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
           bash -n scripts/sync_theorycloud_facetheory_subtree.sh
           bash -n scripts/trigger_theorycloud_publish.sh
           bash -n scripts/test-theorycloud-targets.sh
+          bash -n scripts/test-trigger-theorycloud-publish-awscurl.sh
       - name: Verify no-vars publisher workflow contract
         run: |
           set -euo pipefail
@@ -166,4 +167,6 @@ jobs:
           THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --stage lab --source-revision abc123def456 --idempotency-key ci-lab
           THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --stage live --source-revision abc123def456 --idempotency-key ci-live
       - name: Verify shared rollout target fixtures
-        run: bash scripts/test-theorycloud-targets.sh
+        run: |
+          bash scripts/test-theorycloud-targets.sh
+          bash scripts/test-trigger-theorycloud-publish-awscurl.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack build-release-assets ensure-release-branches test-ensure-release-branches stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets rubric
+.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack build-release-assets ensure-release-branches test-ensure-release-branches stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets test-trigger-theorycloud-publish-awscurl rubric
 
 ts-build:
 	cd ts && npm run build
@@ -47,5 +47,8 @@ trigger-theorycloud-publish:
 
 test-theorycloud-targets:
 	./scripts/test-theorycloud-targets.sh
+
+test-trigger-theorycloud-publish-awscurl:
+	./scripts/test-trigger-theorycloud-publish-awscurl.sh
 
 rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack

--- a/scripts/test-trigger-theorycloud-publish-awscurl.sh
+++ b/scripts/test-trigger-theorycloud-publish-awscurl.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fail() {
+  echo "test-trigger-theorycloud-publish-awscurl: FAIL ($*)" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" <<<"${haystack}"; then
+    fail "expected to find '${needle}'"
+  fi
+}
+
+stub_dir="$(mktemp -d)"
+trap 'rm -rf "${stub_dir}"' EXIT
+
+cat > "${stub_dir}/awscurl" <<'EOF_AWSCURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${AWSCURL_TEST_MODE:-success}"
+output_file=""
+url=""
+seen_fail_with_body="false"
+seen_write_out="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fail-with-body)
+      seen_fail_with_body="true"
+      shift
+      ;;
+    -o)
+      output_file="$2"
+      shift 2
+      ;;
+    -w)
+      seen_write_out="true"
+      shift 2
+      ;;
+    -*)
+      shift
+      if [[ $# -gt 0 && "$1" != -* ]]; then
+        shift
+      fi
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ "${seen_fail_with_body}" != "true" ]]; then
+  echo "missing --fail-with-body" >&2
+  exit 64
+fi
+if [[ "${seen_write_out}" == "true" ]]; then
+  echo "unexpected -w flag" >&2
+  exit 65
+fi
+if [[ -z "${output_file}" ]]; then
+  echo "missing -o output file" >&2
+  exit 66
+fi
+if [[ -z "${url}" ]]; then
+  echo "missing publish URL" >&2
+  exit 67
+fi
+
+case "${mode}" in
+  success)
+    printf '{"job_id":"job-123","status":"enqueued"}\n' > "${output_file}"
+    exit 0
+    ;;
+  failure)
+    printf '{"error":"publish failed"}\n' > "${output_file}"
+    exit 7
+    ;;
+  *)
+    echo "unsupported AWSCURL_TEST_MODE=${mode}" >&2
+    exit 68
+    ;;
+esac
+EOF_AWSCURL
+chmod +x "${stub_dir}/awscurl"
+
+success_output="$(
+  PATH="${stub_dir}:${PATH}" \
+  bash "${SCRIPT_DIR}/trigger_theorycloud_publish.sh" \
+    --stage lab \
+    --source-revision abc123def456 \
+    --idempotency-key stub-success
+)"
+assert_contains "${success_output}" 'trigger-theorycloud-publish: PASS (url=https://l0lw87lsp1.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud)'
+assert_contains "${success_output}" '{"job_id":"job-123","status":"enqueued"}'
+
+set +e
+failure_output="$(
+  PATH="${stub_dir}:${PATH}" \
+  AWSCURL_TEST_MODE=failure \
+  bash "${SCRIPT_DIR}/trigger_theorycloud_publish.sh" \
+    --stage live \
+    --source-revision abc123def456 \
+    --idempotency-key stub-failure 2>&1
+)"
+failure_status=$?
+set -e
+
+if [[ "${failure_status}" -eq 0 ]]; then
+  fail "expected failure when awscurl returns a non-zero status"
+fi
+
+assert_contains "${failure_output}" 'trigger-theorycloud-publish: FAIL (awscurl invocation failed for https://at3k47vix3.execute-api.us-east-1.amazonaws.com/v1/internal/publish/theorycloud (exit 7): {"error":"publish failed"})'
+
+echo 'test-trigger-theorycloud-publish-awscurl: PASS'

--- a/scripts/trigger_theorycloud_publish.sh
+++ b/scripts/trigger_theorycloud_publish.sh
@@ -126,7 +126,7 @@ if [[ "${PUBLISH_DRY_RUN}" == "true" ]]; then
   echo "stage=${STAGE}"
   echo "url=${PUBLISH_URL}"
   echo "payload=${PAYLOAD}"
-  echo "command=awscurl --service execute-api --region ${AWS_REGION} -X POST -H content-type:application/json --data ${PAYLOAD} ${PUBLISH_URL}"
+  echo "command=awscurl --service execute-api --region ${AWS_REGION} -X POST --fail-with-body -H content-type:application/json --data ${PAYLOAD} -o <response-file> ${PUBLISH_URL}"
   echo "trigger-theorycloud-publish: PASS (dry-run; url=${PUBLISH_URL})"
   exit 0
 fi
@@ -134,19 +134,18 @@ fi
 command -v awscurl >/dev/null 2>&1 || fail "awscurl is required for publish invocation"
 
 response_file="$(mktemp)"
-http_code="$(awscurl --service execute-api --region "${AWS_REGION}" -X POST -H 'content-type: application/json' --data "${PAYLOAD}" -o "${response_file}" -w '%{http_code}' "${PUBLISH_URL}")" || {
-  status=$?
-  rm -f "${response_file}"
-  fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status})"
-}
-
-if [[ ! "${http_code}" =~ ^2 ]]; then
+if awscurl --service execute-api --region "${AWS_REGION}" -X POST --fail-with-body -H 'content-type: application/json' --data "${PAYLOAD}" -o "${response_file}" "${PUBLISH_URL}"; then
   body="$(cat "${response_file}")"
   rm -f "${response_file}"
-  fail "publish returned HTTP ${http_code}: ${body}"
+  echo "trigger-theorycloud-publish: PASS (url=${PUBLISH_URL})"
+  printf '%s\n' "${body}"
+  exit 0
+else
+  status=$?
+  body="$(cat "${response_file}" 2>/dev/null || true)"
+  rm -f "${response_file}"
+  if [[ -n "${body}" ]]; then
+    fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status}): ${body}"
+  fi
+  fail "awscurl invocation failed for ${PUBLISH_URL} (exit ${status})"
 fi
-
-body="$(cat "${response_file}")"
-rm -f "${response_file}"
-echo "trigger-theorycloud-publish: PASS (url=${PUBLISH_URL}; http=${http_code})"
-printf '%s\n' "${body}"


### PR DESCRIPTION
## What changed
- fixed `scripts/trigger_theorycloud_publish.sh` to use `awscurl`'s actual interface instead of curl's unsupported `-w` flag
- switched the publish helper to `--fail-with-body -o <response_file>` and now relies on exit status plus saved body for failure reporting
- added a stubbed non-dry-run helper test that exercises both success and failure paths through a fake `awscurl` binary
- wired that new helper test into the TheoryCloud subtree CI job and the Makefile

## Why it changed
FaceTheory #53 progressed past the earlier KT OIDC problem: the latest real `premain -> lab` publisher run now succeeds through role assumption and subtree sync, then fails locally in `Trigger shared theorycloud publish` because `scripts/trigger_theorycloud_publish.sh` still invokes `awscurl` with curl-only `-w '%{http_code}'`. `awscurl` rejects that flag before the request can reach KT.

## Impact
- no render, adapter, SSR, or ISR behavior changes
- the protected-branch subtree publisher should now be able to reach the shared `theorycloud` publish endpoint once this patch is on `premain`
- CI now covers the non-dry-run helper path that previously slipped through

## Validation
- `bash scripts/test-theorycloud-targets.sh`
- `bash scripts/test-trigger-theorycloud-publish-awscurl.sh`
- `make rubric`

## Follow-up
- after this merges to `staging`, promote to `premain` and rerun the real FaceTheory lab publisher to verify end-to-end success
- if the rerun still fails, the saved response body should now surface the actual API-side error clearly

Refs #53
