### PR TITLE
fix!: harden boundary handling across SPA, SSG, and ISR

### DIFF
--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -24,6 +24,8 @@ When using `AppTheorySsrSite` in `ssg-isr` mode:
 - use `staticPathPatterns` for cacheable extensionless HTML sections that should stay on S3
 - use `directS3PathPatterns` for raw object/data paths such as `/.vite/*` and `/_facetheory/data/*`
 - use `ssrPathPatterns` for same-origin dynamic routes that must bypass the S3-primary origin group and go straight to Lambda
+- prefer an `AWS_IAM` Function URL origin for read-only SSR traffic rather than a public direct URL
+- do not forward viewer-supplied tenant headers by default; derive tenancy from trusted request context when possible
 
 Reference example (FaceTheory repo):
 - `infra/apptheory-ssr-site/`
@@ -109,6 +111,7 @@ Notes:
 - Keep static and dynamic origins separate so static hits do not traverse Lambda.
 - Use Origin Access Control for S3.
 - Use an origin request policy for Lambda that forwards only headers/cookies/query needed by app logic.
+- Avoid modeling viewer-supplied tenant headers as part of the default origin request contract.
 
 ## Cache and Header Policy by Rendering Mode
 

--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -139,12 +139,16 @@ Notes:
 ## ISR Request Flow
 
 1. Request reaches Lambda URL behavior.
-2. FaceTheory computes cache key (`tenant + route + params`).
+2. FaceTheory computes cache key (`tenant + route + params + query` by default).
 3. Metadata lookup in DynamoDB:
    - fresh -> serve cached HTML pointer from S3
    - stale/miss -> attempt lease lock and regenerate
 4. Regeneration writes HTML to S3 first, then atomically updates metadata pointer.
 5. On regeneration failure, previous pointer stays valid; stale serve policy applies.
+
+Default tenant note:
+- FaceTheory prefers `x-tenant-id` for the default tenant partition and falls back to legacy `x-facetheory-tenant`.
+- If tenant identity comes from auth/session/host mapping rather than a trusted header, provide an explicit `tenantKey` or keep that route on SSR.
 
 ## Operational Checklist
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -11,6 +11,7 @@ This document describes production hardening guidance for FaceTheory apps and th
   - SSR responses should be explicitly non-cacheable (example: `cache-control: private, no-store`).
   - SSG HTML and hydration JSON should be served from S3 with explicit `cache-control`.
   - ISR responses must include an `x-facetheory-isr` state header (`hit` | `miss` | `stale` | `wait-hit`) and deterministic cache headers.
+  - Query-dependent ISR output now partitions by query string by default; request-personalized output still needs an explicit `cacheKey` / `tenantKey` or SSR.
 - Security headers:
   - Set baseline security headers at the CDN layer (HSTS, nosniff, frame-options, referrer-policy, permissions-policy).
   - Do not attempt to set a nonce-based CSP at CloudFront (nonces are per-request).
@@ -84,6 +85,12 @@ Recommended baseline (CDN layer preferred):
 The SSG/ISR example stack provisions these via `cloudfront.ResponseHeadersPolicy`:
 - `infra/apptheory-ssg-isr-site/src/stack.ts`
 
+### Tenant partitioning guidance
+
+- FaceTheory’s default ISR tenant resolver now prefers `x-tenant-id` and falls back to legacy `x-facetheory-tenant`.
+- Treat both as partition hints, not proof of identity.
+- If tenant identity is derived from a session, auth token, host mapping, or another trusted source, override `tenantKey` so cached HTML keys follow that trusted source instead of raw headers.
+
 ## Limits and Timeouts
 
 - Lambda timeout:
@@ -131,4 +138,3 @@ Mitigations (FaceTheory ISR options):
 - Increase `leaseDurationMs`.
 - Increase `regenerationWaitTimeoutMs` or switch `lockContentionPolicy` to `serve-stale`.
 - Ensure the regeneration path does not block on external dependencies without timeouts.
-

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -208,16 +208,17 @@ Core helpers:
 
 - `readFaceHydrationData(document?)` reads the `__FACETHEORY_DATA__` payload from the current document
 - `parseFaceNavigationSnapshot(html, options)` converts a rendered FaceTheory document into a structured navigation snapshot
-- `fetchFaceNavigationSnapshot(url, options)` fetches and parses the next route as HTML
+- `fetchFaceNavigationSnapshot(url, options)` fetches and parses the next route as HTML and rejects redirected cross-origin responses when an `allowedOrigin` is supplied
 - `applyFaceNavigationSnapshot(snapshot, options)` syncs document attrs, non-executable head tags, and either the configured view container or the full body
-- `loadFaceNavigationModule(snapshot, options)` invokes an exported `hydrateFaceNavigation(...)` hook when present, or reloads the bootstrap module when the hook is absent
-- `startFaceNavigation(options)` intercepts same-origin links, fetches the next FaceTheory document, applies it, and triggers hydration
+- `loadFaceNavigationModule(snapshot, options)` invokes an exported `hydrateFaceNavigation(...)` hook when present, or reloads the bootstrap module when the hook is absent, but rejects cross-origin bootstrap modules
+- `startFaceNavigation(options)` intercepts same-origin links, rejects cross-origin programmatic navigations, fetches the next FaceTheory document, applies it, and triggers hydration
 
 Recommended host pattern:
 
 - wrap route content in a stable shell with a view container such as `data-facetheory-view`
 - export `hydrateFaceNavigation(context)` from the client bootstrap module when you need persistent app state across navigations
 - rely on the default module reload only as a compatibility fallback for existing entry modules that hydrate by top-level side effect
+- keep SPA navigation same-origin; redirects to another origin and remote hydration modules fail closed
 
 ## Document Shell Attrs
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -179,6 +179,12 @@ Relevant helpers:
 - `blockingIsrCacheControl(input)`
 - `isFresh(record, nowMs)`
 
