### PR TITLE
feat(stitch-admin): add operator correlation metadata

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -42,7 +42,7 @@ Use this table as the public entrypoint map for package consumers. It reflects t
 | `@theory-cloud/facetheory/aws-s3`                    | AWS SDK S3 adapter                   | `createAwsSdkS3HtmlStoreClient`                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `@theory-cloud/facetheory/stitch-tokens`             | Shared Stitch token utilities        | `StitchTokenSet` (with optional `surface` classification), `StitchCssVarOptions` (supports `prefix` and `additionalPrefixes`), `stitchToCssVars`, `stitchCssVarsToRootBlock`                                                                                                                                                                                                                                                                                                                |
 | `@theory-cloud/facetheory/stitch-shell`              | Shared Stitch navigation helpers     | `NavItem`, `BreadcrumbNode`, `ResolvedNav`, `CalloutVariant`, `resolveActiveNav`                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `@theory-cloud/facetheory/stitch-admin`              | Shared Stitch admin contracts        | `TabItem`, `FilterChipConfig`, `LogEntry`, `LogLevel`, `StatusVariant`, `AuthorityState`, `OperatorGuardState`, `OperatorVisibilityMetadata`, `OperatorHealthRow`, `VisibilityMatrixRow`, `VisibilityMatrixCell`, `OperatorEmptyStateConfig`                                                                                                                                                                                                                                                |
+| `@theory-cloud/facetheory/stitch-admin`              | Shared Stitch admin contracts        | `TabItem`, `FilterChipConfig`, `LogEntry`, `LogLevel`, `StatusVariant`, `AuthorityState`, `OperatorGuardState`, `OperatorCorrelationMetadata`, `OperatorVisibilityMetadata`, `OperatorHealthRow`, `VisibilityMatrixRow`, `VisibilityMatrixCell`, `OperatorEmptyStateConfig`                                                                                                                                                                                                                 |
 | `@theory-cloud/facetheory/react`                     | React adapter                        | `renderReact`, `renderReactStream`, `createReactFace`, `createReactStreamFace`                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `@theory-cloud/facetheory/react/antd`                | React Ant Design integration         | `createAntdIntegration`                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `@theory-cloud/facetheory/react/emotion`             | React Emotion integration            | `createEmotionIntegration`                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -63,7 +63,7 @@ Use this table as the public entrypoint map for package consumers. It reflects t
 
 The shared Stitch foundation lives under the framework-neutral `stitch-tokens`, `stitch-shell`, and `stitch-admin` subpaths so React, Vue, and Svelte applications can consume the same token, navigation, and dense-admin contracts. The visual primitives now ship with parallel React, Vue, and Svelte adapter subpaths so each framework consumes the same conceptual surface without falling back to React-only wrappers.
 
-Operator visibility contracts in `@theory-cloud/facetheory/stitch-admin` are framework-neutral data shapes for guarded operator dashboards. They describe caller-supplied authorization state, authority/provenance/confidence/staleness metadata, health rows, entity × dimension visibility matrix rows/cells, and explicit empty states. Keep timestamps, age labels, confidence labels, and staleness copy stable in `load()` or serialized hydration data; do not compute freshness from ambient time during render.
+Operator visibility contracts in `@theory-cloud/facetheory/stitch-admin` are framework-neutral data shapes for guarded operator dashboards. They describe caller-supplied authorization state, authority/provenance/confidence/staleness/correlation metadata, health rows, entity × dimension visibility matrix rows/cells, and explicit empty states. Keep timestamps, age labels, confidence labels, staleness copy, and correlation IDs stable in `load()` or serialized hydration data; do not compute freshness or derive correlation from ambient time, browser/session state, or lookups during render.
 
 ## Operator Visibility Dashboard Boundary
 
@@ -72,8 +72,31 @@ The operator visibility surface is presentational. It renders stable state suppl
 Host-owned inputs:
 
 - `OperatorGuardStatus` values derived before render by AppTheory middleware, an Autheory integration, or another request-authorized service. FaceTheory components display the resulting authorized, unauthorized, loading, or error state without importing Autheory validators or reading provider sessions.
-- `OperatorVisibilityMetadata`, `OperatorHealthRow`, `VisibilityMatrixRow`, and `VisibilityMatrixCell` values loaded through `FaceModule.load()` or serialized hydration data. Provenance, confidence, staleness, health, and visibility labels are caller-supplied strings and timestamps.
+- `OperatorVisibilityMetadata`, `OperatorHealthRow`, `VisibilityMatrixRow`, and `VisibilityMatrixCell` values loaded through `FaceModule.load()` or serialized hydration data. Provenance, confidence, staleness, correlation, health, and visibility labels are caller-supplied strings and timestamps.
+- `OperatorCorrelationMetadata` values when operators need a normalized support/debug identifier. Set `correlationId` to the ID operators should see/copy, and optionally include `correlationSource`, `trigger`, and distinct `requestId` values from AppTheory envelopes, EventBridge payloads, DynamoDB Streams records, or other upstream workload metadata.
 - `OperatorEmptyStateConfig` values that use `placeholderDataPolicy: "no-production-like-data"` when a screen would otherwise be empty, filtered, unauthorized, or waiting on upstream evidence.
