### PR TITLE
chore(release): skip stale baseline changelists

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -25,8 +25,18 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check stable release baseline
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
+
       - name: Release Please (PR only)
         id: release
+        if: steps.baseline.outputs.ready == 'true'
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,8 +14,18 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check stable release baseline
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
+
       - name: Release Please (Prerelease)
         id: release
+        if: steps.baseline.outputs.ready == 'true'
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -28,8 +28,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Check current release baseline
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
+
       - name: Compute release-as (align to premain RC)
         id: version
+        if: steps.baseline.outputs.ready == 'true'
         run: |
           set -euo pipefail
 
@@ -68,7 +75,7 @@ jobs:
           echo "release-as: ${release_as:-}"
 
       - name: Release Please (PR only) (aligned)
-        if: steps.version.outputs.release_as != ''
+        if: steps.baseline.outputs.ready == 'true' && steps.version.outputs.release_as != ''
         id: release_aligned
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -85,7 +92,7 @@ jobs:
             --release-as "${RELEASE_AS}"
 
       - name: Release Please (PR only)
-        if: steps.version.outputs.release_as == ''
+        if: steps.baseline.outputs.ready == 'true' && steps.version.outputs.release_as == ''
         id: release_default
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/scripts/check-release-baseline-ready.sh
+++ b/scripts/check-release-baseline-ready.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+manifest_path="${1:-.release-please-manifest.json}"
+
+if [[ ! -f "${manifest_path}" ]]; then
+  echo "release-baseline-ready: FAIL (missing ${manifest_path})"
+  exit 1
+fi
+
+version="$(
+  MANIFEST_PATH="${manifest_path}" python3 - <<'PY'
+import json
+import os
+import re
+from pathlib import Path
+
+manifest = Path(os.environ["MANIFEST_PATH"])
+data = json.loads(manifest.read_text(encoding="utf-8"))
+version = str(data.get(".", "")).strip()
+if not version:
+    raise SystemExit(f"{manifest} missing package version for '.'")
+if not re.match(r"^\d+\.\d+\.\d+(?:-rc(?:\.\d+)?)?$", version):
+    raise SystemExit(
+        f"{manifest} version {version!r} is not X.Y.Z, X.Y.Z-rc, or X.Y.Z-rc.N"
+    )
+print(version)
+PY
+)"
+
+tag="v${version}"
+ready="false"
+
+if command -v gh >/dev/null 2>&1 && gh release view "${tag}" >/dev/null 2>&1; then
+  ready="true"
+elif git rev-parse -q --verify "refs/tags/${tag}^{commit}" >/dev/null 2>&1; then
+  ready="true"
+elif git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+  ready="true"
+fi
+
+if [[ "${ready}" == "true" ]]; then
+  echo "release-baseline-ready: PASS (${tag})"
+else
+  echo "release-baseline-ready: SKIP (${tag} is not published yet; refusing to synthesize a stale changelist)"
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "ready=${ready}" >> "${GITHUB_OUTPUT}"
+  echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+  echo "version=${version}" >> "${GITHUB_OUTPUT}"
+fi

--- a/scripts/verify-release-readiness.sh
+++ b/scripts/verify-release-readiness.sh
@@ -38,6 +38,7 @@ if [[ "${#changed_files[@]}" -gt 0 ]]; then
       | docs/api-reference.md \
       | docs/getting-started.md \
       | scripts/build-release-assets.sh \
+      | scripts/check-release-baseline-ready.sh \
       | scripts/generate-checksums.sh \
       | scripts/read-version.sh \
       | scripts/render-release-notes.sh \


### PR DESCRIPTION
## Summary
- closes the race that produced the invalid `4.0.0` release PR
- adds `scripts/check-release-baseline-ready.sh`, which reports ready only when the manifest's current `vX.Y.Z` baseline release/tag exists
- gates main Release PR generation and premain prerelease PR/release generation on that baseline being ready
- when the baseline is missing, the workflows now skip Release Please PR generation instead of synthesizing a stale historical changelist
- teaches release-readiness that this baseline guard is release-infra-only, not a user-facing release trigger

## What happened
`Release PR (main)` ran concurrently with the recovered `Release (main)` workflow. It started before `v3.0.1` was published, so Release Please could not find the current baseline and replayed old historical breaking changes into PR #153 as `4.0.0`. PR #153 is closed and must not be merged.

## Verification
- closed PR #153
- `scripts/check-release-baseline-ready.sh .release-please-manifest.json` => PASS `v3.0.1`
- temp manifest `99.99.99` => SKIP, no failure/stale changelist
- YAML parse for all workflows
- `scripts/verify-version-alignment.sh`
- `scripts/verify-release-readiness.sh origin/main HEAD release`
- Release Please dry-run for `main` now finds `v3.0.1` and opens 0 PRs
- Release Please dry-run for `premain` now proposes `3.1.0-rc`, not `4.0.0-rc`
- `make rubric`

## Linear
- THE-985: https://linear.app/theorycloud/issue/THE-985/recover-facetheory-release-please-automatic-tag-pipeline