+Default ISR partitioning:
+
+- `defaultIsrCacheKey(input)` now includes sorted route params **and** sorted query-string keys/values.
+- The default tenant resolver prefers `x-tenant-id` and falls back to legacy `x-facetheory-tenant`.
+- If HTML varies by request identity, cookies, auth, or other non-query inputs, supply an explicit `cacheKey` / `tenantKey` or keep that route on SSR.
+
 Important deployment note:
 
 - `S3HtmlStore.keyPrefix` is a physical S3 prefix

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -69,7 +69,7 @@ These contracts shape every adapter and delivery mode. If you change one of thes
 
 | Interface          | Purpose                              | Notes                                                                                                                                               |
 | ------------------ | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FaceModule`       | Route definition                     | Uses `route`, `mode`, optional `load`, optional `generateStaticParams`, and `render`.                                                               |
+| `FaceModule`       | Route definition                     | Uses `route`, `mode`, optional `load`, optional `generateStaticParams`, and `render`. SSG params must resolve to normal route segments; dot-segments such as `.` and `..` are rejected. |
 | `FaceMode`         | Rendering mode                       | One of `ssr`, `ssg`, or `isr`.                                                                                                                      |
 | `FaceRequest`      | Normalized request input             | Supports headers, cookies, query, body, base64 marker, and optional `cspNonce`.                                                                     |
 | `FaceResponse`     | Runtime response                     | Includes normalized headers, cookies array, status, body, and `isBase64`.                                                                           |
@@ -274,6 +274,9 @@ Supported flags:
 - `--emit-hydration-data`
 
 `buildSsgSite()` uses the same contract programmatically.
+
+Security note:
+- `generateStaticParams()` values must stay inside the declared route tree. Dot-segments such as `.` and `..` are rejected so SSG output cannot escape `outDir`.
 
 ## Deployment-Facing Environment Conventions
 

--- a/docs/cdk/aws-deployment.md
+++ b/docs/cdk/aws-deployment.md
@@ -39,6 +39,10 @@ The reference stacks use AppTheory CDK and wire these runtime conventions:
 | `FACETHEORY_ISR_BUCKET` | ISR HTML bucket |
 | `FACETHEORY_ISR_PREFIX` | ISR HTML prefix |
 
+Reference-stack stance:
+- prefer a CloudFront-signed `AWS_IAM` Function URL origin for read-only SSR traffic
+- do not model viewer-supplied tenant-header passthrough as the default copy-paste shape
+
 ## CloudFront Behavior Options
 
 Choose between these patterns based on how many SSG routes you have and whether you want static misses to fail over to Lambda automatically.
@@ -57,6 +61,7 @@ Requirements:
 - preserve the original viewer path for Lambda failover routing
 - keep SSR cache headers explicit and conservative
 - when using `AppTheorySsrSite`, treat `staticPathPatterns` as HTML sections, `directS3PathPatterns` as raw data/object paths, and `ssrPathPatterns` as Lambda-only dynamic routes
+- if tenant identity matters, derive it from trusted context instead of forwarding raw viewer tenant headers by default
 
 ### Strategy B: Explicit Static Behaviors
 
@@ -66,6 +71,11 @@ Use:
 
 This is useful when:
 - the static route set is small and predictable
+
+Notes:
+- use Origin Access Control for S3
+- forward only headers/cookies/query actually required by app logic
+- avoid modeling viewer-supplied tenant headers as part of the default origin request contract
 
 ## Cache Policy By Rendering Mode
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -67,6 +67,7 @@ export const faces: FaceModule[] = [
 
 Why this is correct:
 - `ssg` is reserved for build-time output.
+- `generateStaticParams()` for SSG must resolve to normal path segments; dot-segments such as `.` and `..` are rejected rather than being written into the output tree.
 - `isr` is only used where regeneration is explicit and bounded.
 - `ssr` remains the fallback when freshness depends on request-time inputs.
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -272,6 +272,7 @@ Why this is correct:
 - FaceTheory fetches the next route as HTML and reuses the existing server contract instead of inventing a second route payload format.
 - `lang`, `htmlAttrs`, `bodyAttrs`, and non-executable head tags stay synchronized with the rendered document.
 - Exporting `hydrateFaceNavigation(...)` lets the client module update an existing app root instead of forcing a hard reload.
+- Same-origin boundaries stay intact: redirected cross-origin responses, remote bootstrap modules, and cross-origin programmatic navigations fail closed before the current document is mutated.
 
 Compatibility note:
 - If the bootstrap module does not export `hydrateFaceNavigation(...)`, FaceTheory can still reload that module as a fallback so existing side-effect-based entrypoints continue to work, but that fallback will not preserve long-lived client state.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -197,6 +197,11 @@ Important default:
 
 - SSG disables real network `fetch()` calls unless `--allow-network` or a mocked `fetch` implementation is supplied.
 
+Important ISR default:
+
+- FaceTheory’s default ISR cache key now partitions by route params and query string, and the default tenant hint prefers `x-tenant-id` over legacy `x-facetheory-tenant`.
+- If cached HTML varies by auth/session/cookies/host-derived tenant, configure an explicit `cacheKey` / `tenantKey` or keep that route on SSR.
+
 ## Reference Bundle
 
 The `v0.6.0` GitHub release includes the matching `facetheory-reference-${FACETHEORY_VERSION}.tar.gz` bundle. It contains: <!-- x-release-please-version -->

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,6 +9,7 @@ Use this guide for recurring setup, build, and runtime failures that already hav
 | `npm ci` or scripts fail early | Node.js is below the required baseline | `ts/package.json` (`engines.node: >=24`) |
 | `npm run ssg` exits with usage errors | Missing or invalid CLI flags | `docs/api-reference.md` and `ts/src/ssg-cli.ts` |
 | SSG build fails during page generation | Network access was attempted without opting in | `buildSsgSite()` and SSG fetch guard behavior |
+| SSG build fails with dot-segment output errors | `generateStaticParams()` returned `.` / `..` path segments | `ts/src/ssg.ts` path validation and route params |
 | ISR object keys look duplicated | `S3HtmlStore.keyPrefix` and `htmlPointerPrefix` repeat the same prefix | `docs/core-patterns.md` and `docs/cdk/aws-deployment.md` |
 | React streaming misses late styles | `styleStrategy: shell` was used where `all-ready` was needed | `docs/core-patterns.md` |
 
@@ -77,6 +78,23 @@ npm run ssg -- --entry ./examples/ssg-basic/faces.ts --out ./tmp-ssg --allow-net
 
 Verification:
 - The build completes without the network guard error
+
+## Issue: SSG Build Fails With Dot-Segment Output Paths
+
+Symptoms:
+- `buildSsgSite()` throws about prohibited dot-segments
+- a dynamic SSG route uses values such as `.` or `..`
+
+Cause:
+- `generateStaticParams()` returned path data that would collapse or escape the SSG output tree.
+
+Solution:
+- return only normal route segments from `generateStaticParams()`
+- for catch-all routes, keep every segment inside the intended route subtree instead of using `.` / `..`
+
+Verification:
+- rerun the SSG build
+- confirm the build succeeds and output files remain under the configured `outDir`
 
 ## Issue: ISR HTML Keys Are Duplicated
 

--- a/infra/apptheory-ssg-isr-site/README.md
+++ b/infra/apptheory-ssg-isr-site/README.md
@@ -7,7 +7,7 @@ Canonical operator guidance lives under [`../../docs/cdk/README.md`](../../docs/
 ## What This Stack Demonstrates
 
 - SSG hits served from S3 through CloudFront
-- Lambda Function URL fallback for SSR and ISR
+- signed Lambda Function URL fallback for SSR and ISR
 - request correlation headers
 - baseline security headers
 - blocking ISR using FaceTheory HTML storage plus TableTheory metadata
@@ -36,4 +36,5 @@ npm run synth
 ## Deployment Notes
 
 - Use the canonical AWS deployment and operations docs for routing, cache, and smoke-test expectations.
+- This reference stack intentionally avoids forwarding viewer-supplied tenant headers by default; derive tenant identity from trusted request context if a deployment needs it.
 - Use this README for stack-local prerequisites and commands only.

--- a/infra/apptheory-ssg-isr-site/README.md
+++ b/infra/apptheory-ssg-isr-site/README.md
@@ -10,6 +10,7 @@ Canonical operator guidance lives under [`../../docs/cdk/README.md`](../../docs/
 - signed Lambda Function URL fallback for SSR and ISR
 - request correlation headers
 - baseline security headers
+- escaped reflected request context on the SSR 404 example page
 - blocking ISR using FaceTheory HTML storage plus TableTheory metadata
 
 ## Build Requirement

--- a/infra/apptheory-ssg-isr-site/src/ssr-handler.ts
+++ b/infra/apptheory-ssg-isr-site/src/ssr-handler.ts
@@ -24,6 +24,15 @@ function logJson(value: unknown): void {
   console.log(JSON.stringify(value));
 }
 
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
 function hasHeader(headers: Headers | undefined, key: string): boolean {
   const values = headers?.[key.toLowerCase()];
   return Array.isArray(values) && values.length > 0;
@@ -117,18 +126,24 @@ const faceApp = createFaceApp({
     {
       route: '/{proxy+}',
       mode: 'ssr',
-      render: (ctx) => ({
-        status: 404,
-        headers: { 'cache-control': 'private, no-store' },
-        head: { title: 'Not Found' },
-        html: `
+      render: (ctx) => {
+        const escapedContext = escapeHtml(
+          JSON.stringify({ path: ctx.request.path, proxy: ctx.proxy }, null, 2),
+        );
+
+        return {
+          status: 404,
+          headers: { 'cache-control': 'private, no-store' },
+          head: { title: 'Not Found' },
+          html: `
 <main>
   <h1>Not Found</h1>
-  <pre>${JSON.stringify({ path: ctx.request.path, proxy: ctx.proxy }, null, 2)}</pre>
+  <pre>${escapedContext}</pre>
   <p><a href="/">Back</a></p>
 </main>
 `.trim(),
-      }),
+        };
+      },
     },
   ],
   isr: {

--- a/infra/apptheory-ssg-isr-site/src/stack.ts
+++ b/infra/apptheory-ssg-isr-site/src/stack.ts
@@ -188,7 +188,6 @@ function handler(event) {
       headerBehavior: cloudfront.OriginRequestHeaderBehavior.allowList(
         'x-request-id',
         'x-facetheory-original-uri',
-        'x-facetheory-tenant',
       ),
       queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.all(),
       cookieBehavior: cloudfront.OriginRequestCookieBehavior.all(),

--- a/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
+++ b/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
@@ -509,7 +509,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "e8a64f2e357e99fcbd6d6dcb4d21081463f2d6c23757d613f84fb7bbfa5ae343.zip"
+          "S3Key": "e1d0fd4fd975ffb437d3a15361259de8e3fc6b501764b98a94199403aa83101d.zip"
         },
         "Environment": {
           "Variables": {
@@ -968,8 +968,7 @@
             "HeaderBehavior": "whitelist",
             "Headers": [
               "x-request-id",
-              "x-facetheory-original-uri",
-              "x-facetheory-tenant"
+              "x-facetheory-original-uri"
             ]
           },
           "Name": "FaceTheoryAppTheorySsgIsrSiteOriginRequestPolicy4B63D3F3",

--- a/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
+++ b/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
@@ -509,7 +509,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "e1d0fd4fd975ffb437d3a15361259de8e3fc6b501764b98a94199403aa83101d.zip"
+          "S3Key": "e61ba82fe336892415033159703dab446229375d09d1a0b5407f9bb44d659ce8.zip"
         },
         "Environment": {
           "Variables": {

--- a/infra/apptheory-ssr-site/README.md
+++ b/infra/apptheory-ssr-site/README.md
@@ -7,7 +7,7 @@ Canonical operator guidance lives under [`../../docs/cdk/README.md`](../../docs/
 ## What This Stack Provisions
 
 - private S3 storage for assets
-- Lambda Function URL origin with response streaming
+- Lambda Function URL origin with response streaming and explicit `AWS_IAM` auth
 - CloudFront behaviors for assets, Vite manifests, optional hydration data, and SSR HTML
 
 ## Local Commands
@@ -33,4 +33,5 @@ npm run synth
 ## Deployment Notes
 
 - Deploy and smoke-test instructions should follow the canonical AWS docs first.
+- This reference stack intentionally does **not** forward viewer-supplied tenant headers such as `x-facetheory-tenant`.
 - Use this README for stack-local commands and folder context only.

--- a/infra/apptheory-ssr-site/src/stack.ts
+++ b/infra/apptheory-ssr-site/src/stack.ts
@@ -104,6 +104,7 @@ exports.handler = awslambda.streamifyResponse(async (event, responseStream, cont
 
     this.site = new AppTheorySsrSite(this, 'Site', {
       ssrFunction,
+      ssrUrlAuthType: lambda.FunctionUrlAuthType.AWS_IAM,
       assetsBucket,
       assetsKeyPrefix: 'assets',
       // Vite commonly emits `.vite/manifest.json` in the client build output.
@@ -111,8 +112,6 @@ exports.handler = awslambda.streamifyResponse(async (event, responseStream, cont
       // Raw object/data paths stay on direct S3 behaviors; `staticPathPatterns` is now for
       // extensionless HTML sections in AppTheorySsrSite.
       directS3PathPatterns: ['/.vite/*', '/_facetheory/data/*'],
-      // FaceTheory multi-tenant header (optional).
-      ssrForwardHeaders: ['x-facetheory-tenant'],
       enableLogging: true,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,

--- a/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
+++ b/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
@@ -355,21 +355,7 @@
         "SsrFunctionServiceRoleF0484DAB"
       ]
     },
-    "SsrFunctioninvokefunctionurlBB9A2B69": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunctionUrl",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "SsrFunctionD22C6F1E",
-            "Arn"
-          ]
-        },
-        "FunctionUrlAuthType": "NONE",
-        "Principal": "*"
-      }
-    },
-    "SsrFunctioninvokefunctionCE3E5B81": {
+    "SsrFunctionAllowCloudFrontInvokeFunctionViaUrl8D4F8C8A": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunction",
@@ -380,7 +366,26 @@
           ]
         },
         "InvokedViaFunctionUrl": true,
-        "Principal": "*"
+        "Principal": "cloudfront.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":cloudfront::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":distribution/",
+              {
+                "Ref": "SiteDistribution390DED28"
+              }
+            ]
+          ]
+        }
       }
     },
     "AssetsDeploymentImmutableAwsCliLayer40CE6A61": {
@@ -814,7 +819,7 @@
     "SiteSsrUrl2D74149D": {
       "Type": "AWS::Lambda::Url",
       "Properties": {
-        "AuthType": "NONE",
+        "AuthType": "AWS_IAM",
         "InvokeMode": "RESPONSE_STREAM",
         "TargetFunctionArn": {
           "Fn::GetAtt": [
@@ -841,8 +846,7 @@
               "x-apptheory-original-uri",
               "x-facetheory-original-uri",
               "x-request-id",
-              "x-tenant-id",
-              "x-facetheory-tenant"
+              "x-tenant-id"
             ]
           },
           "Name": "FaceTheoryAppTheorySsrSiteSsrOriginRequestPolicyE60347B7",
@@ -869,8 +873,7 @@
               "x-apptheory-original-uri",
               "x-facetheory-original-uri",
               "x-request-id",
-              "x-tenant-id",
-              "x-facetheory-tenant"
+              "x-tenant-id"
             ]
           },
           "Name": "FaceTheoryAppTheorySsrSiteHtmlOriginRequestPolicy46FBEFF3",
@@ -910,8 +913,7 @@
               "Headers": [
                 "x-apptheory-original-host",
                 "x-facetheory-original-host",
-                "x-tenant-id",
-                "x-facetheory-tenant"
+                "x-tenant-id"
               ]
             },
             "QueryStringsConfig": {
@@ -1004,6 +1006,49 @@
               "Protection": true
             }
           }
