### PR TITLE
fix!(isr): fail closed on unpartitioned tenant headers

### DIFF
--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -142,16 +142,18 @@ Notes:
 ## ISR Request Flow
 
 1. Request reaches Lambda URL behavior.
-2. FaceTheory computes cache key (`tenant + route + params + query` by default).
-3. Metadata lookup in DynamoDB:
+2. FaceTheory verifies tenant partition safety. Requests carrying known tenant boundary headers (`x-tenant-id` or `x-facetheory-tenant`) fail closed unless `tenantKey` or a custom `cacheKey` is configured.
+3. FaceTheory computes cache key (`tenant + route + params + query` by default).
+4. Metadata lookup in DynamoDB:
    - fresh -> serve cached HTML pointer from S3
    - stale/miss -> attempt lease lock and regenerate
-4. Regeneration writes HTML to S3 first, then atomically updates metadata pointer.
-5. On regeneration failure, previous pointer stays valid; stale serve policy applies.
+5. Regeneration writes HTML to S3 first, then atomically updates metadata pointer.
+6. On regeneration failure, previous pointer stays valid; stale serve policy applies.
 
 Default tenant note:
 - FaceTheory uses the `default` tenant unless `tenantKey` is configured.
-- If tenant identity comes from auth/session/host mapping or a trusted header, provide an explicit `tenantKey` or keep that route on SSR.
+- If tenant identity comes from auth/session/host mapping or a trusted header, provide an explicit `tenantKey` or custom `cacheKey`, or keep that route on SSR.
+- Tenant-invariant ISR routes should not receive tenant-like headers; if they do, FaceTheory fails closed rather than sharing cached HTML through the implicit `default` tenant.
 
 ## Operational Checklist
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -11,7 +11,7 @@ This document describes production hardening guidance for FaceTheory apps and th
   - SSR responses should be explicitly non-cacheable (example: `cache-control: private, no-store`).
   - SSG HTML and hydration JSON should be served from S3 with explicit `cache-control`.
   - ISR responses must include an `x-facetheory-isr` state header (`hit` | `miss` | `stale` | `wait-hit`) and deterministic cache headers.
-  - Query-dependent ISR output now partitions by query string by default; request-personalized output still needs an explicit `cacheKey` / `tenantKey` or SSR.
+  - Query-dependent ISR output now partitions by query string by default; request-personalized output still needs an explicit `cacheKey` / `tenantKey` or SSR. Requests with known tenant boundary headers (`x-tenant-id`, `x-facetheory-tenant`) fail closed unless that explicit partition is configured.
 - Security headers:
   - Set baseline security headers at the CDN layer (HSTS, nosniff, frame-options, referrer-policy, permissions-policy).
   - Do not attempt to set a nonce-based CSP at CloudFront (nonces are per-request).
