### PR TITLE
fix(release): guard release baseline versioning

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -25,6 +25,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (baseline verification)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify stable release baseline tag
+        run: scripts/verify-release-baseline-tag.sh
+
       - name: Release Please (PR only)
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,6 +14,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (baseline verification)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify stable release baseline tag
+        run: scripts/verify-release-baseline-tag.sh
+
       - name: Release Please (Prerelease)
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify stable release baseline tag
+        run: scripts/verify-release-baseline-tag.sh
 
       - name: Compute release-as (align to premain RC)
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,34 @@ jobs:
           git fetch origin main --force
           git fetch origin premain --force || true
 
-          # Existing draft tags may predate a synchronized VERSION file.
+          # Existing draft tags may predate synchronized version manifests.
           # Normalize the workspace copy so verification/build scripts use the requested tag version.
           if [[ -f VERSION ]]; then
             printf '%s # x-release-please-version\n' "${TAG_NAME#v}" > VERSION
           fi
+
+          RELEASE_VERSION="${TAG_NAME#v}" python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"]
+          is_prerelease = "-rc" in version.split("+", 1)[0]
+
+
+          def update_manifest(path: str) -> None:
+              manifest = Path(path)
+              if not manifest.exists():
+                  return
+              data = json.loads(manifest.read_text(encoding="utf-8"))
+              data["."] = version
+              manifest.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+          if not is_prerelease:
+              update_manifest(".release-please-manifest.json")
+          update_manifest(".release-please-manifest.premain.json")
+          PY
 
           scripts/verify-release-branch.sh "${TAG_NAME}"
 
@@ -102,9 +125,19 @@ jobs:
 
           gh release edit "${TAG_NAME}" --draft=false ${prerelease_flag} --notes-file dist/RELEASE_NOTES.md
 
+      - name: Checkout (stable release preflight)
+        if: github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.tag_name == '')
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify version alignment before release creation
+        if: github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.tag_name == '')
+        run: scripts/verify-version-alignment.sh
+
       - name: Release Please (Stable)
         id: release
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.tag_name == '')
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -218,3 +251,24 @@ jobs:
           fi
 
           gh release edit "${TAG_NAME}" --draft=false --notes-file dist/RELEASE_NOTES.md
+
+      - name: Cleanup failed draft stable release (no remnants)
+        if: failure() && steps.release.outputs.release_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        run: |
+          if [[ -z "${TAG_NAME}" ]]; then
+            echo "release-cleanup: SKIP (missing tag_name output)"
+            exit 0
+          fi
+
+          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+          if [[ "${is_draft}" != "true" ]]; then
+            echo "release-cleanup: SKIP (release not draft or not found)"
+            exit 0
+          fi
+
+          echo "release-cleanup: deleting draft release and tag ${TAG_NAME}"
+          gh release delete "${TAG_NAME}" --yes || true
+          git push origin ":refs/tags/${TAG_NAME}" || true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,20 @@
   "packages": {
     ".": {
       "extra-files": [
-        { "type": "generic", "path": "VERSION" },
-        { "type": "json", "path": "ts/package.json", "jsonpath": "$.version" },
+        {
+          "type": "generic",
+          "path": "VERSION"
+        },
+        {
+          "type": "json",
+          "path": ".release-please-manifest.premain.json",
+          "jsonpath": "$['.']"
+        },
+        {
+          "type": "json",
+          "path": "ts/package.json",
+          "jsonpath": "$.version"
+        },
         {
           "type": "json",
           "path": "ts/package-lock.json",
@@ -19,11 +31,26 @@
           "path": "ts/package-lock.json",
           "jsonpath": "$.packages[''].version"
         },
-        { "type": "generic", "path": "README.md" },
-        { "type": "generic", "path": "docs/README.md" },
-        { "type": "generic", "path": "docs/api-reference.md" },
-        { "type": "generic", "path": "docs/getting-started.md" },
-        { "type": "generic", "path": "ts/README.md" }
+        {
+          "type": "generic",
+          "path": "README.md"
+        },
+        {
+          "type": "generic",
+          "path": "docs/README.md"
+        },
+        {
+          "type": "generic",
+          "path": "docs/api-reference.md"
+        },
+        {
+          "type": "generic",
+          "path": "docs/getting-started.md"
+        },
+        {
+          "type": "generic",
+          "path": "ts/README.md"
+        }
       ]
     }
   }

