### PR TITLE
fix(deps): align AppTheory v1.1.0 and TableTheory v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Add the framework peers that match your adapter surface:
 
 Optional companion packages from pinned GitHub releases:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-cdk-1.0.0.tgz`
-- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-cdk-1.1.0.tgz`
+- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz`
 
 ## Quickstart
 

--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -7,24 +7,24 @@ This file records the currently pinned versions and the exact install strings we
 
 ## Pins
 
-- AppTheory (TypeScript): `v1.0.0`
-- AppTheory (CDK): `v1.0.0`
-- TableTheory (TypeScript): `v1.6.1`
+- AppTheory (TypeScript): `v1.1.0`
+- AppTheory (CDK): `v1.1.0`
+- TableTheory (TypeScript): `v1.7.0`
 
 ## Install (npm)
 
 ```bash
   # AppTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz
 
   # TableTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz
 
   # AppTheory CDK (only for infra projects)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-cdk-1.0.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-cdk-1.1.0.tgz
 ```
 
 ## package.json Snippet (Pinned)
@@ -35,12 +35,12 @@ registry installs:
 ```json
 {
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz"
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz"
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz"
     }
   }
 }

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -92,9 +92,9 @@ patterns:
     solution: "Use exact release asset URLs documented in the compatibility pins."
     correct_example: |
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz
       npm install --save-exact \
-        https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz
+        https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz
     anti_patterns:
       - name: "Floating registry installs"
         why: "The repo validates against explicit pinned combinations."

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,10 +39,10 @@ These are only required if your application uses the corresponding integration s
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz
 
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz
 ```
 
 Use AppTheory when you want its Lambda Function URL runtime as the AWS entrypoint. Use TableTheory when you want the documented production ISR metadata store adapter.

--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -9,9 +9,9 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1005.0",
         "@aws-sdk/client-s3": "^3.1005.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-cdk-1.0.0.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-cdk-1.1.0.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
         "constructs": "10.6.0",
@@ -2476,23 +2476,23 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "1.0.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz",
-      "integrity": "sha512-XbIoQsZfInUSSHAFViQJp7NJ6vJbLS1E+clK1IhYPMz8SkoTpqkwTHKJBEhMU6w2YGbMnojx7L0scSoJ7FAsqQ==",
+      "version": "1.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz",
+      "integrity": "sha512-TLJc0LLIG0T1jUjy75//9gjqi+tMkjJlfTfMPjD1kmWsSxnU4m7cJnTSRZSPw3GTbrJRbVikqYvFAm+1fbot0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz"
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz"
       },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "1.0.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-cdk-1.0.0.tgz",
-      "integrity": "sha512-2rhcte+Ps7g2/9BvBq7RCN0VbYucTAP6QunQI0s0qzmWDgADf5WH/dim++g6m1uPBcOyVEmo7luCaR76y3wc1g==",
+      "version": "1.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-cdk-1.1.0.tgz",
+      "integrity": "sha512-N2eCkQOTnzIlRxmD2nYOy4BNT/mP9KXKbIR4Y08bMg4+SQrVUA6krRlqs31n6+p7XIksitjc2zr/iNtQB6cq+g==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2504,9 +2504,9 @@
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "1.6.1",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz",
-      "integrity": "sha512-yPZkY1GN+quQ27SSJpqpVXdEzawKr4Pbt3xDlQ94Wm7FZr5OmjVc90hFv4pDnqNrVWOGF06gW9yKemkM01qClQ==",
+      "version": "1.7.0",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz",
+      "integrity": "sha512-iM15Dc7RVrLDyjxtfoxSJkoVN8ijj/WBTk54gQQosy1FswbqpMNitkXK+XwDN7JxCm8MV7xudE7c9CBma9JuMQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/infra/apptheory-ssg-isr-site/package.json
+++ b/infra/apptheory-ssg-isr-site/package.json
@@ -14,9 +14,9 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1005.0",
     "@aws-sdk/client-s3": "^3.1005.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-cdk-1.0.0.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-cdk-1.1.0.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",
     "constructs": "10.6.0",

--- a/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
+++ b/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
@@ -509,7 +509,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "2fafc325b9e7066bfd04d024f152aa6a35e6b3fb1a4a1827152ad430f981949d.zip"
+          "S3Key": "61736c6b440cc21533eb3e36add808972e94113c33a80bcb0a9157ac79221199.zip"
         },
         "Environment": {
           "Variables": {

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-cdk-1.0.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-cdk-1.1.0.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.244.0",
         "constructs": "10.6.0",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "1.0.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-cdk-1.0.0.tgz",
-      "integrity": "sha512-2rhcte+Ps7g2/9BvBq7RCN0VbYucTAP6QunQI0s0qzmWDgADf5WH/dim++g6m1uPBcOyVEmo7luCaR76y3wc1g==",
+      "version": "1.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-cdk-1.1.0.tgz",
+      "integrity": "sha512-N2eCkQOTnzIlRxmD2nYOy4BNT/mP9KXKbIR4Y08bMg4+SQrVUA6krRlqs31n6+p7XIksitjc2zr/iNtQB6cq+g==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,7 +12,7 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-cdk-1.0.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-cdk-1.1.0.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.244.0",
     "constructs": "10.6.0",

--- a/ts/README.md
+++ b/ts/README.md
@@ -19,9 +19,9 @@ Install the peers that match your adapter surface:
 
 Optional companion packages:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-cdk-1.0.0.tgz`
-- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-cdk-1.1.0.tgz`
+- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz`
 
 ## Minimal App
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -15,8 +15,8 @@
         "@emotion/server": "^11.11.0",
         "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
@@ -4420,23 +4420,23 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "1.0.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz",
-      "integrity": "sha512-XbIoQsZfInUSSHAFViQJp7NJ6vJbLS1E+clK1IhYPMz8SkoTpqkwTHKJBEhMU6w2YGbMnojx7L0scSoJ7FAsqQ==",
+      "version": "1.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz",
+      "integrity": "sha512-TLJc0LLIG0T1jUjy75//9gjqi+tMkjJlfTfMPjD1kmWsSxnU4m7cJnTSRZSPw3GTbrJRbVikqYvFAm+1fbot0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz"
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz"
       },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "1.6.1",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz",
-      "integrity": "sha512-yPZkY1GN+quQ27SSJpqpVXdEzawKr4Pbt3xDlQ94Wm7FZr5OmjVc90hFv4pDnqNrVWOGF06gW9yKemkM01qClQ==",
+      "version": "1.7.0",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz",
+      "integrity": "sha512-iM15Dc7RVrLDyjxtfoxSJkoVN8ijj/WBTk54gQQosy1FswbqpMNitkXK+XwDN7JxCm8MV7xudE7c9CBma9JuMQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -192,8 +192,8 @@
     "@emotion/server": "^11.11.0",
     "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.0.0/theory-cloud-apptheory-1.0.0.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.1.0/theory-cloud-apptheory-1.1.0.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
@@ -216,7 +216,7 @@
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.6.1/theory-cloud-tabletheory-ts-1.6.1.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.7.0/theory-cloud-tabletheory-ts-1.7.0.tgz"
     }
   }
 }


### PR DESCRIPTION
## Summary
Updates FaceTheory's upstream Theory Cloud pins to the current immutable GitHub Release assets:

- AppTheory runtime: `v1.1.0`
- AppTheory CDK: `v1.1.0`
- TableTheory TypeScript: `v1.7.0`

TableTheory is aligned with the AppTheory v1.1.0 dependency contract so FaceTheory development, examples, and reference infra do not validate AppTheory against an older overridden TableTheory runtime.

## Branch sync
Created from current `staging` after PR #100 merged. Verified this branch contains:

- `origin/staging`
- `origin/main`
- `origin/premain`

## Files changed
- Root and package READMEs / upstream pin docs
- `ts/package.json` and `ts/package-lock.json`
- AppTheory reference infra package manifests and lockfiles
- SSG+ISR reference stack snapshot after the upstream package update changed the bundled asset hash

## Determinism / render contract impact
No FaceTheory render-mode, adapter, head/style, or ISR runtime code changed. This is an upstream dependency pin alignment and reference infra snapshot refresh.

## Validation
- `make rubric` — PASS (237 tests, 236 pass, 1 skipped; version-alignment PASS; ts-pack PASS)
- `npm test` in `infra/apptheory-ssr-site` — PASS
- `npm test` in `infra/apptheory-ssg-isr-site` — PASS
- `npm ls @theory-cloud/apptheory @theory-cloud/apptheory-cdk @theory-cloud/tabletheory-ts` — confirms AppTheory `1.1.0` and TableTheory `1.7.0` alignment where applicable

## Cross-repo coordination
Uses published AppTheory v1.1.0 and TableTheory v1.7.0 release assets only; no upstream repo changes required.