@@ -90,6 +90,7 @@ The SSG/ISR example stack provisions these via `cloudfront.ResponseHeadersPolicy
 - FaceTheory’s default ISR tenant resolver ignores request tenant headers and uses the `default` tenant.
 - Treat request headers as untrusted until AppTheory middleware, CloudFront, or another authenticated boundary strips client-supplied copies and writes trusted values.
 - If tenant identity is derived from a session, auth token, host mapping, or trusted header, override `tenantKey` so cached HTML keys follow that trusted source instead of raw client input.
+- If `x-tenant-id` or `x-facetheory-tenant` reaches an ISR route without an explicit `tenantKey` or custom `cacheKey`, FaceTheory refuses the ISR request before metadata lookup or HTML writes. Remove tenant-like headers for tenant-invariant ISR, or keep the route on SSR until partitioning is explicit.
 
 ## Limits and Timeouts
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -103,7 +103,7 @@ Render-mode guidance:
 - SSR is the default for request-authorized operator dashboards because each request can derive fresh guard, role, tenant, and visibility state.
 - A deterministic SPA shell is acceptable when the first paint is stable and any client refresh starts from serialized hydration data.
 - SSG is only for static documentation, training, or non-authorized snapshots; do not use it for live auth-varying operator visibility.
-- ISR requires safe partitioning. If HTML varies by user, role, tenant, cookie, locale, environment, or visibility source, encode that variance in explicit `cacheKey` / `tenantKey` functions or keep the route on SSR.
+- ISR requires safe partitioning. If HTML varies by user, role, tenant, cookie, locale, environment, or visibility source, encode that variance in explicit `cacheKey` / `tenantKey` functions or keep the route on SSR. Requests carrying known tenant boundary headers without an explicit ISR partition fail closed instead of sharing the implicit `default` tenant cache entry.
 
 ## Core Runtime Contracts
 
@@ -227,13 +227,14 @@ Relevant helpers:
 
 - `defaultIsrCacheKey(input)`
 - `tenantKeyFromTrustedHeader(headerName?)`
-- `blockingIsrCacheControl(input)
+- `blockingIsrCacheControl(input)`
 - `isFresh(record, nowMs)`
 
 Default ISR partitioning:
 
 - `defaultIsrCacheKey(input)` includes sorted route params, sorted query-string keys/values, and hashed request-identity partitions for cookies and common auth headers (`Authorization`, `Proxy-Authorization`, `X-API-Key`, `X-Amz-Security-Token`). Raw cookie and auth values are not written to cache keys.
 - The default tenant resolver intentionally ignores request tenant headers and uses `default`. For authenticated tenant boundaries, supply `tenantKey` explicitly (for example `tenantKeyFromTrustedHeader('x-tenant-id')` after trusted middleware strips client-supplied copies).
+- If a request includes a known tenant boundary header (`x-tenant-id` or `x-facetheory-tenant`) and the app has not configured an explicit `tenantKey` or custom `cacheKey`, ISR fails closed before cache lookup or HTML writes. Remove tenant-like headers for tenant-invariant ISR, provide a trusted `tenantKey`, provide a custom `cacheKey`, or keep the route on SSR.
 - If HTML varies by other request headers or identity inputs, supply an explicit `cacheKey` / `tenantKey` or keep that route on SSR.
 
 Important deployment note:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,7 +170,7 @@ Operator visibility primitives use caller-supplied metadata, guard state, health
 Keep the dashboard boundary explicit:
 
 - **Auth state is upstream.** AppTheory middleware, an Autheory-hosted auth surface, or another host-owned service can validate the request before FaceTheory runs. FaceTheory should receive the derived `OperatorGuardStatus` and display it; it should not import Autheory validators, read provider sessions in a component, or encode Pay Theory release-control-plane rules.
-- **Render mode follows request variance.** Use SSR for request-authorized operator pages and a deterministic SPA shell when client refreshes happen after the initial render. Do not use SSG for live authorized visibility data. Use ISR only for non-personalized or safely partitioned snapshots where `cacheKey` and `tenantKey` include every authorization, tenant, role, locale, and visibility variant that can change the HTML.
+- **Render mode follows request variance.** Use SSR for request-authorized operator pages and a deterministic SPA shell when client refreshes happen after the initial render. Do not use SSG for live authorized visibility data. Use ISR only for non-personalized or safely partitioned snapshots where `cacheKey` and `tenantKey` include every authorization, tenant, role, locale, and visibility variant that can change the HTML. ISR fails closed when known tenant boundary headers are present without an explicit cache partition.
 - **Freshness and correlation are data, not render side effects.** Age labels, observed timestamps, normalized correlation IDs, health summaries, and visibility cells come from `load()` or serialized hydration data. Components should display those values exactly instead of recomputing or looking them up from `Date.now()`, browser globals, auth/session state, or network calls during render.
 - **No production-like placeholders.** Loading, unauthorized, filtered-empty, and missing-data states should be explicit about what is unavailable. Do not fill empty dashboards with realistic partner, tenant, release, version, or account-looking mock values.
 
@@ -229,6 +229,7 @@ Important ISR default:
 
 - FaceTheory’s default ISR cache key partitions by route params, query string, and hashed request-identity inputs for cookies and common auth headers without storing raw secrets.
 - FaceTheory’s default ISR tenant is `default`; configure `tenantKey` explicitly for authenticated tenant boundaries.
