### PR TITLE
docs(stitch-admin): document operator visibility dashboard patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,16 @@ High-signal examples:
 - Vue Vite SSR: `npm run example:vite:vue:build && npm run example:vite:vue:serve`
 - Svelte Vite SSR: `npm run example:vite:svelte:build && npm run example:vite:svelte:serve`
 - Svelte external library host: `npm run example:vite:svelte:library:build && npm run example:vite:svelte:library:serve`
+- Operator visibility SSR example: `npm run example:operator-visibility:build && npm run example:operator-visibility:serve`
 - SSG: `npm run example:ssg:build && npm run example:ssg:serve`
+
+## Operator Visibility Dashboards
+
+Stitch admin includes operator visibility contracts and React, Vue, and Svelte primitives for guarded operator dashboards. Hosts pass AppTheory/Autheory-derived auth state into FaceTheory as caller-supplied `OperatorGuardStatus`; FaceTheory renders that state but does not validate sessions or embed Autheory business logic.
+
+For auth-varying dashboards, prefer SSR or a deterministic SPA shell. Avoid SSG for live authorized visibility data, and use ISR only when the cache key and tenant partitioning fully separate every request-varying dimension. Empty and placeholder states must use explicit no-data copy instead of production-like partner, tenant, release, or version mock values.
+
+See [Getting Started](./docs/getting-started.md#add-stitch-control-plane-primitives), [API Reference](./docs/api-reference.md#operator-visibility-dashboard-boundary), and [Core Patterns](./docs/core-patterns.md#pattern-build-operator-dashboards-from-caller-supplied-state) for the integration boundary.
 
 ## Repository Layout
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -65,6 +65,23 @@ The shared Stitch foundation lives under the framework-neutral `stitch-tokens`, 
 
 Operator visibility contracts in `@theory-cloud/facetheory/stitch-admin` are framework-neutral data shapes for guarded operator dashboards. They describe caller-supplied authorization state, authority/provenance/confidence/staleness metadata, health rows, entity × dimension visibility matrix rows/cells, and explicit empty states. Keep timestamps, age labels, confidence labels, and staleness copy stable in `load()` or serialized hydration data; do not compute freshness from ambient time during render.
 
+## Operator Visibility Dashboard Boundary
+
+The operator visibility surface is presentational. It renders stable state supplied by the host; it is not an auth provider, cache-invalidation service, or release-control-plane business-logic package.
+
+Host-owned inputs:
+
+- `OperatorGuardStatus` values derived before render by AppTheory middleware, an Autheory integration, or another request-authorized service. FaceTheory components display the resulting authorized, unauthorized, loading, or error state without importing Autheory validators or reading provider sessions.
+- `OperatorVisibilityMetadata`, `OperatorHealthRow`, `VisibilityMatrixRow`, and `VisibilityMatrixCell` values loaded through `FaceModule.load()` or serialized hydration data. Provenance, confidence, staleness, health, and visibility labels are caller-supplied strings and timestamps.
+- `OperatorEmptyStateConfig` values that use `placeholderDataPolicy: "no-production-like-data"` when a screen would otherwise be empty, filtered, unauthorized, or waiting on upstream evidence.
+
+Render-mode guidance:
+
+- SSR is the default for request-authorized operator dashboards because each request can derive fresh guard, role, tenant, and visibility state.
+- A deterministic SPA shell is acceptable when the first paint is stable and any client refresh starts from serialized hydration data.
+- SSG is only for static documentation, training, or non-authorized snapshots; do not use it for live auth-varying operator visibility.
+- ISR requires safe partitioning. If HTML varies by user, role, tenant, cookie, locale, environment, or visibility source, encode that variance in explicit `cacheKey` / `tenantKey` functions or keep the route on SSR.
+
 ## Core Runtime Contracts
 
 These contracts shape every adapter and delivery mode. If you change one of these interfaces, update the canonical docs in the same change.

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -379,6 +379,91 @@ Why this is incorrect:
 - Re-declaring local tab/filter/log/status variants lets one application drift away from the shared Stitch surface.
 - Ad hoc contracts make it harder to keep docs, tests, and framework adapters aligned in future changes.
 
+## Pattern: Build operator dashboards from caller-supplied state
+
+Problem:
+You need an operator visibility dashboard that shows guarded access, non-authoritative evidence, health rows, and entity × dimension visibility without embedding auth-provider or product-specific rules in FaceTheory.
+
+**CORRECT**
+
+```tsx
+import type { FaceContext } from '@theory-cloud/facetheory';
+import { createReactFace } from '@theory-cloud/facetheory/react';
+import type {
+  OperatorGuardStatus,
+  OperatorHealthRow,
+  VisibilityMatrixDimension,
+  VisibilityMatrixRow,
+} from '@theory-cloud/facetheory/stitch-admin';
+import {
+  GuardedOperatorShell,
+  HealthStatusPanel,
+  VisibilityMatrix,
+} from '@theory-cloud/facetheory/react/stitch-admin';
+
+interface OperatorDashboardData {
+  guard: OperatorGuardStatus;
+  healthRows: OperatorHealthRow[];
+  visibilityDimensions: VisibilityMatrixDimension[];
+  visibilityRows: VisibilityMatrixRow[];
+  freshnessLabel: string;
+}
+
+async function loadDashboard(ctx: FaceContext): Promise<OperatorDashboardData> {
+  const guard = await deriveGuardInHostRuntime(ctx); // AppTheory / Autheory-owned boundary
+  const snapshot = await loadVisibilitySnapshot(ctx, guard); // host-owned data source
+
+  return {
+    guard,
+    healthRows: snapshot.healthRows,
+    visibilityDimensions: snapshot.visibilityDimensions,
+    visibilityRows: snapshot.visibilityRows,
+    freshnessLabel: snapshot.freshnessLabel,
+  };
+}
+
+export const face = createReactFace<OperatorDashboardData>({
+  route: '/operators/visibility',
+  mode: 'ssr',
+  load: loadDashboard,
+  render: (_ctx, data) => (
+    <GuardedOperatorShell guard={data.guard}>
+      <HealthStatusPanel rows={data.healthRows} />
+      <VisibilityMatrix rows={data.visibilityRows} dimensions={data.visibilityDimensions} />
+    </GuardedOperatorShell>
+  ),
+});
+```
+
+Why this is correct:
+- AppTheory or Autheory-derived authorization is resolved before FaceTheory renders; FaceTheory receives `OperatorGuardStatus` as data and does not embed the auth provider.
+- Health, staleness, confidence, provenance, and visibility cells are loaded once and serialized as stable render data.
+- SSR is used because the HTML can vary by request identity, role, tenant, and visibility source.
+- The same shared contracts can feed Vue or Svelte by switching only the adapter import path.
+
+**INCORRECT**
+
+```tsx
+export const face = createReactFace({
+  route: '/operators/visibility',
+  mode: 'ssg',
+  render: async () => (
+    <GuardedOperatorShell guard={readBrowserSession()}>
+      <p>{Math.round((Date.now() - lastChecked) / 1000)} seconds old</p>
+      <p>Placeholder partner release 1.2.3</p>
+    </GuardedOperatorShell>
+  ),
+});
+```
+
+Why this is incorrect:
+- A live auth-varying dashboard is being rendered as SSG output.
+- Authorization and freshness are read during render from ambient browser/time state, which can drift from the server-rendered HTML.
+- Production-like mock partner, tenant, release, or version values make empty states look like real operational data.
+
+ISR note:
+- Use ISR for operator visibility only when the rendered HTML is non-personalized or fully partitioned. If the output varies by identity, role, tenant, cookie, locale, environment, or data-source variant, include those dimensions in explicit `cacheKey` and `tenantKey` functions or keep the route on SSR.
+
 ## Pattern Selection Notes
 
 - Prefer published package exports over private source imports.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -165,6 +165,15 @@ The example renders `NonAuthoritativeBanner`, `GuardedOperatorShell`, `HealthSta
 
 Operator visibility primitives use caller-supplied metadata, guard state, health observations, and visibility matrix rows/cells only. Pass stable provenance, confidence, staleness labels, matrix cell labels, and `OperatorGuardStatus` values from `load()` or serialized hydration data; do not compute freshness or authorization from ambient browser/session globals during render. Empty states should use `OperatorEmptyStateConfig.placeholderDataPolicy = "no-production-like-data"` instead of production-looking placeholder tenants, partners, releases, or versions.
 
+### Operator dashboard integration boundaries
+
+Keep the dashboard boundary explicit:
+
+- **Auth state is upstream.** AppTheory middleware, an Autheory-hosted auth surface, or another host-owned service can validate the request before FaceTheory runs. FaceTheory should receive the derived `OperatorGuardStatus` and display it; it should not import Autheory validators, read provider sessions in a component, or encode Pay Theory release-control-plane rules.
+- **Render mode follows request variance.** Use SSR for request-authorized operator pages and a deterministic SPA shell when client refreshes happen after the initial render. Do not use SSG for live authorized visibility data. Use ISR only for non-personalized or safely partitioned snapshots where `cacheKey` and `tenantKey` include every authorization, tenant, role, locale, and visibility variant that can change the HTML.
+- **Freshness is data, not a render side effect.** Age labels, observed timestamps, health summaries, and visibility cells come from `load()` or serialized hydration data. Components should display those values exactly instead of recomputing them from `Date.now()`, browser globals, auth/session state, or network calls during render.
+- **No production-like placeholders.** Loading, unauthorized, filtered-empty, and missing-data states should be explicit about what is unavailable. Do not fill empty dashboards with realistic partner, tenant, release, version, or account-looking mock values.
+
 For control-plane navigation, treat `path` as the SSR-safe baseline contract for nav items and breadcrumbs. Use `onNavigate` only as an optional client-side interception hook; if a host never hydrates, links with `path` must still work as normal anchors.
 
 ### Brand-agnostic surface primitives

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -82,6 +82,12 @@ Use this when changing:
 
 The example intentionally passes stable age labels, guard status, health observations, and matrix cells through Face `load()` data. Do not compute freshness from `Date.now()`, browser globals, auth/session state, or network calls during render.
 
+For operator dashboard documentation or integration reviews, also confirm:
+
+- AppTheory/Autheory-derived auth state is passed into FaceTheory as `OperatorGuardStatus`; FaceTheory docs and examples do not embed Autheory validation or product-specific authorization logic.
+- Live auth-varying dashboards use SSR or a deterministic SPA shell. SSG is limited to static snapshots, and ISR examples call out explicit cache/tenant partitioning for every request-varying dimension.
+- Empty, loading, unauthorized, and filtered states do not use production-like mock partner, tenant, release, account, or version values.
+
 ### Vite SSR Adapters
 
 ```bash


### PR DESCRIPTION
## Milestone
operator-dashboard-guidance — document auth, cache, determinism, and no-mock-data boundaries for operator dashboards.

## Linear
https://linear.app/pay-theory/project/facetheory-operator-visibility-dashboard-primitives-ade624497136 / https://linear.app/pay-theory/issue/PRD-49/docs-document-operator-visibility-dashboard-patterns

## Render modes and adapters affected
Documentation-only guidance for SSR, SSG, ISR, and deterministic SPA-shell usage across the shared Stitch admin contracts and React/Vue/Svelte adapter primitives. No runtime mode or adapter behavior changed.

## Determinism impact
Preserves runtime behavior. The docs now make the deterministic boundary explicit: guard state, freshness/staleness labels, health rows, and matrix cells must come from Face `load()` or serialized hydration data rather than ambient browser/session/time/network state during render.

## Backward compatibility
Additive docs-only change. No public API or runtime behavior changed.

## Tasks
- [x] PRD-49 — docs: document operator visibility dashboard patterns

## Validation
Baseline on `staging` after PR #99 merge:
- `make rubric` — PASS (237 tests, 236 pass, 1 skipped; version-alignment PASS; ts-pack PASS)

Milestone branch:
- `git diff --check` — PASS
- `cd ts && npm run example:operator-visibility:build` — PASS
- `cd ts && npx tsx test/unit/operator-visibility-example.test.ts` — PASS (2 tests)
- Documentation review against issue #93/PRD-49 acceptance criteria — PASS; docs now cover AppTheory/Autheory-derived `OperatorGuardStatus`, SSR/SPA vs SSG/ISR cache boundaries, and no production-like placeholder data
- `make rubric` — PASS (237 tests, 236 pass, 1 skipped; version-alignment PASS; ts-pack PASS)

## Cross-repo coordination
No code changes required in AppTheory, TableTheory, Autheory, or Pay Theory. Docs intentionally describe the boundary: upstream hosts derive auth/state; FaceTheory renders caller-supplied state.