### PR TITLE
feat(examples): add operator visibility SSR example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,6 +153,16 @@ const logs: LogEntry[] = [
 
 Use the shared contract subpaths for data shape and semantic variants. Use the adapter-matched subpaths for actual components. That keeps the React, Vue, and Svelte surfaces in lockstep instead of letting one host drift into framework-local shapes.
 
+The React operator visibility SSR example shows those primitives wired together from a Face `load()` function:
+
+```bash
+cd ts
+npm run example:operator-visibility:build
+npm run example:operator-visibility:serve
+```
+
+The example renders `NonAuthoritativeBanner`, `GuardedOperatorShell`, `HealthStatusPanel`, `VisibilityMatrix`, and `OperatorEmptyState` from injected data. Treat it as the reference shape for deterministic operator dashboards: load stable labels and metadata first, then render them without reading browser/session globals.
+
 Operator visibility primitives use caller-supplied metadata, guard state, health observations, and visibility matrix rows/cells only. Pass stable provenance, confidence, staleness labels, matrix cell labels, and `OperatorGuardStatus` values from `load()` or serialized hydration data; do not compute freshness or authorization from ambient browser/session globals during render. Empty states should use `OperatorEmptyStateConfig.placeholderDataPolicy = "no-production-like-data"` instead of production-looking placeholder tenants, partners, releases, or versions.
 
 For control-plane navigation, treat `path` as the SSR-safe baseline contract for nav items and breadcrumbs. Use `onNavigate` only as an optional client-side interception hook; if a host never hydrates, links with `path` must still work as normal anchors.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -7,6 +7,7 @@ This guide covers the verification commands that back the public contract and th
 FaceTheory verification is centered on deterministic runtime behavior in the TypeScript workspace.
 
 Primary goals:
+
 - Validate request normalization, routing, buffered SSR, streaming SSR, SSG, ISR, and framework adapter behavior.
 - Keep example commands runnable so docs and implementation do not drift apart.
 - Capture enough evidence to distinguish toolchain issues from runtime regressions.
@@ -29,6 +30,7 @@ make ts-test
 ```
 
 Expected result:
+
 - Type checking completes with no errors.
 - The unit suite passes.
 
@@ -45,6 +47,7 @@ npm run example:ssg:serve
 ```
 
 Use this when changing:
+
 - route planning
 - hydration data output
 - static file layout
@@ -58,9 +61,26 @@ npm run example:streaming:serve
 ```
 
 Use this when changing:
+
 - head rendering
 - streaming behavior
 - style extraction timing
+
+### Operator Visibility SSR Example
+
+```bash
+cd ts
+npm run example:operator-visibility:build
+npx tsx test/unit/operator-visibility-example.test.ts
+```
+
+Use this when changing:
+
+- Stitch admin operator visibility primitives
+- deterministic guard/authority/confidence/staleness rendering
+- health panels or visibility matrices used by operator dashboards
+
+The example intentionally passes stable age labels, guard status, health observations, and matrix cells through Face `load()` data. Do not compute freshness from `Date.now()`, browser globals, auth/session state, or network calls during render.
 
 ### Vite SSR Adapters
 
@@ -72,6 +92,7 @@ npm run example:vite:svelte:build && npm run example:vite:svelte:serve
 ```
 
 Use this when changing:
+
 - manifest asset injection
 - framework adapter parity
 - hydration bootstrap behavior
@@ -81,6 +102,7 @@ Use this when changing:
 These areas provide the fastest signal that a change has altered public behavior rather than only internal implementation details.
 
 Representative unit coverage includes:
+
 - HTTP and app runtime behavior
 - Lambda Function URL conversion
 - React streaming and style handling
@@ -94,6 +116,7 @@ Representative unit coverage includes:
 Capture enough context that another engineer can reproduce a failure without reverse-engineering your environment from scratch.
 
 For every regression or risky change, capture:
+
 - command run
 - pass or fail result
 - failing test names or stack traces
@@ -101,6 +124,7 @@ For every regression or risky change, capture:
 - the adapter or mode involved, such as `react`, `vue`, `svelte`, `ssg`, or `isr`
 
 For example-driven verification, also capture:
+
 - URL checked
 - expected versus actual headers
 - generated output path if the flow writes files

--- a/ts/examples/operator-visibility-react/README.md
+++ b/ts/examples/operator-visibility-react/README.md
@@ -1,0 +1,12 @@
+# Operator visibility React SSR example
+
+This example renders a deterministic operator visibility dashboard through the React adapter.
+
+The Face `load()` function injects every guard, authority, confidence, staleness, health, and matrix value. The React render path only displays those values; it does not compute freshness from ambient time, browser globals, auth/session state, or network calls.
+
+```bash
+npm run example:operator-visibility:build
+npm run example:operator-visibility:serve
+```
+
+The build command writes `examples/operator-visibility-react/dist/index.html` for inspection. The serve command starts a small Node HTTP server on `PORT` or `4174`.

--- a/ts/examples/operator-visibility-react/build.ts
+++ b/ts/examples/operator-visibility-react/build.ts
@@ -1,0 +1,40 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { faceApp } from './handler.js';
+import type { FaceBody } from '../../src/types.js';
+
+async function collectBody(body: FaceBody): Promise<Uint8Array> {
+  if (body instanceof Uint8Array) return body;
+
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of body) chunks.push(chunk);
+  const total = chunks.reduce((size, chunk) => size + chunk.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+export async function buildOperatorVisibilityExample(): Promise<string> {
+  const response = await faceApp.handle({ method: 'GET', path: '/' });
+  if (response.status !== 200) {
+    throw new Error(`operator visibility example returned ${response.status}`);
+  }
+
+  const outDir = path.resolve('examples/operator-visibility-react/dist');
+  const outPath = path.join(outDir, 'index.html');
+  await mkdir(outDir, { recursive: true });
+  await writeFile(
+    outPath,
+    new TextDecoder().decode(await collectBody(response.body)),
+    'utf8',
+  );
+  return outPath;
+}
+
+const outPath = await buildOperatorVisibilityExample();
+console.log(`operator visibility example built: ${outPath}`);

--- a/ts/examples/operator-visibility-react/handler.ts
+++ b/ts/examples/operator-visibility-react/handler.ts
@@ -1,0 +1,360 @@
+// Deterministic React SSR operator visibility example.
+//
+// The Face `load()` function injects every authority, confidence, freshness,
+// guard, health, and matrix value. The React render path only displays those
+// caller-supplied values; it never computes freshness from ambient time.
+
+import * as React from 'react';
+
+import { createFaceApp } from '../../src/app.js';
+import { createReactFace } from '../../src/adapters/react.js';
+import type { FaceApp } from '../../src/app.js';
+import type { FaceContext } from '../../src/types.js';
+import type {
+  OperatorEmptyStateConfig,
+  OperatorGuardStatus,
+  OperatorHealthRow,
+  OperatorVisibilityMetadata,
+  VisibilityMatrixDimension,
+  VisibilityMatrixRow,
+} from '../../src/stitch-admin/index.js';
+import {
+  GuardedOperatorShell,
+  HealthStatusPanel,
+  NonAuthoritativeBanner,
+  OperatorEmptyState,
+  VisibilityMatrix,
+} from '../../src/react/stitch-admin/index.js';
+
+const h = React.createElement;
+
+const SNAPSHOT_AT = '2026-04-24T18:00:00.000Z';
+
+export interface OperatorVisibilityExampleData {
+  snapshotLabel: string;
+  snapshotAt: string;
+  guard: OperatorGuardStatus;
+  noticeMetadata: OperatorVisibilityMetadata;
+  healthRows: OperatorHealthRow[];
+  dimensions: VisibilityMatrixDimension[];
+  rows: VisibilityMatrixRow[];
+  emptyState: OperatorEmptyStateConfig;
+}
+
+export async function loadOperatorVisibilityDashboard(
+  _ctx: FaceContext,
+): Promise<OperatorVisibilityExampleData> {
+  return {
+    snapshotLabel: 'Training snapshot · 2026-04-24 18:00 UTC',
+    snapshotAt: SNAPSHOT_AT,
+    guard: {
+      state: 'authorized',
+      principalLabel: 'Operator Training Role',
+      requestId: 'req_example_visibility_001',
+    },
+    noticeMetadata: {
+      authority: 'non-authoritative',
+      provenance: {
+        source: 'Example import manifest',
+        sourceId: 'example-import-2026-04-24T18:00Z',
+        observedAt: SNAPSHOT_AT,
+      },
+      confidence: {
+        level: 'low',
+        label: 'Low confidence',
+        reason: 'Only one injected source supplied the sandbox mapping.',
+      },
+      staleness: {
+        state: 'stale',
+        ageLabel: 'refreshed 2 hours before snapshot',
+        reason:
+          'The fixture intentionally passes a stale caller-supplied label.',
+      },
+    },
+    healthRows: [
+      {
+        key: 'policy-api',
+        label: 'Policy API',
+        status: 'degraded',
+        description: 'Injected Lambda health observation for the policy path.',
+        detail: 'p95 420ms',
+        checkedAt: '2026-04-24T17:54:00.000Z',
+        metadata: {
+          provenance: {
+            source: 'operator-health-fixture',
+            sourceId: 'health_example_001',
+          },
+          staleness: {
+            state: 'stale',
+            ageLabel: 'checked 6 minutes before snapshot',
+            reason: 'Health observations are supplied by load data.',
+          },
+        },
+      },
+      {
+        key: 'audit-stream',
+        label: 'Audit stream',
+        status: 'healthy',
+        description: 'Injected stream observation for audit evidence.',
+        detail: 'lag 11s',
+        checkedAt: '2026-04-24T17:59:00.000Z',
+        metadata: {
+          provenance: { source: 'operator-health-fixture' },
+          staleness: {
+            state: 'fresh',
+            ageLabel: 'checked 1 minute before snapshot',
+          },
+        },
+      },
+    ],
+    dimensions: [
+      {
+        key: 'checkout-sandbox',
+        label: 'Checkout sandbox',
+        description: 'Safe integration environment.',
+      },
+      {
+        key: 'checkout-live-review',
+        label: 'Checkout live review',
+        description: 'Operator review gate for live access.',
+      },
+      {
+        key: 'support-view',
+        label: 'Support view',
+        description: 'Read-only support diagnostics.',
+      },
+    ],
+    rows: [
+      {
+        entity: {
+          key: 'training-cohort-alpha',
+          label: 'Training cohort alpha',
+          description: 'Synthetic cohort with injected visibility evidence.',
+          metadata: {
+            authority: 'non-authoritative',
+            provenance: { source: 'Example import manifest' },
+            confidence: { level: 'medium', label: 'Medium confidence' },
+          },
+        },
+        cells: [
+          {
+            entityKey: 'training-cohort-alpha',
+            dimensionKey: 'checkout-sandbox',
+            state: 'visible',
+            label: 'Visible',
+            detail: 'Sandbox entitlement imported by the loader.',
+            metadata: {
+              authority: 'non-authoritative',
+              provenance: { source: 'Example import manifest' },
+              confidence: { level: 'low', label: 'Low confidence' },
+              staleness: {
+                state: 'stale',
+                ageLabel: 'refreshed 2 hours before snapshot',
+              },
+            },
+          },
+          {
+            entityKey: 'training-cohort-alpha',
+            dimensionKey: 'checkout-live-review',
+            state: 'partial',
+            label: 'Review required',
+            detail: 'A human approval gate has not completed.',
+            metadata: {
+              authority: 'unknown',
+              confidence: { level: 'low', label: 'Low confidence' },
+              staleness: {
+                state: 'unknown',
+                ageLabel: 'freshness supplied as unknown',
+              },
+            },
+          },
+          {
+            entityKey: 'training-cohort-alpha',
+            dimensionKey: 'support-view',
+            state: 'blocked',
+            label: 'Blocked',
+            detail: 'Support access is intentionally withheld.',
+            metadata: {
+              authority: 'authoritative',
+              confidence: { level: 'high', label: 'High confidence' },
+            },
+          },
+        ],
+      },
+      {
+        entity: {
+          key: 'training-cohort-beta',
+          label: 'Training cohort beta',
+          description: 'Synthetic cohort with a missing matrix cell.',
+        },
+        cells: [
+          {
+            entityKey: 'training-cohort-beta',
+            dimensionKey: 'checkout-sandbox',
+            state: 'not-visible',
+            label: 'Not visible',
+            detail: 'No sandbox entitlement was injected.',
+          },
+          {
+            entityKey: 'training-cohort-beta',
+            dimensionKey: 'checkout-live-review',
+            state: 'unknown',
+            detail: 'The loader supplied an unknown live-review state.',
+          },
+        ],
+      },
+    ],
+    emptyState: {
+      intent: 'filtered-empty',
+      title: 'No matching visibility rows',
+      description:
+        'The filtered state is intentionally empty; the example does not render fake partner, tenant, release, or version placeholders.',
+      placeholderDataPolicy: 'no-production-like-data',
+    },
+  };
+}
+
+export interface OperatorVisibilityDashboardProps {
+  data: OperatorVisibilityExampleData;
+}
+
+export function OperatorVisibilityDashboard(
+  props: OperatorVisibilityDashboardProps,
+): React.ReactElement {
+  const { data } = props;
+
+  return h(
+    'main',
+    {
+      className: 'facetheory-operator-visibility-example',
+      'data-example': 'operator-visibility-react',
+      'data-source': 'facetheory-load',
+      'data-snapshot-at': data.snapshotAt,
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        padding: '32px',
+        background: 'var(--stitch-color-surface, #fbf8ff)',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      },
+    },
+    h(
+      'header',
+      {
+        className: 'facetheory-operator-visibility-example-header',
+        style: { display: 'flex', flexDirection: 'column', gap: '8px' },
+      },
+      h('p', { style: { margin: 0, fontSize: '13px' } }, data.snapshotLabel),
+      h(
+        'h1',
+        { style: { margin: 0, fontSize: '30px', lineHeight: 1.15 } },
+        'Operator visibility dashboard',
+      ),
+      h(
+        'p',
+        {
+          style: {
+            maxWidth: '760px',
+            margin: 0,
+            fontSize: '14px',
+            lineHeight: 1.6,
+            color: 'var(--stitch-color-on-surface-variant, #464553)',
+          },
+        },
+        'All authority, confidence, freshness, guard, health, and matrix values are injected by the Face load() function before render.',
+      ),
+    ),
+    h(
+      GuardedOperatorShell,
+      { guard: data.guard },
+      h(
+        React.Fragment,
+        null,
+        h(NonAuthoritativeBanner, {
+          title: 'Imported visibility evidence',
+          description:
+            'This snapshot is useful for operator review, but it remains non-authoritative until an upstream approval gate confirms it.',
+          metadata: data.noticeMetadata,
+        }),
+        h(HealthStatusPanel, {
+          title: 'Operator dependency health',
+          description:
+            'Stable API and stream observations injected by the loader.',
+          rows: data.healthRows,
+        }),
+        h(VisibilityMatrix, {
+          title: 'Entity × capability visibility',
+          description:
+            'The host supplies each cell; missing cells render as explicit empty records.',
+          dimensions: data.dimensions,
+          rows: data.rows,
+          emptyCellLabel: 'No injected visibility record',
+        }),
+        h(OperatorEmptyState, { config: data.emptyState }),
+      ),
+    ),
+  );
+}
+
+export interface OperatorVisibilityExampleAppOptions {
+  loadDashboard?: (ctx: FaceContext) => Promise<OperatorVisibilityExampleData>;
+}
+
+export function createOperatorVisibilityExampleApp(
+  options: OperatorVisibilityExampleAppOptions = {},
+): FaceApp {
+  return createFaceApp({
+    faces: [
+      createReactFace<OperatorVisibilityExampleData>({
+        route: '/',
+        mode: 'ssr',
+        load: options.loadDashboard ?? loadOperatorVisibilityDashboard,
+        render: (_ctx, data) => h(OperatorVisibilityDashboard, { data }),
+        renderOptions: {
+          headers: { 'cache-control': 'no-store' },
+          headTags: [
+            {
+              type: 'title',
+              text: 'FaceTheory operator visibility example',
+            },
+            {
+              type: 'meta',
+              attrs: {
+                name: 'facetheory-example',
+                content: 'operator-visibility-react',
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+}
+
+export const faceApp = createOperatorVisibilityExampleApp();
+
+export async function handler(event: unknown): Promise<unknown> {
+  const lambdaEvent = event as {
+    requestContext?: { http?: { method?: string } };
+    rawPath?: string;
+    rawQueryString?: string;
+    headers?: Record<string, string | undefined>;
+  };
+
+  return faceApp.handle({
+    method: lambdaEvent.requestContext?.http?.method ?? 'GET',
+    path:
+      lambdaEvent.rawQueryString && lambdaEvent.rawPath
+        ? `${lambdaEvent.rawPath}?${lambdaEvent.rawQueryString}`
+        : (lambdaEvent.rawPath ?? '/'),
+    headers: Object.fromEntries(
+      Object.entries(lambdaEvent.headers ?? {}).map(([name, value]) => [
+        name,
+        value === undefined ? [] : [value],
+      ]),
+    ),
+  });
+}

--- a/ts/examples/operator-visibility-react/node-server.ts
+++ b/ts/examples/operator-visibility-react/node-server.ts
@@ -1,0 +1,60 @@
+import http from 'node:http';
+
+import { faceApp } from './handler.js';
+
+function toNodeHeaders(
+  headers: Record<string, string[]>,
+): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  for (const [name, values] of Object.entries(headers)) {
+    if (!values.length) continue;
+    out[name] = values.length === 1 ? values[0] : values;
+  }
+  return out;
+}
+
+async function main() {
+  const server = http.createServer(async (req, res) => {
+    if (!req.url) {
+      res.writeHead(400);
+      res.end('Bad Request');
+      return;
+    }
+
+    const response = await faceApp.handle({
+      method: req.method ?? 'GET',
+      path: req.url,
+      headers: Object.fromEntries(
+        Object.entries(req.headers).map(([name, value]) => [
+          name,
+          Array.isArray(value)
+            ? value.map(String)
+            : value
+              ? [String(value)]
+              : [],
+        ]),
+      ),
+    });
+
+    res.writeHead(response.status, toNodeHeaders(response.headers));
+
+    if (response.body instanceof Uint8Array) {
+      res.end(response.body);
+      return;
+    }
+
+    for await (const chunk of response.body) {
+      res.write(chunk);
+    }
+    res.end();
+  });
+
+  const port = Number(process.env.PORT ?? 4174);
+  server.listen(port);
+  console.log(`listening on http://localhost:${port}/`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ts/package.json
+++ b/ts/package.json
@@ -181,7 +181,9 @@
     "example:vite:svelte:build": "vite build --config examples/vite-ssr-svelte/vite.config.ts && vite build --ssr src/entry-server.ts --config examples/vite-ssr-svelte/vite.config.ts",
     "example:vite:svelte:serve": "tsx examples/vite-ssr-svelte/node-server.ts",
     "example:vite:svelte:library:build": "vite build --config examples/vite-ssr-svelte-library/vite.config.ts && vite build --ssr src/entry-server.ts --config examples/vite-ssr-svelte-library/vite.config.ts",
-    "example:vite:svelte:library:serve": "tsx examples/vite-ssr-svelte-library/node-server.ts"
+    "example:vite:svelte:library:serve": "tsx examples/vite-ssr-svelte-library/node-server.ts",
+    "example:operator-visibility:build": "tsx examples/operator-visibility-react/build.ts",
+    "example:operator-visibility:serve": "tsx examples/operator-visibility-react/node-server.ts"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1005.0",

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -28,6 +28,7 @@ await import('./unit/vue-stitch-hosted-auth.test.js');
 await import('./unit/vue-stitch-admin.test.js');
 await import('./unit/svelte.test.js');
 await import('./unit/svelte-stitch-admin.test.js');
+await import('./unit/operator-visibility-example.test.js');
 await import('./unit/vite-ssr-example.test.js');
 await import('./unit/vite-ssr-vue-example.test.js');
 await import('./unit/vite-ssr-svelte-example.test.js');

--- a/ts/test/unit/operator-visibility-example.test.ts
+++ b/ts/test/unit/operator-visibility-example.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { createOperatorVisibilityExampleApp } from '../../examples/operator-visibility-react/handler.js';
+import type { FaceBody } from '../../src/types.js';
+
+async function collectBody(body: FaceBody): Promise<string> {
+  if (body instanceof Uint8Array) return new TextDecoder().decode(body);
+
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of body) chunks.push(chunk);
+  const total = chunks.reduce((size, chunk) => size + chunk.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return new TextDecoder().decode(out);
+}
+
+test('operator visibility example renders deterministic SSR markers from load data', async () => {
+  const app = createOperatorVisibilityExampleApp();
+
+  const first = await app.handle({ method: 'GET', path: '/' });
+  const second = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(first.status, 200);
+  assert.equal(second.status, 200);
+
+  const firstBody = await collectBody(first.body);
+  const secondBody = await collectBody(second.body);
+  assert.equal(firstBody, secondBody);
+
+  assert.ok(firstBody.includes('FaceTheory operator visibility example'));
+  assert.ok(firstBody.includes('data-example="operator-visibility-react"'));
+  assert.ok(firstBody.includes('data-source="facetheory-load"'));
+  assert.ok(firstBody.includes('data-snapshot-at="2026-04-24T18:00:00.000Z"'));
+  assert.ok(
+    firstBody.includes('facetheory-stitch-guarded-operator-shell-authorized'),
+  );
+  assert.ok(firstBody.includes('data-operator-guard-state="authorized"'));
+  assert.ok(firstBody.includes('facetheory-stitch-non-authoritative-banner'));
+  assert.ok(firstBody.includes('Non-authoritative'));
+  assert.ok(firstBody.includes('Low confidence'));
+  assert.ok(firstBody.includes('refreshed 2 hours before snapshot'));
+  assert.ok(firstBody.includes('facetheory-stitch-metadata-badge-danger'));
+  assert.ok(firstBody.includes('facetheory-stitch-health-row-stale'));
+  assert.ok(firstBody.includes('facetheory-stitch-visibility-matrix'));
+  assert.ok(
+    firstBody.includes('facetheory-stitch-visibility-matrix-cell-partial'),
+  );
+  assert.ok(
+    firstBody.includes('facetheory-stitch-visibility-matrix-cell-empty'),
+  );
+  assert.ok(firstBody.includes('No injected visibility record'));
+  assert.ok(
+    firstBody.includes('data-placeholder-policy="no-production-like-data"'),
+  );
+
+  assert.ok(!firstBody.includes('Acme'));
+  assert.ok(!firstBody.includes('Globex'));
+  assert.ok(!firstBody.includes('v1.2.3'));
+});
+
+test('operator visibility example source does not compute freshness during render', async () => {
+  const source = await readFile(
+    path.resolve('examples/operator-visibility-react/handler.ts'),
+    'utf8',
+  );
+
+  assert.ok(!source.includes('Date.now('));
+  assert.ok(!source.includes('new Date('));
+  assert.ok(!source.includes('Math.random('));
+});


### PR DESCRIPTION
## Milestone
operator-visibility-example — add a deterministic React SSR operator visibility example with injected real-shaped data.

## Linear
https://linear.app/pay-theory/project/facetheory-operator-visibility-dashboard-primitives-ade624497136 / https://linear.app/pay-theory/issue/PRD-48/examples-add-operator-visibility-ssr-example

## Render modes and adapters affected
SSR example using the React adapter. Documentation also names the SPA shell boundary for operator dashboards. No render-mode semantics changed.

## Determinism impact
Adds a determinism demonstration: the example loads all guard, authority, confidence, staleness, health, and matrix values through Face `load()` data and renders them without reading browser/session globals or computing freshness in render. Unit coverage renders the app twice and asserts the output body is stable.

## Backward compatibility
Additive. Adds a new example, scripts, docs, and unit coverage without changing existing runtime APIs.

## Tasks
- [x] PRD-48 — examples: add operator visibility SSR example

## Validation
Baseline on `staging` after PR #98 merge:
- `make rubric` — PASS (235 tests, 234 pass, 1 skipped; version-alignment PASS; ts-pack PASS)

Milestone branch:
- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run lint` — PASS
- `cd ts && npm run example:operator-visibility:build` — PASS
- `cd ts && npx tsx test/unit/operator-visibility-example.test.ts` — PASS (2 tests)
- `PORT=4175 npm run example:operator-visibility:serve` + curl marker smoke — PASS
- `git diff --check` — PASS
- `make rubric` — PASS (237 tests, 236 pass, 1 skipped; version-alignment PASS; ts-pack PASS)

## Cross-repo coordination
None required. This is a FaceTheory-only additive example and docs update.