+- If a request carries `x-tenant-id` or `x-facetheory-tenant` and no explicit `tenantKey` or custom `cacheKey` is configured, ISR fails closed before cache lookup/write.
 - If cached HTML varies by other headers or host-derived tenant, configure an explicit `cacheKey` / `tenantKey` or keep that route on SSR.
 
 ## Reference Bundle

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -26,6 +26,10 @@ const DEFAULT_AUTH_VARY_HEADERS = [
   'x-api-key',
   'x-amz-security-token',
 ] as const;
+const DEFAULT_TENANT_BOUNDARY_HEADERS = [
+  'x-tenant-id',
+  'x-facetheory-tenant',
+] as const;
 
 export type IsrFailurePolicy = 'serve-stale' | 'error';
 export type IsrLockContentionPolicy = 'wait' | 'serve-stale';
@@ -166,7 +170,10 @@ interface CreateIsrRuntimeOptions {
   failurePolicy: IsrFailurePolicy;
   lockContentionPolicy: IsrLockContentionPolicy;
   tenantKey: (ctx: FaceContext) => string | null | undefined;
+  hasExplicitTenantKey: boolean;
   cacheKey: (input: IsrCacheKeyInput) => string;
+  hasExplicitCacheKey: boolean;
+  tenantBoundaryHeaders: readonly string[];
   htmlPointerPrefix: string;
   cacheControl: (input: IsrCacheHeaderInput) => string;
 }
@@ -386,6 +393,7 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
       const revalidateSeconds = normalizeRevalidateSeconds(
         input.face.revalidateSeconds,
       );
