### PR TITLE
fix(security): address dependency and redos alerts

### DIFF
--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -1212,14 +1212,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.5.8",
+        "fast-xml-parser": "5.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1677,6 +1677,19 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.12",
@@ -3019,9 +3032,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "dev": true,
       "funding": [
         {
@@ -3031,9 +3044,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1374,14 +1374,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.5.8",
+        "fast-xml-parser": "5.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2576,6 +2576,19 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
@@ -5651,9 +5664,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "dev": true,
       "funding": [
         {
@@ -5663,9 +5676,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/ts/src/stitch-shell/surface-tone.ts
+++ b/ts/src/stitch-shell/surface-tone.ts
@@ -4,19 +4,41 @@ export interface ResolvedSurfaceTone {
   chipColor: string;
 }
 
-export function normalizeSurfaceTone(surfaceTone: string | undefined): string | undefined {
+function isAsciiAlphaNumeric(charCode: number): boolean {
+  return (
+    (charCode >= 48 && charCode <= 57) || (charCode >= 97 && charCode <= 122)
+  );
+}
+
+export function normalizeSurfaceTone(
+  surfaceTone: string | undefined,
+): string | undefined {
   if (surfaceTone === undefined) return undefined;
 
-  const normalized = surfaceTone
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  const lower = surfaceTone.trim().toLowerCase();
+  let normalized = '';
+  let pendingSeparator = false;
+
+  for (let index = 0; index < lower.length; index += 1) {
+    const char = lower[index]!;
+
+    if (isAsciiAlphaNumeric(char.charCodeAt(0))) {
+      if (pendingSeparator && normalized.length > 0) {
+        normalized += '-';
+      }
+      normalized += char;
+      pendingSeparator = false;
+    } else if (normalized.length > 0) {
+      pendingSeparator = true;
+    }
+  }
 
   return normalized ? normalized : undefined;
 }
 
-export function resolveSurfaceTone(surfaceTone: string | undefined): ResolvedSurfaceTone {
+export function resolveSurfaceTone(
+  surfaceTone: string | undefined,
+): ResolvedSurfaceTone {
   const normalizedTone = normalizeSurfaceTone(surfaceTone);
 
   return normalizedTone !== undefined

--- a/ts/test/unit/stitch-shell.test.ts
+++ b/ts/test/unit/stitch-shell.test.ts
@@ -504,9 +504,26 @@ test('BrandHeader surfaceTone normalizes to safe stitch CSS variable suffixes', 
     }),
   );
   assert.ok(body.includes('--stitch-color-secondary-accent-prod-2-container'));
-  assert.ok(body.includes('--stitch-color-on-secondary-accent-prod-2-container'));
+  assert.ok(
+    body.includes('--stitch-color-on-secondary-accent-prod-2-container'),
+  );
   assert.ok(body.includes('data-surface-tone="secondary-accent-prod-2"'));
   assert.ok(!body.includes('Secondary Accent / Prod 2'));
+});
+
+test('BrandHeader surfaceTone handles long separator runs safely', async () => {
+  const separators = '-'.repeat(10_000);
+  const body = await renderSSR(
+    h(BrandHeader, {
+      logo: h('span', null, '◆'),
+      wordmark: 'Theory Cloud',
+      surfaceLabel: '[Core]',
+      surfaceTone: `${separators}Admin${separators}Ops${separators}`,
+    }),
+  );
+  assert.ok(body.includes('--stitch-color-admin-ops-container'));
+  assert.ok(body.includes('--stitch-color-on-admin-ops-container'));
+  assert.ok(body.includes('data-surface-tone="admin-ops"'));
 });
 
 test('BrandHeader falls back to neutral tokens when surfaceTone normalizes empty', async () => {


### PR DESCRIPTION
## Summary
- Resolves Dependabot alerts #32 and #33 by updating `@aws-sdk/xml-builder` lockfile entries to `3.972.19`, which pulls `fast-xml-parser@5.7.1` (patched for GHSA-gh4j-gqv2-49f6 / CVE-2026-41650) in both affected lockfiles.
- Resolves code scanning alert #14 by replacing the `surfaceTone` normalization regex chain with a linear scanner that preserves the same lowercase kebab-case output without regex backtracking risk.
- Adds a regression test for long separator runs in `BrandHeader.surfaceTone`.

## Alerts addressed
- Dependabot #32: `ts/package-lock.json` transitive dev `fast-xml-parser < 5.7.0`
- Dependabot #33: `infra/apptheory-ssg-isr-site/package-lock.json` transitive dev `fast-xml-parser < 5.7.0`
- Code scanning #14: CodeQL `js/polynomial-redos` in `ts/src/stitch-shell/surface-tone.ts`

## Render modes and adapters affected
Shared Stitch shell normalization used by React, Vue, and Svelte BrandHeader surfaces. No SSR / SSG / ISR / SPA mode semantics changed.

## Determinism impact
Preserves determinism. The new scanner is pure and produces the same stable normalized token suffix from caller-supplied input; it does not read time, randomness, browser globals, or environment state.

## Validation
- [x] `npm ci` in `ts/`
- [x] `npm ci` in `infra/apptheory-ssg-isr-site/`
- [x] `cd ts && npx tsx test/unit/stitch-shell.test.ts`
- [x] `cd infra/apptheory-ssg-isr-site && npm test`
- [x] `make rubric`
- [x] `git diff --check`
- [x] `cd ts && npx prettier --check src/stitch-shell/surface-tone.ts test/unit/stitch-shell.test.ts`
- [x] `npm ls fast-xml-parser @aws-sdk/xml-builder --all` in both affected package roots confirms `fast-xml-parser@5.7.1`
