### PR TITLE
fix(isr)!: fail closed on null tenant partitions

### DIFF
--- a/docs/planning/ENUMERATED_CHANGES_ISR_TENANT_PARTITION_SAFETY.md
+++ b/docs/planning/ENUMERATED_CHANGES_ISR_TENANT_PARTITION_SAFETY.md
@@ -12,7 +12,7 @@ Decision locked for this enumeration: **fail closed by default**. If a request c
 - **Determinism-sensitive**: no — this changes deterministic ISR cache identity and failure behavior, not server/client DOM or hydration equivalence.
 - **Acceptance**: ISR requests containing known tenant boundary headers, initially `x-tenant-id` and `x-facetheory-tenant`, fail closed before cache lookup/write when neither `tenantKey` nor a custom `cacheKey` is explicitly configured; tenant-invariant ISR without those headers still works; explicit `tenantKey` and explicit `cacheKey` paths continue to work; thrown/configuration errors do not include raw tenant/header secret values.
 - **Validation**: `make rubric`; targeted ISR validation such as `cd ts && npx tsx --test test/unit/isr.test.ts`; verify docs mention the breaking fail-closed default and the explicit `tenantKey` / `cacheKey` escape path.
-- **Conventional Commit subject**: `fix!(isr): fail closed on unpartitioned tenant headers`
+- **Conventional Commit subject**: `fix(isr)!: fail closed on unpartitioned tenant headers`
 
 Commit body must include a `BREAKING CHANGE:` footer because tenant-like headers that previously collapsed into the implicit `default` ISR tenant now fail closed unless the app configures an explicit tenant/cache partition.
 

--- a/docs/planning/ROADMAP_ISR_TENANT_PARTITION_SAFETY.md
+++ b/docs/planning/ROADMAP_ISR_TENANT_PARTITION_SAFETY.md
@@ -78,7 +78,7 @@ Suggested RC soak duration: short but explicit, at least one downstream validati
 
 ## Version-bump implication
 