+      assertPartitionedTenantBoundary(runtimeOptions, input.ctx);
       const tenant = resolveTenant(runtimeOptions, input.ctx);
       const cacheKey = runtimeOptions.cacheKey({
         tenant,
@@ -775,12 +783,46 @@ function normalizeRuntimeOptions(
     failurePolicy: input.failurePolicy ?? 'serve-stale',
     lockContentionPolicy: input.lockContentionPolicy ?? 'wait',
     tenantKey: input.tenantKey ?? defaultTenantKey,
+    hasExplicitTenantKey: input.tenantKey !== undefined,
     cacheKey: input.cacheKey ?? defaultIsrCacheKey,
+    hasExplicitCacheKey: input.cacheKey !== undefined,
+    tenantBoundaryHeaders: DEFAULT_TENANT_BOUNDARY_HEADERS,
     htmlPointerPrefix: normalizeObjectPrefix(input.htmlPointerPrefix ?? 'isr'),
     cacheControl:
       input.cacheControl ??
       ((options) => blockingIsrCacheControl(options.revalidateSeconds)),
   };
+}
+
+function assertPartitionedTenantBoundary(
+  runtimeOptions: CreateIsrRuntimeOptions,
+  ctx: FaceContext,
+): void {
+  if (runtimeOptions.hasExplicitTenantKey || runtimeOptions.hasExplicitCacheKey)
+    return;
+  if (
+    !hasNonEmptyHeader(
+      ctx.request.headers,
+      runtimeOptions.tenantBoundaryHeaders,
+    )
+  )
+    return;
+
+  throw new Error(
+    'ISR tenant boundary header requires explicit tenantKey or cacheKey configuration',
+  );
+}
+
+function hasNonEmptyHeader(
+  headers: Headers | undefined,
+  headerNames: readonly string[],
+): boolean {
+  const canonical = canonicalizeHeaders(headers);
+  for (const name of headerNames) {
+    const values = canonical[name] ?? [];
+    if (values.some((value) => String(value).trim().length > 0)) return true;
+  }
+  return false;
 }
 
 function resolveTenant(

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { createFaceApp } from '../../src/app.js';
 import {
   type CommitIsrGenerationInput,
+  createIsrRuntime,
   defaultIsrCacheKey,
   InMemoryHtmlStore,
   InMemoryIsrMetaStore,
@@ -272,7 +273,7 @@ test('isr: default cache key partitions by query strings', async () => {
   assert.equal(cacheKeys.length, 2);
 });
 
-test('isr: default tenant partition ignores spoofable request headers', async () => {
+test('isr: default tenant partition fails closed on tenant boundary headers', async () => {
   const htmlStore = new InMemoryHtmlStore();
   const metaStore = new InMemoryIsrMetaStore();
   let renderCount = 0;
@@ -283,9 +284,10 @@ test('isr: default tenant partition ignores spoofable request headers', async ()
         route: '/tenant/{slug}',
         mode: 'isr',
         revalidateSeconds: 60,
-        render: async () => {
+        render: async (ctx) => {
           const seq = ++renderCount;
-          return { html: `<main>tenant-${seq}</main>` };
+          const tenant = ctx.request.headers['x-tenant-id']?.[0] ?? 'missing';
+          return { html: `<main>${tenant}-${seq}</main>` };
         },
       },
     ],
@@ -299,7 +301,7 @@ test('isr: default tenant partition ignores spoofable request headers', async ()
     method: 'GET',
     path: '/tenant/home',
     headers: {
-      'x-tenant-id': ['tenant-a'],
+      'x-tenant-id': ['TENANT_SECRET_A'],
       'x-facetheory-tenant': ['spoofed-tenant'],
     },
   });
@@ -307,18 +309,55 @@ test('isr: default tenant partition ignores spoofable request headers', async ()
     method: 'GET',
     path: '/tenant/home',
     headers: {
-      'x-tenant-id': ['tenant-b'],
-      'x-facetheory-tenant': ['tenant-a'],
+      'x-tenant-id': ['TENANT_SECRET_B'],
+      'x-facetheory-tenant': ['TENANT_SECRET_A'],
     },
   });
 
-  assert.ok(decodeBody(tenantAHeader.body as Uint8Array).includes('tenant-1'));
-  assert.ok(decodeBody(tenantBHeader.body as Uint8Array).includes('tenant-1'));
-  assert.equal(renderCount, 1);
+  assert.equal(tenantAHeader.status, 500);
+  assert.equal(tenantBHeader.status, 500);
+  const tenantAHtml = decodeBody(tenantAHeader.body as Uint8Array);
+  const tenantBHtml = decodeBody(tenantBHeader.body as Uint8Array);
+  assert.equal(tenantAHtml.includes('TENANT_SECRET_A'), false);
+  assert.equal(tenantBHtml.includes('TENANT_SECRET_B'), false);
+  assert.equal(renderCount, 0);
 
   const cacheKeys = metaStore.debugSnapshot().map((record) => record.cacheKey);
-  assert.equal(cacheKeys.length, 1);
-  assert.ok(cacheKeys.every((key) => key.startsWith('default::')));
+  assert.deepEqual(cacheKeys, []);
+
+  const runtime = createIsrRuntime({ htmlStore, metaStore });
+  await assert.rejects(
+    runtime.handleFace({
+      face: {
+        route: '/tenant/{slug}',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: async () => ({ html: '<main>should not render</main>' }),
+      },
+      ctx: {
+        request: {
+          method: 'GET',
+          path: '/tenant/home',
+          query: {},
+          headers: { 'x-tenant-id': ['TENANT_SECRET_C'] },
+          cookies: {},
+          body: new Uint8Array(),
+          isBase64: false,
+          cspNonce: null,
+        },
+        params: { slug: 'home' },
+        proxy: null,
+      },
+      routePattern: '/tenant/{slug}',
+      renderFresh: async () => {
+        throw new Error('should not render');
+      },
+    }),
+    (err) =>
+      err instanceof Error &&
+      err.message.includes('tenantKey or cacheKey') &&
+      !err.message.includes('TENANT_SECRET_C'),
+  );
 });
 
 test('isr: tenantKey option partitions by a trusted header boundary', async () => {
@@ -368,6 +407,74 @@ test('isr: tenantKey option partitions by a trusted header boundary', async () =
 
   const cacheKeys = metaStore.debugSnapshot().map((record) => record.cacheKey);
   assert.equal(cacheKeys.length, 2);
+});
+
+test('isr: custom cacheKey is an explicit tenant boundary partition contract', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/tenant/{slug}',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: async (ctx) => {
+          const seq = ++renderCount;
+          const tenant = ctx.request.headers['x-tenant-id']?.[0] ?? 'missing';
+          return { html: `<main>${tenant}-${seq}</main>` };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      cacheKey: (input) => {
+        const tenant = input.headers?.['x-tenant-id']?.[0];
+        const tenantPartition = tenant === 'TENANT_SECRET_A' ? 'a' : 'b';
+        return `custom::${input.routePattern}#tenant=${tenantPartition}`;
+      },
+    },
+  });
+
+  const tenantAFirst = await app.handle({
+    method: 'GET',
+    path: '/tenant/home',
+    headers: { 'x-tenant-id': ['TENANT_SECRET_A'] },
+  });
+  const tenantBFirst = await app.handle({
+    method: 'GET',
+    path: '/tenant/home',
+    headers: { 'x-tenant-id': ['TENANT_SECRET_B'] },
+  });
+  const tenantASecond = await app.handle({
+    method: 'GET',
+    path: '/tenant/home',
+    headers: { 'x-tenant-id': ['TENANT_SECRET_A'] },
+  });
+
+  assert.equal(tenantAFirst.status, 200);
+  assert.equal(tenantBFirst.status, 200);
+  assert.equal(tenantASecond.status, 200);
+  assert.ok(
+    decodeBody(tenantAFirst.body as Uint8Array).includes('TENANT_SECRET_A-1'),
+  );
+  assert.ok(
+    decodeBody(tenantBFirst.body as Uint8Array).includes('TENANT_SECRET_B-2'),
+  );
+  assert.ok(
+    decodeBody(tenantASecond.body as Uint8Array).includes('TENANT_SECRET_A-1'),
+  );
+  assert.equal(renderCount, 2);
+
+  const serializedKeys = metaStore
+    .debugSnapshot()
+    .map((record) => record.cacheKey)
+    .join('\n');
+  assert.equal(serializedKeys.includes('TENANT_SECRET_A'), false);
+  assert.equal(serializedKeys.includes('TENANT_SECRET_B'), false);
+  assert.equal(metaStore.debugSnapshot().length, 2);
 });
 
 test('isr: default cache key partitions by auth headers and cookies without raw secrets', async () => {


### PR DESCRIPTION
## Milestone
isr-tenant-fail-closed-core — Add the core guard, regression tests, and in-place API docs so unpartitioned tenant-like ISR requests fail before cache interaction.

## Linear
Project: https://linear.app/theorycloud/project/isr-tenant-partition-safety-d304475ccec1
Milestone: isr-tenant-fail-closed-core
Issue: https://linear.app/theorycloud/issue/THE-416/fail-closed-on-unpartitioned-isr-tenant-boundary-signals

## Render modes and adapters affected
- ISR: behavior change; tenant-like boundary headers fail closed without explicit `tenantKey` or custom `cacheKey`.
- SSR / SSG / SPA: no behavior change.
- React / Vue / Svelte: no adapter-specific changes.

## Determinism impact
Preserves determinism. The guard runs before ISR cache lookup/write and does not touch SSR/CSR hydration, head emission, or style extraction.

## Backward compatibility
Breaking. ISR routes that receive `x-tenant-id` or `x-facetheory-tenant` without an explicit tenant/cache partition now fail closed instead of sharing the implicit `default` tenant cache entry.

## Tasks
- [x] THE-416 — Fail closed on unpartitioned ISR tenant boundary signals

## Validation
- [x] `cd ts && npx tsx --test test/unit/isr.test.ts`
- [x] `make rubric`
- [x] ISR blocking example smoke check via `faceApp.handle()` (`miss` then `hit`)

## Cross-repo coordination
No AppTheory or TableTheory code changes required. Docs remain aligned with AppTheory's tenant-header trust boundary guidance.