+        }
+      }
+    },
+    "SiteDistributionOrigin1FunctionUrlOriginAccessControlFF5C1633": {
+      "Type": "AWS::CloudFront::OriginAccessControl",
+      "Properties": {
+        "OriginAccessControlConfig": {
+          "Name": "FaceTheoryAppTheorySsrSiteDinctionUrlOriginAccessControl506FC69E",
+          "OriginAccessControlOriginType": "lambda",
+          "SigningBehavior": "always",
+          "SigningProtocol": "sigv4"
+        }
+      }
+    },
+    "SiteDistributionOrigin1InvokeFromApiForFaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA468D34E14C": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunctionUrl",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SiteSsrUrl2D74149D",
+            "FunctionArn"
+          ]
+        },
+        "Principal": "cloudfront.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":cloudfront::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":distribution/",
+              {
+                "Ref": "SiteDistribution390DED28"
+              }
+            ]
+          ]
         }
       }
     },
@@ -1311,7 +1356,13 @@
                   }
                 ]
               },
-              "Id": "FaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA46"
+              "Id": "FaceTheoryAppTheorySsrSiteDistributionOrigin1ADF5CA46",
+              "OriginAccessControlId": {
+                "Fn::GetAtt": [
+                  "SiteDistributionOrigin1FunctionUrlOriginAccessControlFF5C1633",
+                  "Id"
+                ]
+              }
             },
             {
               "DomainName": {

--- a/scripts/trigger_theorycloud_publish.sh
+++ b/scripts/trigger_theorycloud_publish.sh
@@ -109,13 +109,20 @@ if [[ -z "${IDEMPOTENCY_KEY}" ]]; then
   fi
 fi
 
-PAYLOAD="$(python3 - <<PY
+PAYLOAD="$(
+  SOURCE_REVISION="${SOURCE_REVISION}" \
+  IDEMPOTENCY_KEY="${IDEMPOTENCY_KEY}" \
+  REASON="${REASON}" \
+  FORCE="${FORCE}" \
+  python3 - <<'PY'
 import json
+import os
+
 payload = {
-  'source_revision': ${SOURCE_REVISION@Q},
-  'idempotency_key': ${IDEMPOTENCY_KEY@Q},
-  'reason': ${REASON@Q},
-  'force': ${FORCE@Q}.lower() == 'true',
+  'source_revision': os.environ['SOURCE_REVISION'],
+  'idempotency_key': os.environ['IDEMPOTENCY_KEY'],
+  'reason': os.environ['REASON'],
+  'force': os.environ['FORCE'].lower() == 'true',
 }
 print(json.dumps(payload, separators=(',', ':')))
 PY

--- a/ts/examples/vite-ssr-react/node-server.ts
+++ b/ts/examples/vite-ssr-react/node-server.ts
@@ -29,9 +29,17 @@ function contentTypeForPath(filePath: string): string {
   }
 }
 
+function decodeUrlPath(urlPath: string): string | null {
+  try {
+    return decodeURIComponent(urlPath);
+  } catch {
+    return null;
+  }
+}
+
 async function readStaticFile(root: string, urlPath: string): Promise<{ body: Uint8Array; type: string } | null> {
-  const decoded = decodeURIComponent(urlPath);
-  if (!decoded.startsWith('/')) return null;
+  const decoded = decodeUrlPath(urlPath);
+  if (!decoded?.startsWith('/')) return null;
   if (decoded.includes('\0')) return null;
 
   const safePath = decoded.replaceAll('\\', '/');

--- a/ts/examples/vite-ssr-svelte-library/node-server.ts
+++ b/ts/examples/vite-ssr-svelte-library/node-server.ts
@@ -29,9 +29,17 @@ function contentTypeForPath(filePath: string): string {
   }
 }
 
+function decodeUrlPath(urlPath: string): string | null {
+  try {
+    return decodeURIComponent(urlPath);
+  } catch {
+    return null;
+  }
+}
+
 async function readStaticFile(root: string, urlPath: string): Promise<{ body: Uint8Array; type: string } | null> {
-  const decoded = decodeURIComponent(urlPath);
-  if (!decoded.startsWith('/')) return null;
+  const decoded = decodeUrlPath(urlPath);
+  if (!decoded?.startsWith('/')) return null;
   if (decoded.includes('\0')) return null;
 
   const safePath = decoded.replaceAll('\\', '/');

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -5,6 +5,7 @@ import type {
   FaceModule,
   FaceResponse,
   Headers,
+  Query,
 } from './types.js';
 import {
   canonicalizeHeaders,
@@ -103,6 +104,7 @@ export interface IsrCacheKeyInput {
   tenant: string;
   routePattern: string;
   params: Record<string, string>;
+  query: Query;
 }
 
 export interface IsrCacheControlOptions {
@@ -380,6 +382,7 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
         tenant,
         routePattern: normalizePath(input.routePattern),
         params: input.ctx.params,
+        query: input.ctx.request.query,
       });
       const currentNow = runtimeOptions.now();
       const existing = await runtimeOptions.metaStore.get(cacheKey);
@@ -484,7 +487,17 @@ export function defaultIsrCacheKey(input: IsrCacheKeyInput): string {
       (key) =>
         `${encodeURIComponent(key)}=${encodeURIComponent(String(input.params[key]))}`,
     );
-  return `${input.tenant}::${routePattern}?${paramParts.join('&')}`;
+  const queryParts = Object.keys(input.query)
+    .sort((left, right) => left.localeCompare(right))
+    .flatMap((key) =>
+      (input.query[key] ?? []).map(
+        (value) =>
+          `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`,
+      ),
+    );
+
+  const keyParts = [...paramParts, ...queryParts];
+  return `${input.tenant}::${routePattern}?${keyParts.join('&')}`;
 }
 
 export function blockingIsrCacheControl(
@@ -703,9 +716,11 @@ function resolveTenant(
 }
 
 function defaultTenantKey(ctx: FaceContext): string {
-  const values = ctx.request.headers['x-facetheory-tenant'] ?? [];
-  const first = values[0] ?? '';
-  return String(first).trim() || 'default';
+  const primary = firstHeaderValue(ctx.request.headers, 'x-tenant-id');
+  if (primary) return primary;
+
+  const legacy = firstHeaderValue(ctx.request.headers, 'x-facetheory-tenant');
+  return legacy ?? 'default';
 }
 
 function buildHtmlPointer(
@@ -762,6 +777,13 @@ function normalizeStatus(value: number): number {
   return int;
 }
 
+function firstHeaderValue(headers: Headers, key: string): string | null {
+  const values = headers[key] ?? headers[key.toLowerCase()] ?? [];
+  const first = values[0] ?? '';
+  const normalized = String(first).trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
 function normalizeRevalidateSeconds(value: number | undefined): number {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return DEFAULT_REVALIDATE_SECONDS;
@@ -808,13 +830,6 @@ async function prepareFreshResponse(
     contentType,
     etag,
   };
-}
-
-function firstHeaderValue(headers: Headers, key: string): string | null {
-  const values = headers[key.toLowerCase()] ?? [];
-  if (!values.length) return null;
-  const first = values[0];
-  return first === undefined ? null : String(first);
 }
 
 async function collectBody(body: FaceResponse['body']): Promise<Uint8Array> {

--- a/ts/src/spa.ts
+++ b/ts/src/spa.ts
@@ -26,6 +26,7 @@ export interface ParseFaceNavigationSnapshotOptions extends SnapshotFaceDocument
 }
 
 export interface FetchFaceNavigationSnapshotOptions extends ParseFaceNavigationSnapshotOptions {
+  allowedOrigin?: string | URL;
   fetcher?: typeof fetch;
   requestInit?: RequestInit;
 }
@@ -51,6 +52,7 @@ export interface FaceNavigationBootstrapModule {
 }
 
 export interface LoadFaceNavigationModuleOptions {
+  allowedOrigin?: string | URL;
   document?: Document;
   importModule?: (specifier: string) => Promise<FaceNavigationBootstrapModule>;
   reloadOnMissingHook?: boolean;
@@ -151,6 +153,16 @@ export async function fetchFaceNavigationSnapshot(
     );
   }
 
+  const allowedOrigin = resolveAllowedNavigationOrigin(options.allowedOrigin);
+  if (allowedOrigin) {
+    assertSameOriginNavigationUrl(
+      response.url || String(url),
+      allowedOrigin,
+      resolveNavigationBaseHref(url, allowedOrigin),
+      'FaceTheory SPA navigation fetch resolved cross-origin',
+    );
+  }
+
   const parseOptions: ParseFaceNavigationSnapshotOptions = {
     url: response.url || String(url),
   };
@@ -196,6 +208,11 @@ export async function loadFaceNavigationModule(
   if (!snapshot.hydration?.bootstrapModule) return;
 
   const doc = options.document ?? document;
+  const allowedOrigin =
+    resolveAllowedNavigationOrigin(options.allowedOrigin) ??
+    doc.defaultView?.location.origin ??
+    resolveNavigationUrl(snapshot.url, 'http://localhost/').origin;
+  assertSameOriginHydrationModule(snapshot, allowedOrigin);
   const importModule = options.importModule ?? importFaceNavigationModule;
   const context = createBootstrapContext(
     snapshot,
@@ -245,8 +262,17 @@ export function startFaceNavigation(
     },
   ): Promise<FaceNavigationSnapshot> => {
     const url = new URL(String(urlInput), win.location.href);
+    assertSameOriginNavigationUrl(
+      url,
+      win.location.origin,
+      win.location.href,
+      'FaceTheory SPA navigation requires same-origin URLs',
+    );
     const winWithParser = win as Window & { DOMParser?: typeof DOMParser };
-    const fetchOptions: FetchFaceNavigationSnapshotOptions = { viewSelector };
+    const fetchOptions: FetchFaceNavigationSnapshotOptions = {
+      allowedOrigin: win.location.origin,
+      viewSelector,
+    };
     if (options.fetcher !== undefined) fetchOptions.fetcher = options.fetcher;
     if (options.requestInit !== undefined) fetchOptions.requestInit = options.requestInit;
     if (options.parser !== undefined) {
@@ -256,6 +282,7 @@ export function startFaceNavigation(
     }
 
     const snapshot = await fetchFaceNavigationSnapshot(url, fetchOptions);
+    assertSameOriginHydrationModule(snapshot, win.location.origin);
 
     if (options.render) {
       await options.render(
@@ -271,6 +298,7 @@ export function startFaceNavigation(
       applyFaceNavigationSnapshot(snapshot, applyOptions);
 
       const loadOptions: LoadFaceNavigationModuleOptions = {
+        allowedOrigin: win.location.origin,
         document: doc,
         viewSelector,
       };
@@ -358,6 +386,38 @@ function resolveSnapshotUrl(doc: Document, url: string | URL | undefined): strin
   }
 
   return doc.URL || doc.defaultView?.location.href || '';
+}
+
+function resolveAllowedNavigationOrigin(origin: string | URL | undefined): string | null {
+  if (origin === undefined) return null;
+  return new URL(String(origin)).origin;
+}
+
+function resolveNavigationBaseHref(url: string | URL, fallbackOrigin: string): string {
+  try {
+    return new URL(String(url)).toString();
+  } catch {
+    return new URL('/', fallbackOrigin).toString();
+  }
+}
+
+function resolveNavigationUrl(url: string | URL, baseHref: string): URL {
+  return new URL(String(url), baseHref);
+}
+
+function assertSameOriginNavigationUrl(
+  url: string | URL,
+  allowedOrigin: string,
+  baseHref: string,
+  reason: string,
+): URL {
+  const resolved = resolveNavigationUrl(url, baseHref);
+  if (resolved.origin !== allowedOrigin) {
+    throw new Error(
+      `${reason}: expected ${allowedOrigin}, received ${resolved.origin} (${resolved.toString()})`,
+    );
+  }
+  return resolved;
 }
 
 function readAttributes(element: Element): FaceAttributes {
@@ -459,6 +519,21 @@ function createBootstrapContext(
     url: new URL(snapshot.url, doc.defaultView?.location.href ?? 'http://localhost/'),
     view: doc.querySelector(viewSelector),
   };
+}
+
+function assertSameOriginHydrationModule(
+  snapshot: FaceNavigationSnapshot,
+  allowedOrigin: string,
+): void {
+  const specifier = snapshot.hydration?.bootstrapModule;
+  if (!specifier) return;
+
+  assertSameOriginNavigationUrl(
+    specifier,
+    allowedOrigin,
+    snapshot.url,
+    'FaceTheory SPA hydration module resolved cross-origin',
+  );
 }
 
 async function importFaceNavigationModule(

--- a/ts/src/ssg.ts
+++ b/ts/src/ssg.ts
@@ -287,6 +287,7 @@ function parseRouteSegments(routePattern: string): SsgRouteSegment[] {
         return { kind: 'proxy_star', value: token.slice(0, -1) };
       return { kind: 'param', value: token };
     }
+    assertSafeSsgPathSegment(part, `route "${routePattern}"`);
     return { kind: 'static', value: part };
   });
 }
@@ -316,6 +317,9 @@ function resolveRoutePath(
       if (proxyParts.length === 0) {
         throw new Error(`missing required proxy param "${segment.value}"`);
       }
+      proxyParts.forEach((part) =>
+        assertSafeSsgPathSegment(part, `param "${segment.value}"`),
+      );
       pathParts.push(...proxyParts.map((part) => encodeURIComponent(part)));
       continue;
     }
@@ -323,6 +327,9 @@ function resolveRoutePath(
     if (segment.kind === 'proxy_star') {
       if (!value) continue;
       const proxyParts = value.split('/').filter((part) => part.length > 0);
+      proxyParts.forEach((part) =>
+        assertSafeSsgPathSegment(part, `param "${segment.value}"`),
+      );
       pathParts.push(...proxyParts.map((part) => encodeURIComponent(part)));
       continue;
     }
@@ -330,6 +337,7 @@ function resolveRoutePath(
     if (!value) {
       throw new Error(`missing required route param "${segment.value}"`);
     }
+    assertSafeSsgPathSegment(value, `param "${segment.value}"`);
     pathParts.push(encodeURIComponent(value));
   }
 
@@ -368,8 +376,39 @@ async function writeOutFile(
   content: string,
 ): Promise<void> {
   const absolutePath = path.resolve(outDir, relativePath);
+  assertSafeSsgOutputPath(outDir, relativePath, absolutePath);
   await mkdir(path.dirname(absolutePath), { recursive: true });
   await writeFile(absolutePath, content);
+}
+
+function assertSafeSsgPathSegment(segment: string, source: string): void {
+  if (segment === '.' || segment === '..') {
+    throw new Error(
+      `SSG ${source} contains prohibited dot-segment "${segment}"; generateStaticParams() values must not escape the output root`,
+    );
+  }
+}
+
+function assertSafeSsgOutputPath(
+  outDir: string,
+  relativePath: string,
+  absolutePath: string,
+): void {
+  const normalizedRelative = relativePath.replaceAll('\\', '/');
+  for (const segment of normalizedRelative.split('/')) {
+    if (!segment) continue;
+    assertSafeSsgPathSegment(segment, `output path "${relativePath}"`);
+  }
+
+  const relativeToOutDir = path.relative(outDir, absolutePath);
+  if (
+    !relativeToOutDir ||
+    relativeToOutDir === '..' ||
+    relativeToOutDir.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeToOutDir)
+  ) {
+    throw new Error(`SSG output path "${relativePath}" escapes outDir "${outDir}"`);
+  }
 }
 
 function extractHydrationDataJson(html: string): string | null {

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -122,6 +122,7 @@ test('isr: regeneration failure serves stale and keeps pointer intact', async ()
     tenant: 'default',
     routePattern: '/faces/{id}',
     params: { id: '42' },
+    query: {},
   });
   const beforeFailure = await metaStore.get(cacheKey);
   assert.ok(beforeFailure?.htmlPointer);
@@ -198,7 +199,46 @@ test('isr: expired lease does not deadlock regeneration', async () => {
   assert.equal(renderCount, 3);
 });
 
-test('isr: tenant partitioning keeps cache entries isolated', async () => {
+test('isr: default cache key partitions by query strings', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/search',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: async () => {
+          const seq = ++renderCount;
+          return { html: `<main>search-${seq}</main>` };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+    },
+  });
+
+  const first = await app.handle({ method: 'GET', path: '/search?view=table&sort=asc' });
+  const sameQueryDifferentOrder = await app.handle({
+    method: 'GET',
+    path: '/search?sort=asc&view=table',
+  });
+  const differentQuery = await app.handle({ method: 'GET', path: '/search?view=grid&sort=asc' });
+
+  assert.ok(decodeBody(first.body as Uint8Array).includes('search-1'));
+  assert.ok(decodeBody(sameQueryDifferentOrder.body as Uint8Array).includes('search-1'));
+  assert.ok(decodeBody(differentQuery.body as Uint8Array).includes('search-2'));
+  assert.equal(renderCount, 2);
+
+  const cacheKeys = metaStore.debugSnapshot().map((record) => record.cacheKey);
+  assert.equal(cacheKeys.length, 2);
+});
+
+test('isr: tenant partitioning prefers x-tenant-id with legacy fallback', async () => {
   const htmlStore = new InMemoryHtmlStore();
   const metaStore = new InMemoryIsrMetaStore();
   let renderCount = 0;
@@ -224,12 +264,18 @@ test('isr: tenant partitioning keeps cache entries isolated', async () => {
   const tenantAFirst = await app.handle({
     method: 'GET',
     path: '/tenant/home',
-    headers: { 'x-facetheory-tenant': ['tenant-a'] },
+    headers: {
+      'x-tenant-id': ['tenant-a'],
+      'x-facetheory-tenant': ['spoofed-tenant'],
+    },
   });
   const tenantBFirst = await app.handle({
     method: 'GET',
     path: '/tenant/home',
-    headers: { 'x-facetheory-tenant': ['tenant-b'] },
+    headers: {
+      'x-tenant-id': ['tenant-b'],
+      'x-facetheory-tenant': ['tenant-a'],
+    },
   });
   const tenantASecond = await app.handle({
     method: 'GET',

--- a/ts/test/unit/spa.test.ts
+++ b/ts/test/unit/spa.test.ts
@@ -6,6 +6,7 @@ import { JSDOM } from 'jsdom';
 import {
   applyFaceNavigationSnapshot,
   DEFAULT_FACE_VIEW_SELECTOR,
+  loadFaceNavigationModule,
   parseFaceNavigationSnapshot,
   readFaceHydrationData,
   startFaceNavigation,
@@ -199,6 +200,188 @@ test('spa helpers: startFaceNavigation intercepts links and invokes hydration ho
     ]);
   } finally {
     controller.stop();
+    dom.window.close();
+  }
+});
+
+test('spa helpers: startFaceNavigation rejects cross-origin programmatic navigation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+
+  let fetchCalls = 0;
+  const errors: string[] = [];
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    fetcher: async () => {
+      fetchCalls += 1;
+      return new Response('<!doctype html><html><head><title>Ignored</title></head><body></body></html>');
+    },
+    onError: (error) => {
+      errors.push(error instanceof Error ? error.message : String(error));
+    },
+  });
+
+  try {
+    await assert.rejects(
+      controller.navigate('https://evil.example/next'),
+      /FaceTheory SPA navigation requires same-origin URLs/,
+    );
+
+    assert.equal(fetchCalls, 0);
+    assert.equal(errors.length, 1);
+    assert.equal(dom.window.location.href, 'http://localhost/');
+    assert.equal(dom.window.document.title, 'Home');
+    assert.equal(
+      dom.window.document.querySelector(DEFAULT_FACE_VIEW_SELECTOR)?.textContent?.trim(),
+      'Home',
+    );
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
+test('spa helpers: startFaceNavigation rejects redirected cross-origin snapshots before DOM mutation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    onError: () => {},
+    fetcher: async () =>
+      ({
+        ok: true,
+        status: 200,
+        url: 'https://evil.example/next',
+        text: async () =>
+          '<!doctype html><html><head><title>Redirected</title></head><body><main data-facetheory-view><p>Bad</p></main></body></html>',
+      }) as Response,
+  });
+
+  try {
+    await assert.rejects(
+      controller.navigate('/next'),
+      /FaceTheory SPA navigation fetch resolved cross-origin/,
+    );
+
+    assert.equal(dom.window.location.href, 'http://localhost/');
+    assert.equal(dom.window.document.title, 'Home');
+    assert.equal(
+      dom.window.document.querySelector(DEFAULT_FACE_VIEW_SELECTOR)?.textContent?.trim(),
+      'Home',
+    );
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
+test('spa helpers: startFaceNavigation rejects remote hydration modules before DOM mutation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    onError: () => {},
+    fetcher: async () =>
+      new Response(
+        `<!doctype html>
+          <html lang="en">
+            <head>
+              <title>Next</title>
+              <script id="__FACETHEORY_DATA__" type="application/json">{"page":"next"}</script>
+              <script src="https://evil.example/assets/entry-client.js" type="module"></script>
+            </head>
+            <body class="shell-next">
+              <main data-facetheory-view><p>Next Page</p></main>
+            </body>
+          </html>`,
+        { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } },
+      ),
+  });
+
+  try {
+    await assert.rejects(
+      controller.navigate('/next'),
+      /FaceTheory SPA hydration module resolved cross-origin/,
+    );
+
+    assert.equal(dom.window.location.href, 'http://localhost/');
+    assert.equal(dom.window.document.title, 'Home');
+    assert.equal(
+      dom.window.document.querySelector(DEFAULT_FACE_VIEW_SELECTOR)?.textContent?.trim(),
+      'Home',
+    );
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
+test('spa helpers: loadFaceNavigationModule rejects cross-origin bootstrap modules', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+
+  try {
+    const snapshot = parseFaceNavigationSnapshot(
+      `<!doctype html>
+        <html lang="en">
+          <head>
+            <title>Next</title>
+            <script id="__FACETHEORY_DATA__" type="application/json">{"page":"next"}</script>
+            <script src="https://evil.example/assets/entry-client.js" type="module"></script>
+          </head>
+          <body class="shell-next">
+            <main data-facetheory-view><p>Next Page</p></main>
+          </body>
+        </html>`,
+      {
+        parser: new dom.window.DOMParser(),
+        url: 'http://localhost/next',
+        viewSelector: DEFAULT_FACE_VIEW_SELECTOR,
+      },
+    );
+
+    await assert.rejects(
+      loadFaceNavigationModule(snapshot, { document: dom.window.document }),
+      /FaceTheory SPA hydration module resolved cross-origin/,
+    );
+  } finally {
     dom.window.close();
   }
 });

--- a/ts/test/unit/ssg.test.ts
+++ b/ts/test/unit/ssg.test.ts
@@ -173,6 +173,31 @@ test('ssg: denies network fetch by default', async () => {
   }
 });
 
+test('ssg: rejects dot-segment params that would escape the output root', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-traversal-'));
+  const outDir = path.resolve(tempRoot, 'out');
+  const escapedCandidate = path.resolve(tempRoot, 'escape', 'index.html');
+
+  const faces: FaceModule[] = [
+    {
+      route: '/docs/{path+}',
+      mode: 'ssg',
+      generateStaticParams: async () => [{ path: '../../escape' }],
+      render: () => ({ html: '<main>bad</main>' }),
+    },
+  ];
+
+  try {
+    await assert.rejects(
+      buildSsgSite({ faces, outDir }),
+      /prohibited dot-segment|escapes outDir/i,
+    );
+    await assert.rejects(readFile(escapedCandidate, 'utf8'), /ENOENT/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('ssg: allows explicit fetch mock', async () => {
   const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-mock-'));
   const outDir = path.resolve(tempRoot, 'out');

--- a/ts/test/unit/vite-ssr-example.test.ts
+++ b/ts/test/unit/vite-ssr-example.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { execFile } from 'node:child_process';
+import { execFile, spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
 import { rm, readFile, stat } from 'node:fs/promises';
+import { createServer } from 'node:net';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { pathToFileURL } from 'node:url';
@@ -17,6 +19,95 @@ async function exists(filePath: string): Promise<boolean> {
     return true;
   } catch {
     return false;
+  }
+}
+
+async function reservePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    throw new Error('Failed to reserve an ephemeral port for the Vite SSR example');
+  }
+  const { port } = address;
+  await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  return port;
+}
+
+async function startExampleServer(
+  cwd: string,
+  entryPoint: string,
+  port: number,
+): Promise<ChildProcess> {
+  const tsxBin = path.resolve(cwd, 'node_modules/.bin/tsx');
+  const child = spawn(tsxBin, [entryPoint], {
+    cwd,
+    env: { ...process.env, PORT: String(port) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let logs = '';
+  const appendLogs = (chunk: string | Buffer) => {
+    logs += chunk.toString();
+  };
+
+  child.stdout.on('data', appendLogs);
+  child.stderr.on('data', appendLogs);
+
+  await new Promise<void>((resolve, reject) => {
+    const readyLine = `listening on http://localhost:${port}/`;
+
+    const onData = () => {
+      if (logs.includes(readyLine)) {
+        child.stdout.off('data', onData);
+        child.stderr.off('data', onData);
+        child.off('error', onError);
+        child.off('exit', onExit);
+        resolve();
+      }
+    };
+    const onError = (error: Error) => {
+      child.stdout.off('data', onData);
+      child.stderr.off('data', onData);
+      child.off('exit', onExit);
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      child.stdout.off('data', onData);
+      child.stderr.off('data', onData);
+      child.off('error', onError);
+      reject(
+        new Error(
+          `Vite SSR example server exited before listening (code=${code}, signal=${signal})\n${logs}`,
+        ),
+      );
+    };
+
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.once('error', onError);
+    child.once('exit', onExit);
+  });
+
+  return child;
+}
+
+async function stopExampleServer(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return;
+
+  child.kill('SIGTERM');
+  await Promise.race([
+    once(child, 'exit').then(() => undefined),
+    new Promise<void>((resolve) => setTimeout(resolve, 2_000)),
+  ]);
+
+  if (child.exitCode === null) {
+    child.kill('SIGKILL');
+    await once(child, 'exit');
   }
 }
 
@@ -58,5 +149,20 @@ test('vite SSR example: builds client+server and renders without missing assets'
   for (const injectedPath of injectedPaths) {
     const builtPath = path.resolve('examples/vite-ssr-react/dist/client', `.${injectedPath}`);
     assert.ok(await exists(builtPath), `missing built asset: ${injectedPath}`);
+  }
+
+  const port = await reservePort();
+  const server = await startExampleServer(cwd, 'examples/vite-ssr-react/node-server.ts', port);
+  try {
+    const malformedResp = await fetch(`http://127.0.0.1:${port}/assets/%E0%A4%A`);
+    assert.equal(malformedResp.status, 404);
+    assert.equal(await malformedResp.text(), 'Not Found');
+    assert.equal(server.exitCode, null);
+
+    const healthyResp = await fetch(`http://127.0.0.1:${port}/`);
+    assert.equal(healthyResp.status, 200);
+    assert.match(await healthyResp.text(), /Hello from server/);
+  } finally {
+    await stopExampleServer(server);
   }
 });

--- a/ts/test/unit/vite-ssr-svelte-library-example.test.ts
+++ b/ts/test/unit/vite-ssr-svelte-library-example.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { execFile } from 'node:child_process';
+import { execFile, spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
 import { readFile, rm, stat } from 'node:fs/promises';
+import { createServer } from 'node:net';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
@@ -19,6 +21,95 @@ async function exists(filePath: string): Promise<boolean> {
     return true;
   } catch {
     return false;
+  }
+}
+
+async function reservePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    throw new Error('Failed to reserve an ephemeral port for the Vite Svelte library example');
+  }
+  const { port } = address;
+  await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  return port;
+}
+
+async function startExampleServer(
+  cwd: string,
+  entryPoint: string,
+  port: number,
+): Promise<ChildProcess> {
+  const tsxBin = path.resolve(cwd, 'node_modules/.bin/tsx');
+  const child = spawn(tsxBin, [entryPoint], {
+    cwd,
+    env: { ...process.env, PORT: String(port) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let logs = '';
+  const appendLogs = (chunk: string | Buffer) => {
+    logs += chunk.toString();
+  };
+
+  child.stdout.on('data', appendLogs);
+  child.stderr.on('data', appendLogs);
+
+  await new Promise<void>((resolve, reject) => {
+    const readyLine = `listening on http://localhost:${port}/`;
+
+    const onData = () => {
+      if (logs.includes(readyLine)) {
+        child.stdout.off('data', onData);
+        child.stderr.off('data', onData);
+        child.off('error', onError);
+        child.off('exit', onExit);
+        resolve();
+      }
+    };
+    const onError = (error: Error) => {
+      child.stdout.off('data', onData);
+      child.stderr.off('data', onData);
+      child.off('exit', onExit);
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      child.stdout.off('data', onData);
+      child.stderr.off('data', onData);
+      child.off('error', onError);
+      reject(
+        new Error(
+          `Vite Svelte library example server exited before listening (code=${code}, signal=${signal})\n${logs}`,
+        ),
+      );
+    };
+
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.once('error', onError);
+    child.once('exit', onExit);
+  });
+
+  return child;
+}
+
+async function stopExampleServer(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return;
+
+  child.kill('SIGTERM');
+  await Promise.race([
+    once(child, 'exit').then(() => undefined),
+    new Promise<void>((resolve) => setTimeout(resolve, 2_000)),
+  ]);
+
+  if (child.exitCode === null) {
+    child.kill('SIGKILL');
+    await once(child, 'exit');
   }
 }
 
@@ -159,6 +250,25 @@ test(
       console.error = originalConsoleError;
       console.warn = originalConsoleWarn;
       dom.window.close();
+    }
+
+    const port = await reservePort();
+    const server = await startExampleServer(
+      cwd,
+      'examples/vite-ssr-svelte-library/node-server.ts',
+      port,
+    );
+    try {
+      const malformedResp = await fetch(`http://127.0.0.1:${port}/assets/%E0%A4%A`);
+      assert.equal(malformedResp.status, 404);
+      assert.equal(await malformedResp.text(), 'Not Found');
+      assert.equal(server.exitCode, null);
+
+      const healthyResp = await fetch(`http://127.0.0.1:${port}/`);
+      assert.equal(healthyResp.status, 200);
+      assert.match(await healthyResp.text(), /FaceTheory Svelte Library Host/);
+    } finally {
+      await stopExampleServer(server);
     }
   },
 );


### PR DESCRIPTION
## Milestone
Boundary hardening — secure untrusted input across SPA navigation, SSG output generation, ISR default partitioning, AppTheory-based reference stacks, examples, and local publish/example server tooling.

## Linear
https://linear.app/theorycloud/project/facetheory-2026-security-hardening-f0987c14dd16

Milestone: Boundary hardening

## Render modes and adapters affected
SSR / SSG / ISR / SPA × core runtime, AppTheory reference stacks, and example/tooling surfaces

## Determinism impact
Preserves determinism and hardens the SPA hydration boundary so navigation snapshots and bootstrap modules remain same-origin before the current document is mutated.

## Backward compatibility
Breaking — this milestone includes the approved ISR default change: query strings join the default cache key and `x-tenant-id` takes precedence over legacy `x-facetheory-tenant`.

## Tasks
- [x] THE-397 — 03. Enforce same-origin SPA navigation snapshots
- [x] THE-398 — 04. Block SSG output path traversal
- [x] THE-399 — 09. Harden default ISR cache partitioning
- [x] THE-395 — 01. Harden AppTheory reference stacks
- [x] THE-396 — 02. Escape 404 context in the SSG/ISR example handler
- [x] THE-400 — 12. Guard malformed URL decoding in Vite examples
- [x] THE-401 — 13. Quote publish payload generation safely

## Validation
- `make rubric` — PASS
- `cd infra/apptheory-ssr-site && npm test` — PASS
- `cd infra/apptheory-ssg-isr-site && npm test` — PASS
- `cd ts && npm run example:ssg:build` — PASS
- `THEORYCLOUD_PUBLISH_DRY_RUN=true bash scripts/trigger_theorycloud_publish.sh --reason "operator's note"` — PASS
- `cd ts && npm run example:streaming:serve` + `curl -fsS http://127.0.0.1:4173/` — PASS (streaming SSR smoke)
- Browser-console hydration verification remains limited in this environment because the Chrome MCP browser could not start without an X server; hydration mismatch coverage still ran in `make rubric` via the React/Vite hydration test suites.

## Cross-repo coordination
AppTheory #437 is tracked separately for trusted tenant-header enforcement and is not a blocker for this milestone.