-Minor bump under pre-1.0 semver, driven by a breaking `fix!` commit with a `BREAKING CHANGE:` footer. Although the package is currently versioned above `1.0`, the repository instructions still treat FaceTheory as pre-1.0; release-please will determine the exact resulting version from Conventional Commits.
+Minor bump under pre-1.0 semver, driven by a breaking `fix(isr)!:` commit with a `BREAKING CHANGE:` footer. Although the package is currently versioned above `1.0`, the repository instructions still treat FaceTheory as pre-1.0; release-please will determine the exact resulting version from Conventional Commits.
 
 ## Cross-phase risks
 

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -759,6 +759,12 @@ function normalizeRuntimeOptions(
 ): CreateIsrRuntimeOptions {
   const htmlStore = input.htmlStore ?? new InMemoryHtmlStore();
   const metaStore = input.metaStore ?? new InMemoryIsrMetaStore();
+  const tenantKey =
+    typeof input.tenantKey === 'function' ? input.tenantKey : defaultTenantKey;
+  const hasExplicitTenantKey = typeof input.tenantKey === 'function';
+  const cacheKey =
+    typeof input.cacheKey === 'function' ? input.cacheKey : defaultIsrCacheKey;
+  const hasExplicitCacheKey = typeof input.cacheKey === 'function';
 
   return {
     htmlStore,
@@ -782,10 +788,10 @@ function normalizeRuntimeOptions(
     ),
     failurePolicy: input.failurePolicy ?? 'serve-stale',
     lockContentionPolicy: input.lockContentionPolicy ?? 'wait',
-    tenantKey: input.tenantKey ?? defaultTenantKey,
-    hasExplicitTenantKey: input.tenantKey !== undefined,
-    cacheKey: input.cacheKey ?? defaultIsrCacheKey,
-    hasExplicitCacheKey: input.cacheKey !== undefined,
+    tenantKey,
+    hasExplicitTenantKey,
+    cacheKey,
+    hasExplicitCacheKey,
     tenantBoundaryHeaders: DEFAULT_TENANT_BOUNDARY_HEADERS,
     htmlPointerPrefix: normalizeObjectPrefix(input.htmlPointerPrefix ?? 'isr'),
     cacheControl:

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -6,6 +6,7 @@ import {
   type CommitIsrGenerationInput,
   createIsrRuntime,
   defaultIsrCacheKey,
+  type FaceIsrOptions,
   InMemoryHtmlStore,
   InMemoryIsrMetaStore,
   type IsrMetaRecord,
@@ -359,6 +360,76 @@ test('isr: default tenant partition fails closed on tenant boundary headers', as
       !err.message.includes('TENANT_SECRET_C'),
   );
 });
+
+for (const variant of [
+  {
+    label: 'null tenantKey',
+    isr: { tenantKey: null },
+  },
+  {
+    label: 'null cacheKey',
+    isr: { cacheKey: null },
+  },
+  {
+    label: 'null tenantKey and cacheKey',
+    isr: { tenantKey: null, cacheKey: null },
+  },
+]) {
+  test(`isr: ${variant.label} does not count as an explicit tenant partition`, async () => {
+    const htmlStore = new InMemoryHtmlStore();
+    const metaStore = new InMemoryIsrMetaStore();
+    let renderCount = 0;
+
+    const app = createFaceApp({
+      faces: [
+        {
+          route: '/tenant-null/{slug}',
+          mode: 'isr',
+          revalidateSeconds: 60,
+          render: async (ctx) => {
+            const seq = ++renderCount;
+            const tenant =
+              ctx.request.headers['x-tenant-id']?.[0] ?? 'missing';
+            return { html: `<main>${tenant}-${seq}</main>` };
+          },
+        },
+      ],
+      isr: {
+        htmlStore,
+        metaStore,
+        ...variant.isr,
+      } as unknown as FaceIsrOptions,
+    });
+
+    const tenantAHeader = await app.handle({
+      method: 'GET',
+      path: '/tenant-null/home',
+      headers: { 'x-tenant-id': ['TENANT_SECRET_A'] },
+    });
+    const tenantBHeader = await app.handle({
+      method: 'GET',
+      path: '/tenant-null/home',
+      headers: { 'x-tenant-id': ['TENANT_SECRET_B'] },
+    });
+
+    assert.equal(tenantAHeader.status, 500);
+    assert.equal(tenantBHeader.status, 500);
+    assert.equal(renderCount, 0);
+    assert.deepEqual(metaStore.debugSnapshot(), []);
+    assert.equal(
+      decodeBody(tenantAHeader.body as Uint8Array).includes(
+        'TENANT_SECRET_A',
+      ),
+      false,
+    );
+    assert.equal(
+      decodeBody(tenantBHeader.body as Uint8Array).includes(
+        'TENANT_SECRET_B',
+      ),
+      false,
+    );
+  });
+}
 
 test('isr: tenantKey option partitions by a trusted header boundary', async () => {
   const htmlStore = new InMemoryHtmlStore();


### PR DESCRIPTION
## Summary
Addresses the two blocking findings from PR #124 before promoting staging to premain:

1. Treats only function-valued `tenantKey` / `cacheKey` options as explicit ISR tenant partition contracts, so `tenantKey: null` or `cacheKey: null` cannot bypass the fail-closed guard while the runtime still falls back to the default resolver/cache key.
2. Corrects the ISR tenant partition planning docs to use the repo-recognized breaking Conventional Commit spelling: `fix(isr)!:`.

## Security / determinism impact
- Security: closes the null-option ISR tenant partition bypass reproduced in PR #124 review.
- Determinism: preserves deterministic fail-closed behavior before cache lookup, lease acquisition, metadata writes, or HTML writes.
- Adapter impact: adapter-agnostic core ISR only; no React/Vue/Svelte rendering changes.

## Validation
- `npx --prefix ts tsx --test ts/test/unit/isr.test.ts` — PASS
- `make rubric` — PASS
- `scripts/verify-release-readiness.sh origin/premain HEAD prerelease` — PASS

## Notes
Commit subject is intentionally `fix(isr)!:` with a `BREAKING CHANGE:` footer so prerelease readiness and release-please see a user-facing breaking fix in the staging → premain range.

Refs #124