--- a/scripts/verify-release-baseline-tag.sh
+++ b/scripts/verify-release-baseline-tag.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+manifest_path="${1:-.release-please-manifest.json}"
+
+if [[ ! -f "${manifest_path}" ]]; then
+  echo "release-baseline: FAIL (missing ${manifest_path})"
+  exit 1
+fi
+
+version="$(
+  MANIFEST_PATH="${manifest_path}" python3 - <<'PY'
+import json
+import os
+import re
+from pathlib import Path
+
+manifest = Path(os.environ["MANIFEST_PATH"])
+data = json.loads(manifest.read_text(encoding="utf-8"))
+version = str(data.get(".", "")).strip()
+if not version:
+    raise SystemExit(f"{manifest} missing package version for '.'")
+if not re.match(r"^\d+\.\d+\.\d+(?:-rc(?:\.\d+)?)?$", version):
+    raise SystemExit(f"{manifest} version {version!r} is not X.Y.Z, X.Y.Z-rc, or X.Y.Z-rc.N")
+print(version)
+PY
+)"
+
+tag="v${version}"
+
+# Ensure local tag data is present when the workflow checkout did not fetch tags.
+if git remote get-url origin >/dev/null 2>&1; then
+  git fetch --quiet origin "refs/tags/${tag}:refs/tags/${tag}" 2>/dev/null || true
+fi
+
+if ! git rev-parse -q --verify "refs/tags/${tag}^{commit}" >/dev/null; then
+  echo "release-baseline: FAIL (${manifest_path} points to ${version}, but ${tag} is not a git tag)"
+  exit 1
+fi
+
+if ! git merge-base --is-ancestor "${tag}" HEAD; then
+  echo "release-baseline: FAIL (${tag} is not an ancestor of HEAD)"
+  exit 1
+fi
+
+echo "release-baseline: PASS (${tag})"

--- a/scripts/verify-version-alignment.sh
+++ b/scripts/verify-version-alignment.sh
@@ -45,7 +45,7 @@ if [[ "${ts_version}" != "${expected_version}" ]]; then
 fi
 
 manifest_check_output="$(
-  EXPECTED_VERSION="${expected_version}" python3 - <<'PY'
+  EXPECTED_VERSION="${expected_version}" python3 - <<'PY' 2>&1
 import json
 import os
 import re
@@ -153,7 +153,7 @@ PY
   fi
 fi
 
-EXPECTED_VERSION="${expected_version}" python3 - <<'PY'
+EXPECTED_VERSION="${expected_version}" python3 - <<'PY' 2>&1
 import os
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- Stop the bad release-please churn that was re-surfacing old ISR breaking-change footers in new release PRs.
- Make stable release PRs update `.release-please-manifest.premain.json` alongside the stable manifest/version files.
- Preflight stable release version alignment before Release Please can create a draft release.
- Add `scripts/verify-release-baseline-tag.sh` and wire prerelease/stable release-PR generation to fail if the stable manifest points at a missing tag.
- Add stable-release cleanup so failed draft releases do not leave orphan draft/tag state behind.

## Current recovery state
- PR #147 was converted to draft because `4.0.0-rc` is wrong and must not merge.
- The repository still has draft, untagged `v2.0.1` and `v3.0.1` releases; those need a deliberate recovery step after this guard lands.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...)` over all workflow YAML files — pass
- `bash -n scripts/verify-release-baseline-tag.sh scripts/verify-version-alignment.sh scripts/render-release-notes.sh scripts/verify-release-branch.sh` — pass
- `scripts/verify-version-alignment.sh` — pass (`3.0.1`)
- `make rubric` — pass