+
+Example correlation mappings:
+
+```ts
+const eventBridgeMetadata = {
+  correlation: {
+    correlationId: envelope.correlation_id,
+    correlationSource: envelope.correlation_source,
+    trigger: "eventbridge",
+    requestId: envelope.request_id,
+  },
+};
+
+const dynamoStreamMetadata = {
+  correlation: {
+    correlationId: streamRecord.eventID,
+    correlationSource: "dynamodb.event_id",
+    trigger: "dynamodb_stream",
+    requestId: lambdaRequestId,
+  },
+};
+```
 
 Render-mode guidance:
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -437,7 +437,7 @@ export const face = createReactFace<OperatorDashboardData>({
 
 Why this is correct:
 - AppTheory or Autheory-derived authorization is resolved before FaceTheory renders; FaceTheory receives `OperatorGuardStatus` as data and does not embed the auth provider.
-- Health, staleness, confidence, provenance, and visibility cells are loaded once and serialized as stable render data.
+- Health, staleness, confidence, provenance, correlation, and visibility cells are loaded once and serialized as stable render data.
 - SSR is used because the HTML can vary by request identity, role, tenant, and visibility source.
 - The same shared contracts can feed Vue or Svelte by switching only the adapter import path.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -161,9 +161,9 @@ npm run example:operator-visibility:build
 npm run example:operator-visibility:serve
 ```
 
-The example renders `NonAuthoritativeBanner`, `GuardedOperatorShell`, `HealthStatusPanel`, `VisibilityMatrix`, and `OperatorEmptyState` from injected data. Treat it as the reference shape for deterministic operator dashboards: load stable labels and metadata first, then render them without reading browser/session globals.
+The example renders `NonAuthoritativeBanner`, `GuardedOperatorShell`, `HealthStatusPanel`, `VisibilityMatrix`, and `OperatorEmptyState` from injected data. Treat it as the reference shape for deterministic operator dashboards: load stable labels, metadata, and correlation IDs first, then render them without reading browser/session globals.
 
-Operator visibility primitives use caller-supplied metadata, guard state, health observations, and visibility matrix rows/cells only. Pass stable provenance, confidence, staleness labels, matrix cell labels, and `OperatorGuardStatus` values from `load()` or serialized hydration data; do not compute freshness or authorization from ambient browser/session globals during render. Empty states should use `OperatorEmptyStateConfig.placeholderDataPolicy = "no-production-like-data"` instead of production-looking placeholder tenants, partners, releases, or versions.
+Operator visibility primitives use caller-supplied metadata, guard state, health observations, and visibility matrix rows/cells only. Pass stable provenance, confidence, staleness labels, correlation metadata, matrix cell labels, and `OperatorGuardStatus` values from `load()` or serialized hydration data; do not compute freshness, correlation, or authorization from ambient browser/session globals during render. Empty states should use `OperatorEmptyStateConfig.placeholderDataPolicy = "no-production-like-data"` instead of production-looking placeholder tenants, partners, releases, or versions.
 
 ### Operator dashboard integration boundaries
 
@@ -171,7 +171,7 @@ Keep the dashboard boundary explicit:
 
 - **Auth state is upstream.** AppTheory middleware, an Autheory-hosted auth surface, or another host-owned service can validate the request before FaceTheory runs. FaceTheory should receive the derived `OperatorGuardStatus` and display it; it should not import Autheory validators, read provider sessions in a component, or encode Pay Theory release-control-plane rules.
 - **Render mode follows request variance.** Use SSR for request-authorized operator pages and a deterministic SPA shell when client refreshes happen after the initial render. Do not use SSG for live authorized visibility data. Use ISR only for non-personalized or safely partitioned snapshots where `cacheKey` and `tenantKey` include every authorization, tenant, role, locale, and visibility variant that can change the HTML.
-- **Freshness is data, not a render side effect.** Age labels, observed timestamps, health summaries, and visibility cells come from `load()` or serialized hydration data. Components should display those values exactly instead of recomputing them from `Date.now()`, browser globals, auth/session state, or network calls during render.
+- **Freshness and correlation are data, not render side effects.** Age labels, observed timestamps, normalized correlation IDs, health summaries, and visibility cells come from `load()` or serialized hydration data. Components should display those values exactly instead of recomputing or looking them up from `Date.now()`, browser globals, auth/session state, or network calls during render.
 - **No production-like placeholders.** Loading, unauthorized, filtered-empty, and missing-data states should be explicit about what is unavailable. Do not fill empty dashboards with realistic partner, tenant, release, version, or account-looking mock values.
 
 For control-plane navigation, treat `path` as the SSR-safe baseline contract for nav items and breadcrumbs. Use `onNavigate` only as an optional client-side interception hook; if a host never hydrates, links with `path` must still work as normal anchors.

--- a/docs/planning/ENUMERATED_CHANGES_OPERATOR_VISIBILITY_DASHBOARDS.md
+++ b/docs/planning/ENUMERATED_CHANGES_OPERATOR_VISIBILITY_DASHBOARDS.md
@@ -10,7 +10,7 @@ This list keeps issue #93 inside the existing FaceTheory shape: no render-mode c
 - **Layer**: stitch / docs
 - **Render mode impact**: none
 - **Determinism-sensitive**: no — this is type-only shared contract surface.
-- **Acceptance**: `@theory-cloud/facetheory/stitch-admin` exports framework-neutral contracts for `AuthorityState`, `OperatorGuardState`, provenance/confidence/staleness metadata, health rows, visibility matrix rows/cells, and explicit empty-state intent.
+- **Acceptance**: `@theory-cloud/facetheory/stitch-admin` exports framework-neutral contracts for `AuthorityState`, `OperatorGuardState`, provenance/confidence/staleness/correlation metadata, health rows, visibility matrix rows/cells, and explicit empty-state intent.
 - **Validation**: `cd ts && npm run typecheck`; `cd ts && npm run check`
 - **Conventional Commit subject**: `feat(stitch-admin): add operator visibility contracts`
 
@@ -20,7 +20,7 @@ This list keeps issue #93 inside the existing FaceTheory shape: no render-mode c
 - **Layer**: react adapter / stitch / docs
 - **Render mode impact**: all render modes can render the primitives; no mode semantics change.
 - **Determinism-sensitive**: no — components render caller-supplied stable labels and metadata only.
-- **Acceptance**: React exports `NonAuthoritativeBanner`, metadata badge/group primitives, and `OperatorEmptyState`; SSR tests cover non-authoritative, stale, low-confidence, provenance, and no-mock empty states.
+- **Acceptance**: React exports `NonAuthoritativeBanner`, metadata badge/group primitives, and `OperatorEmptyState`; SSR tests cover non-authoritative, stale, low-confidence, provenance, correlation, and no-mock empty states.
 - **Validation**: `cd ts && npx tsx test/unit/stitch-admin.test.ts`; `cd ts && npm run check`
 - **Conventional Commit subject**: `feat(react): add operator visibility notice primitives`
 
@@ -139,7 +139,7 @@ This list keeps issue #93 inside the existing FaceTheory shape: no render-mode c
 - **Paths**: `ts/examples/operator-visibility-react/`, `ts/package.json`, `ts/test/unit/operator-visibility-example.test.ts`, `ts/test/run-unit.ts`, `docs/getting-started.md`, `docs/testing-guide.md`
 - **Layer**: example / react adapter / docs
 - **Render mode impact**: ssr / spa
-- **Determinism-sensitive**: yes — the example demonstrates the deterministic SSR boundary for authority/staleness metadata and must not compute freshness labels from `Date.now()` during render.
+- **Determinism-sensitive**: yes — the example demonstrates the deterministic SSR boundary for authority/staleness/correlation metadata and must not compute freshness labels or derive correlation IDs from ambient request/session state during render.
 - **Acceptance**: A runnable React SSR example renders a guarded operator dashboard from injected `load()` data, includes non-authoritative/stale/low-confidence states, contains no mock production-like partner/version values in placeholders, and has a unit test asserting deterministic output markers.
 - **Validation**: `cd ts && npm run example:operator-visibility:build`; `cd ts && npx tsx test/unit/operator-visibility-example.test.ts`; `cd ts && npm run check`
 - **Conventional Commit subject**: `feat(examples): add operator visibility SSR example`
@@ -159,7 +159,7 @@ This list keeps issue #93 inside the existing FaceTheory shape: no render-mode c
 - [x] Core runtime/render-mode primitives are not changed because the need fits inside Stitch/admin.
 - [x] Shared contracts land before adapter implementations.
 - [x] React, Vue, and Svelte implementations are enumerated for every shared visual primitive family.
-- [x] Determinism-sensitive work is limited to the SSR example that demonstrates stable staleness metadata at the hydration boundary.
+- [x] Determinism-sensitive work is limited to the SSR example that demonstrates stable staleness and correlation metadata at the hydration boundary.
 - [x] Examples and docs are included because this is consumer-facing UI surface.
 - [x] No release manifests, version markers, dependencies, AWS-S3 code, ISR storage, or infrastructure stacks are part of the feature commits.
 - [x] The full list satisfies issue #93's acceptance criteria without adding release-control-plane business logic to FaceTheory.

--- a/docs/planning/ROADMAP_OPERATOR_VISIBILITY_DASHBOARDS.md
+++ b/docs/planning/ROADMAP_OPERATOR_VISIBILITY_DASHBOARDS.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Deliver issue #93 as an additive Stitch admin capability: shared operator-visibility contracts plus React, Vue, and Svelte visual primitives for guarded operator dashboards, non-authoritative data, provenance/confidence/staleness metadata, health/status panels, entity × dimension visibility matrices, and explicit no-mock empty states. The roadmap keeps FaceTheory inside its existing SSR/SSG/ISR/SPA and React/Vue/Svelte shape while giving Pay Theory `release-control-plane` reusable Phase 1 dashboard building blocks.
+Deliver issue #93 as an additive Stitch admin capability: shared operator-visibility contracts plus React, Vue, and Svelte visual primitives for guarded operator dashboards, non-authoritative data, provenance/confidence/staleness/correlation metadata, health/status panels, entity × dimension visibility matrices, and explicit no-mock empty states. The roadmap keeps FaceTheory inside its existing SSR/SSG/ISR/SPA and React/Vue/Svelte shape while giving Pay Theory `release-control-plane` reusable Phase 1 dashboard building blocks.
 
 ## Render modes and adapters affected
 
@@ -18,7 +18,7 @@ SSG and ISR can render static or safely partitioned visibility snapshots, but au
 
 ## Determinism impact
 
-The primitive work preserves determinism because components render caller-supplied state and metadata. The new determinism surface is the example and documentation for staleness/freshness: freshness labels must be server-computed or passed as stable serialized values rather than recomputed from `Date.now()` during render or hydration.
+The primitive work preserves determinism because components render caller-supplied state and metadata. The new determinism surface is the example and documentation for staleness/freshness and correlation: freshness labels and correlation IDs must be server-computed or passed as stable serialized values rather than recomputed or looked up from `Date.now()`, request/session globals, or network state during render or hydration.
 
 ## Phases
 
@@ -63,7 +63,7 @@ The primitive work preserves determinism because components render caller-suppli
 
 **Milestone candidates:**
 
-- **Operator visibility SSR example** — Add a runnable React SSR example using injected real-shaped data and deterministic metadata.
+- **Operator visibility SSR example** — Add a runnable React SSR example using injected real-shaped data and deterministic metadata, including normalized correlation IDs.
   - Items: 14
   - Dependencies: Phases 1 and 2
   - Determinism-sensitive: yes

--- a/docs/planning/SCOPED_NEED_OPERATOR_VISIBILITY_DASHBOARDS.md
+++ b/docs/planning/SCOPED_NEED_OPERATOR_VISIBILITY_DASHBOARDS.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-Pay Theory's `release-control-plane` needs Phase 1 operator visibility panels that show real imported release and partner visibility while making safety boundaries obvious. The UI must distinguish real data from placeholders, mark data as non-authoritative until a later gate transition, expose provenance/confidence/staleness metadata, and keep authorization integration outside FaceTheory's business logic. These patterns are reusable for Theory Cloud operator dashboards beyond `release-control-plane`.
+Pay Theory's `release-control-plane` needs Phase 1 operator visibility panels that show real imported release and partner visibility while making safety boundaries obvious. The UI must distinguish real data from placeholders, mark data as non-authoritative until a later gate transition, expose provenance/confidence/staleness/correlation metadata, and keep authorization integration outside FaceTheory's business logic. These patterns are reusable for Theory Cloud operator dashboards beyond `release-control-plane`.
 
 ## Driver
 
@@ -10,7 +10,7 @@ Pay Theory `release-control-plane` Phase 1, with likely reuse by future Theory C
 
 ## Problem
 
-FaceTheory's current Stitch shell/admin primitives provide generic layout, callouts, tables, status tags, logs, filters, and hosted-auth state cards, but they do not provide domain-neutral operator-visibility semantics. Downstream dashboards must currently hand-roll the same safety cues: non-authoritative data banners, provenance/confidence/staleness badges, guarded shell states, health/API panels, entity-by-dimension visibility matrices, and explicit empty states that cannot be mistaken for mock partner/version data.
+FaceTheory's current Stitch shell/admin primitives provide generic layout, callouts, tables, status tags, logs, filters, and hosted-auth state cards, but they do not provide domain-neutral operator-visibility semantics. Downstream dashboards must currently hand-roll the same safety cues: non-authoritative data banners, provenance/confidence/staleness/correlation badges, guarded shell states, health/API panels, entity-by-dimension visibility matrices, and explicit empty states that cannot be mistaken for mock partner/version data.
 
 ## Render modes affected
 
@@ -31,7 +31,7 @@ Fits inside the existing FaceTheory shape as an additive Stitch capability. It d
 
 ## Determinism impact
 
-Preserves determinism if the primitives receive already-resolved display values and serialized metadata rather than reading time/random/browser state during render. Staleness display must be deterministic at the server/client boundary: examples should pass ISO timestamps, stable labels, or server-computed age text through `load()`/hydration data instead of recomputing `Date.now()` during render. Empty/loading/unauthorized states must render explicit stable markup.
+Preserves determinism if the primitives receive already-resolved display values and serialized metadata rather than reading time/random/browser state during render. Staleness and correlation display must be deterministic at the server/client boundary: examples should pass ISO timestamps, stable labels, server-computed age text, and normalized correlation IDs through `load()`/hydration data instead of recomputing `Date.now()` or looking up request/session state during render. Empty/loading/unauthorized states must render explicit stable markup.
 
 ## AWS-first posture
 
@@ -41,7 +41,7 @@ Preserves the AWS-first posture. Health/status examples should assume a Lambda/A
 
 - Shared operator-visibility contracts exist for:
   - authority/non-authoritative state,
-  - provenance/confidence/staleness metadata,
+  - provenance/confidence/staleness/correlation metadata,
   - guarded operator access states,
   - health/status panel rows,
   - entity × dimension visibility matrix rows/cells,

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -77,10 +77,10 @@ npx tsx test/unit/operator-visibility-example.test.ts
 Use this when changing:
 
 - Stitch admin operator visibility primitives
-- deterministic guard/authority/confidence/staleness rendering
+- deterministic guard/authority/confidence/staleness/correlation rendering
 - health panels or visibility matrices used by operator dashboards
 
-The example intentionally passes stable age labels, guard status, health observations, and matrix cells through Face `load()` data. Do not compute freshness from `Date.now()`, browser globals, auth/session state, or network calls during render.
+The example intentionally passes stable age labels, normalized correlation IDs, guard status, health observations, and matrix cells through Face `load()` data. Do not compute freshness or correlation from `Date.now()`, browser globals, auth/session state, or network calls during render.
 
 For operator dashboard documentation or integration reviews, also confirm:
 

--- a/ts/examples/operator-visibility-react/handler.ts
+++ b/ts/examples/operator-visibility-react/handler.ts
@@ -1,8 +1,9 @@
 // Deterministic React SSR operator visibility example.
 //
 // The Face `load()` function injects every authority, confidence, freshness,
-// guard, health, and matrix value. The React render path only displays those
-// caller-supplied values; it never computes freshness from ambient time.
+// correlation, guard, health, and matrix value. The React render path only
+// displays those caller-supplied values; it never computes freshness from
+// ambient time.
 
 import * as React from 'react';
 
@@ -59,6 +60,12 @@ export async function loadOperatorVisibilityDashboard(
         sourceId: 'example-import-2026-04-24T18:00Z',
         observedAt: SNAPSHOT_AT,
       },
+      correlation: {
+        correlationId: 'corr_example_visibility_001',
+        correlationSource: 'example.envelope.correlation_id',
+        trigger: 'eventbridge',
+        requestId: 'req_example_visibility_001',
+      },
       confidence: {
         level: 'low',
         label: 'Low confidence',
@@ -83,6 +90,12 @@ export async function loadOperatorVisibilityDashboard(
           provenance: {
             source: 'operator-health-fixture',
             sourceId: 'health_example_001',
+          },
+          correlation: {
+            correlationId: 'health_example_001',
+            correlationSource: 'fixture.health_id',
+            trigger: 'scheduled',
+            requestId: 'req_example_visibility_001',
           },
           staleness: {
             state: 'stale',
@@ -146,6 +159,11 @@ export async function loadOperatorVisibilityDashboard(
             metadata: {
               authority: 'non-authoritative',
               provenance: { source: 'Example import manifest' },
+              correlation: {
+                correlationId: 'corr_example_visibility_001',
+                correlationSource: 'example.envelope.correlation_id',
+                trigger: 'eventbridge',
+              },
               confidence: { level: 'low', label: 'Low confidence' },
               staleness: {
                 state: 'stale',
@@ -264,7 +282,7 @@ export function OperatorVisibilityDashboard(
             color: 'var(--stitch-color-on-surface-variant, #464553)',
           },
         },
-        'All authority, confidence, freshness, guard, health, and matrix values are injected by the Face load() function before render.',
+        'All authority, confidence, freshness, correlation, guard, health, and matrix values are injected by the Face load() function before render.',
       ),
     ),
     h(

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -6805,9 +6805,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/ts/src/react/stitch-admin/operator-notices.ts
+++ b/ts/src/react/stitch-admin/operator-notices.ts
@@ -133,8 +133,9 @@ export function MetadataBadge(props: MetadataBadgeProps): React.ReactElement {
 }
 
 /**
- * Renders the standard authority/provenance/confidence/staleness metadata
- * envelope as deterministic badges. It never computes freshness or age text.
+ * Renders the standard authority/provenance/correlation/confidence/staleness
+ * metadata envelope as deterministic badges. It never computes freshness,
+ * age text, or correlation identifiers.
  */
 export function MetadataBadgeGroup(
   props: MetadataBadgeGroupProps,
@@ -320,6 +321,19 @@ function metadataToBadges(
     out.push(provenanceBadge);
   }
 
+  if (metadata.correlation !== undefined) {
+    const correlationBadge: MetadataBadgeProps = {
+      label: 'Correlation',
+      detail: metadata.correlation.correlationId,
+      tone: 'info',
+    };
+    const title = correlationTitle(metadata.correlation);
+    if (title !== undefined) {
+      correlationBadge.title = title;
+    }
+    out.push(correlationBadge);
+  }
+
   if (metadata.confidence !== undefined) {
     const confidenceBadge: MetadataBadgeProps = {
       label: 'Confidence',
@@ -347,6 +361,22 @@ function metadataToBadges(
   }
 
   return out;
+}
+
+function correlationTitle(
+  correlation: NonNullable<OperatorVisibilityMetadata['correlation']>,
+): string | undefined {
+  const parts: string[] = [];
+  if (correlation.correlationSource !== undefined) {
+    parts.push(`Source: ${correlation.correlationSource}`);
+  }
+  if (correlation.trigger !== undefined) {
+    parts.push(`Trigger: ${correlation.trigger}`);
+  }
+  if (correlation.requestId !== undefined) {
+    parts.push(`Request ID: ${correlation.requestId}`);
+  }
+  return parts.length > 0 ? parts.join(' · ') : undefined;
 }
 
 function authorityLabel(

--- a/ts/src/stitch-admin/index.ts
+++ b/ts/src/stitch-admin/index.ts
@@ -9,6 +9,7 @@ export type {
   ConfidenceMetadata,
   OperatorEmptyStateConfig,
   OperatorEmptyStateIntent,
+  OperatorCorrelationMetadata,
   OperatorGuardState,
   OperatorGuardStatus,
   OperatorHealthRow,

--- a/ts/src/stitch-admin/operator-visibility-types.ts
+++ b/ts/src/stitch-admin/operator-visibility-types.ts
@@ -54,15 +54,32 @@ export interface StalenessMetadata {
 }
 
 /**
- * Shared metadata envelope for authority, provenance, confidence, and
- * staleness. Adapter primitives can render this consistently across React,
- * Vue, and Svelte without each adapter inventing its own data shape.
+ * Caller-provided correlation identifiers for operator support workflows.
+ * Values are normalized before render so badge output is deterministic across
+ * SSR and client hydration.
+ */
+export interface OperatorCorrelationMetadata {
+  /** Normalized correlation identifier shown/copied by operators. */
+  correlationId: string;
+  /** Where the selected correlation ID came from. */
+  correlationSource?: string;
+  /** Workload/trigger surface, e.g. "http", "eventbridge", or "dynamodb_stream". */
+  trigger?: string;
+  /** Invocation/request ID when distinct from correlationId. */
+  requestId?: string;
+}
+
+/**
+ * Shared metadata envelope for authority, provenance, confidence, staleness,
+ * and correlation. Adapter primitives can render this consistently across
+ * React, Vue, and Svelte without each adapter inventing its own data shape.
  */
 export interface OperatorVisibilityMetadata {
   authority?: AuthorityState;
   provenance?: ProvenanceMetadata;
   confidence?: ConfidenceMetadata;
   staleness?: StalenessMetadata;
+  correlation?: OperatorCorrelationMetadata;
 }
 
 /** Guard states for caller-supplied operator authorization. */

--- a/ts/src/svelte/stitch-admin/HealthStatusPanel.svelte
+++ b/ts/src/svelte/stitch-admin/HealthStatusPanel.svelte
@@ -112,6 +112,17 @@
       out.push(badge);
     }
 
+    if (metadata.correlation !== undefined) {
+      const badge: HealthBadge = {
+        label: 'Correlation',
+        detail: metadata.correlation.correlationId,
+        tone: 'info',
+      };
+      const title = correlationTitle(metadata.correlation);
+      if (title !== undefined) badge.title = title;
+      out.push(badge);
+    }
+
     if (metadata.confidence !== undefined) {
       const badge: HealthBadge = {
         label: 'Confidence',
@@ -133,6 +144,22 @@
     }
 
     return out;
+  }
+
+  function correlationTitle(
+    correlation: NonNullable<OperatorVisibilityMetadata['correlation']>,
+  ): string | undefined {
+    const parts: string[] = [];
+    if (correlation.correlationSource !== undefined) {
+      parts.push(`Source: ${correlation.correlationSource}`);
+    }
+    if (correlation.trigger !== undefined) {
+      parts.push(`Trigger: ${correlation.trigger}`);
+    }
+    if (correlation.requestId !== undefined) {
+      parts.push(`Request ID: ${correlation.requestId}`);
+    }
+    return parts.length > 0 ? parts.join(' · ') : undefined;
   }
 
   function healthStatusStyle(status: OperatorHealthStatus): string {

--- a/ts/src/svelte/stitch-admin/MetadataBadgeGroup.svelte
+++ b/ts/src/svelte/stitch-admin/MetadataBadgeGroup.svelte
@@ -64,6 +64,17 @@
       out.push(badge);
     }
 
+    if (source.correlation !== undefined) {
+      const badge: MetadataBadgeProps = {
+        label: 'Correlation',
+        detail: source.correlation.correlationId,
+        tone: 'info',
+      };
+      const title = correlationTitle(source.correlation);
+      if (title !== undefined) badge.title = title;
+      out.push(badge);
+    }
+
     if (source.confidence !== undefined) {
       const badge: MetadataBadgeProps = {
         label: 'Confidence',
@@ -85,6 +96,22 @@
     }
 
     return out;
+  }
+
+  function correlationTitle(
+    correlation: NonNullable<OperatorVisibilityMetadata['correlation']>,
+  ): string | undefined {
+    const parts: string[] = [];
+    if (correlation.correlationSource !== undefined) {
+      parts.push(`Source: ${correlation.correlationSource}`);
+    }
+    if (correlation.trigger !== undefined) {
+      parts.push(`Trigger: ${correlation.trigger}`);
+    }
+    if (correlation.requestId !== undefined) {
+      parts.push(`Request ID: ${correlation.requestId}`);
+    }
+    return parts.length > 0 ? parts.join(' · ') : undefined;
   }
 
   function badgeStyle(tone: MetadataBadgeTone): string {

--- a/ts/src/svelte/stitch-admin/NonAuthoritativeBanner.svelte
+++ b/ts/src/svelte/stitch-admin/NonAuthoritativeBanner.svelte
@@ -59,6 +59,16 @@
     if (source.provenance !== undefined) {
       out.push({ label: 'Source', detail: source.provenance.source, tone: 'info' });
     }
+    if (source.correlation !== undefined) {
+      const badge: MetadataBadgeProps = {
+        label: 'Correlation',
+        detail: source.correlation.correlationId,
+        tone: 'info',
+      };
+      const title = correlationTitle(source.correlation);
+      if (title !== undefined) badge.title = title;
+      out.push(badge);
+    }
     if (source.confidence !== undefined) {
       out.push({
         label: 'Confidence',
@@ -74,6 +84,22 @@
       });
     }
     return out;
+  }
+
+  function correlationTitle(
+    correlation: NonNullable<OperatorVisibilityMetadata['correlation']>,
+  ): string | undefined {
+    const parts: string[] = [];
+    if (correlation.correlationSource !== undefined) {
+      parts.push(`Source: ${correlation.correlationSource}`);
+    }
+    if (correlation.trigger !== undefined) {
+      parts.push(`Trigger: ${correlation.trigger}`);
+    }
+    if (correlation.requestId !== undefined) {
+      parts.push(`Request ID: ${correlation.requestId}`);
+    }
+    return parts.length > 0 ? parts.join(' · ') : undefined;
   }
 
   function badgeStyle(tone: MetadataBadgeTone): string {
@@ -129,6 +155,7 @@
       {#each badges as badge}
         <span
           class={`facetheory-stitch-metadata-badge facetheory-stitch-metadata-badge-${badge.tone ?? 'neutral'}`}
+          title={badge.title}
           style={badgeStyle(badge.tone ?? 'neutral')}
         >
           <span>{badge.label}</span>

--- a/ts/src/svelte/stitch-admin/VisibilityMatrix.svelte
+++ b/ts/src/svelte/stitch-admin/VisibilityMatrix.svelte
@@ -145,6 +145,17 @@
       out.push(badge);
     }
 
+    if (metadata.correlation !== undefined) {
+      const badge: MatrixBadge = {
+        label: 'Correlation',
+        detail: metadata.correlation.correlationId,
+        tone: 'info',
+      };
+      const title = correlationTitle(metadata.correlation);
+      if (title !== undefined) badge.title = title;
+      out.push(badge);
+    }
+
     if (metadata.confidence !== undefined) {
       const badge: MatrixBadge = {
         label: 'Confidence',
@@ -166,6 +177,22 @@
     }
 
     return out;
+  }
+
+  function correlationTitle(
+    correlation: NonNullable<OperatorVisibilityMetadata['correlation']>,
+  ): string | undefined {
+    const parts: string[] = [];
+    if (correlation.correlationSource !== undefined) {
+      parts.push(`Source: ${correlation.correlationSource}`);
+    }
+    if (correlation.trigger !== undefined) {
+      parts.push(`Trigger: ${correlation.trigger}`);
+    }
+    if (correlation.requestId !== undefined) {
+      parts.push(`Request ID: ${correlation.requestId}`);
+    }
+    return parts.length > 0 ? parts.join(' · ') : undefined;
   }
 
   function cellStatusStyle(state: VisibilityMatrixCellState): string {

--- a/ts/src/svelte/stitch-admin/index.d.ts
+++ b/ts/src/svelte/stitch-admin/index.d.ts
@@ -61,6 +61,7 @@ export type {
   AuthorityState,
   ConfidenceLevel,
   ConfidenceMetadata,
+  OperatorCorrelationMetadata,
   OperatorEmptyStateConfig,
   OperatorEmptyStateIntent,
   OperatorGuardState,

--- a/ts/src/svelte/stitch-admin/index.ts
+++ b/ts/src/svelte/stitch-admin/index.ts
@@ -42,6 +42,7 @@ export type {
   MetadataBadgeProps,
   MetadataBadgeTone,
   NonAuthoritativeBannerProps,
+  OperatorCorrelationMetadata,
   OperatorEmptyStateProps,
   OperatorGuardState,
   OperatorGuardStatus,

--- a/ts/src/svelte/stitch-admin/types.ts
+++ b/ts/src/svelte/stitch-admin/types.ts
@@ -59,6 +59,7 @@ export type {
   AuthorityState,
   ConfidenceLevel,
   ConfidenceMetadata,
+  OperatorCorrelationMetadata,
   OperatorEmptyStateConfig,
   OperatorEmptyStateIntent,
   OperatorGuardState,

--- a/ts/src/vue/stitch-admin/operator-notices.ts
+++ b/ts/src/vue/stitch-admin/operator-notices.ts
@@ -381,6 +381,19 @@ function metadataToBadges(
     out.push(provenanceBadge);
   }
 
+  if (metadata.correlation !== undefined) {
+    const correlationBadge: MetadataBadgeProps = {
+      label: 'Correlation',
+      detail: metadata.correlation.correlationId,
+      tone: 'info',
+    };
+    const title = correlationTitle(metadata.correlation);
+    if (title !== undefined) {
+      correlationBadge.title = title;
+    }
+    out.push(correlationBadge);
+  }
+
   if (metadata.confidence !== undefined) {
     const confidenceBadge: MetadataBadgeProps = {
       label: 'Confidence',
@@ -408,6 +421,22 @@ function metadataToBadges(
   }
 
   return out;
+}
+
+function correlationTitle(
+  correlation: NonNullable<OperatorVisibilityMetadata['correlation']>,
+): string | undefined {
+  const parts: string[] = [];
+  if (correlation.correlationSource !== undefined) {
+    parts.push(`Source: ${correlation.correlationSource}`);
+  }
+  if (correlation.trigger !== undefined) {
+    parts.push(`Trigger: ${correlation.trigger}`);
+  }
+  if (correlation.requestId !== undefined) {
+    parts.push(`Request ID: ${correlation.requestId}`);
+  }
+  return parts.length > 0 ? parts.join(' · ') : undefined;
 }
 
 function authorityLabel(

--- a/ts/test/unit/operator-visibility-example.test.ts
+++ b/ts/test/unit/operator-visibility-example.test.ts
@@ -44,6 +44,10 @@ test('operator visibility example renders deterministic SSR markers from load da
   assert.ok(firstBody.includes('data-operator-guard-state="authorized"'));
   assert.ok(firstBody.includes('facetheory-stitch-non-authoritative-banner'));
   assert.ok(firstBody.includes('Non-authoritative'));
+  assert.ok(firstBody.includes('Correlation'));
+  assert.ok(firstBody.includes('corr_example_visibility_001'));
+  assert.ok(firstBody.includes('Source: example.envelope.correlation_id'));
+  assert.ok(firstBody.includes('Trigger: eventbridge'));
   assert.ok(firstBody.includes('Low confidence'));
   assert.ok(firstBody.includes('refreshed 2 hours before snapshot'));
   assert.ok(firstBody.includes('facetheory-stitch-metadata-badge-danger'));

--- a/ts/test/unit/stitch-admin.test.ts
+++ b/ts/test/unit/stitch-admin.test.ts
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { createFaceApp } from '../../src/app.js';
 import { createReactFace } from '../../src/adapters/react.js';
 import { createAntdIntegration } from '../../src/react/antd.js';
+import type { OperatorCorrelationMetadata } from '../../src/stitch-admin/index.js';
 import {
   CopyableCode,
   DataTable,
@@ -30,6 +31,13 @@ import {
 } from '../../src/react/stitch-admin/index.js';
 
 const h = React.createElement;
+
+const sampleCorrelation = {
+  correlationId: 'corr_release_20260424_001',
+  correlationSource: 'eventbridge.envelope',
+  trigger: 'eventbridge',
+  requestId: 'lambda_req_123',
+} satisfies OperatorCorrelationMetadata;
 
 async function renderSSR(element: React.ReactElement): Promise<string> {
   const app = createFaceApp({
@@ -92,7 +100,7 @@ test('NonAuthoritativeBanner renders authority, provenance, confidence, and stal
   assert.ok(body.includes('facetheory-stitch-metadata-badge-danger'));
 });
 
-test('MetadataBadgeGroup renders provenance links without computing freshness', async () => {
+test('MetadataBadgeGroup renders provenance and correlation without computing freshness', async () => {
   const body = await renderSSR(
     h(MetadataBadgeGroup, {
       metadata: {
@@ -100,6 +108,7 @@ test('MetadataBadgeGroup renders provenance links without computing freshness', 
           source: 'Release manifest',
           href: '/operator/sources/release-manifest',
         },
+        correlation: sampleCorrelation,
         staleness: {
           state: 'fresh',
           ageLabel: 'refreshed 4 minutes ago',
@@ -111,6 +120,11 @@ test('MetadataBadgeGroup renders provenance links without computing freshness', 
   assert.ok(body.includes('facetheory-stitch-metadata-badge-group'));
   assert.ok(body.includes('href="/operator/sources/release-manifest"'));
   assert.ok(body.includes('Release manifest'));
+  assert.ok(body.includes('Correlation'));
+  assert.ok(body.includes('corr_release_20260424_001'));
+  assert.ok(body.includes('Source: eventbridge.envelope'));
+  assert.ok(body.includes('Trigger: eventbridge'));
+  assert.ok(body.includes('Request ID: lambda_req_123'));
   assert.ok(body.includes('refreshed 4 minutes ago'));
 });
 

--- a/ts/test/unit/svelte-stitch-admin.test.ts
+++ b/ts/test/unit/svelte-stitch-admin.test.ts
@@ -8,6 +8,14 @@ import { pathToFileURL } from 'node:url';
 
 import { createFaceApp } from '../../src/app.js';
 import { createSvelteFace } from '../../src/svelte/index.js';
+import type { OperatorCorrelationMetadata } from '../../src/stitch-admin/index.js';
+
+const sampleCorrelation = {
+  correlationId: 'corr_release_20260424_001',
+  correlationSource: 'eventbridge.envelope',
+  trigger: 'eventbridge',
+  requestId: 'lambda_req_123',
+} satisfies OperatorCorrelationMetadata;
 
 async function renderComponent(
   componentPath: string,
@@ -86,7 +94,7 @@ test('svelte stitch-admin: NonAuthoritativeBanner renders metadata parity marker
   assert.ok(body.includes('facetheory-stitch-metadata-badge-danger'));
 });
 
-test('svelte stitch-admin: MetadataBadgeGroup renders provenance links and stable freshness', async () => {
+test('svelte stitch-admin: MetadataBadgeGroup renders provenance, correlation, and stable freshness', async () => {
   const body = await renderComponent(
     path.resolve('src/svelte/stitch-admin/MetadataBadgeGroup.svelte'),
     {
@@ -95,6 +103,7 @@ test('svelte stitch-admin: MetadataBadgeGroup renders provenance links and stabl
           source: 'Release manifest',
           href: '/operator/sources/release-manifest',
         },
+        correlation: sampleCorrelation,
         staleness: {
           state: 'fresh',
           ageLabel: 'refreshed 4 minutes ago',
@@ -106,6 +115,11 @@ test('svelte stitch-admin: MetadataBadgeGroup renders provenance links and stabl
   assert.ok(body.includes('facetheory-stitch-metadata-badge-group'));
   assert.ok(body.includes('href="/operator/sources/release-manifest"'));
   assert.ok(body.includes('Release manifest'));
+  assert.ok(body.includes('Correlation'));
+  assert.ok(body.includes('corr_release_20260424_001'));
+  assert.ok(body.includes('Source: eventbridge.envelope'));
+  assert.ok(body.includes('Trigger: eventbridge'));
+  assert.ok(body.includes('Request ID: lambda_req_123'));
   assert.ok(body.includes('refreshed 4 minutes ago'));
 });
 

--- a/ts/test/unit/vue-stitch-admin.test.ts
+++ b/ts/test/unit/vue-stitch-admin.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { createFaceApp } from '../../src/app.js';
+import type { OperatorCorrelationMetadata } from '../../src/stitch-admin/index.js';
 import { createVueFace, h } from '../../src/vue/index.js';
 import {
   CopyableCode,
@@ -24,6 +25,13 @@ import {
   StatusTag,
   Tabs,
 } from '../../src/vue/stitch-admin/index.js';
+
+const sampleCorrelation = {
+  correlationId: 'corr_release_20260424_001',
+  correlationSource: 'eventbridge.envelope',
+  trigger: 'eventbridge',
+  requestId: 'lambda_req_123',
+} satisfies OperatorCorrelationMetadata;
 
 async function renderSSR(vnode: ReturnType<typeof h>): Promise<string> {
   const app = createFaceApp({
@@ -73,7 +81,7 @@ test('vue stitch-admin: operator visibility notices render parity metadata', asy
   assert.ok(body.includes('facetheory-stitch-metadata-badge-danger'));
 });
 
-test('vue stitch-admin: MetadataBadgeGroup renders provenance links and stable freshness', async () => {
+test('vue stitch-admin: MetadataBadgeGroup renders provenance, correlation, and stable freshness', async () => {
   const body = await renderSSR(
     h(MetadataBadgeGroup, {
       metadata: {
@@ -81,6 +89,7 @@ test('vue stitch-admin: MetadataBadgeGroup renders provenance links and stable f
           source: 'Release manifest',
           href: '/operator/sources/release-manifest',
         },
+        correlation: sampleCorrelation,
         staleness: {
           state: 'fresh',
           ageLabel: 'refreshed 4 minutes ago',
@@ -92,6 +101,11 @@ test('vue stitch-admin: MetadataBadgeGroup renders provenance links and stable f
   assert.ok(body.includes('facetheory-stitch-metadata-badge-group'));
   assert.ok(body.includes('href="/operator/sources/release-manifest"'));
   assert.ok(body.includes('Release manifest'));
+  assert.ok(body.includes('Correlation'));
+  assert.ok(body.includes('corr_release_20260424_001'));
+  assert.ok(body.includes('Source: eventbridge.envelope'));
+  assert.ok(body.includes('Trigger: eventbridge'));
+  assert.ok(body.includes('Request ID: lambda_req_123'));
   assert.ok(body.includes('refreshed 4 minutes ago'));
 });
 


### PR DESCRIPTION
## Summary
- adds public `OperatorCorrelationMetadata` and `OperatorVisibilityMetadata.correlation`
- renders deterministic `Correlation` metadata badges in React, Vue, and Svelte operator visibility surfaces
- documents AppTheory/EventBridge and DynamoDB Streams correlation mapping patterns and updates the operator visibility example/tests
- fixes Dependabot alert 34 (`postcss` GHSA-qx2v-qp2m-jg93 / CVE-2026-41305) by updating the `ts/package-lock.json` transitive resolution to `postcss@8.5.10`

## Determinism
- correlation values are caller-supplied only; no time, request/session, browser, or lookup work happens during render
- badge title details are emitted in a stable order: source, trigger, request ID

## Verification
- `make rubric`
- `cd ts && npm audit --audit-level=moderate`
