### PR TITLE
[codex] resolve Dependabot alert 45 for Svelte peer range

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the framework peers that match your adapter surface:
 - React: `npm install react react-dom`
 - React + AntD/Emotion: `npm install antd @emotion/react @emotion/cache @emotion/server`
 - Vue: `npm install vue @vue/server-renderer`
-- Svelte: `npm install svelte`
+- Svelte: `npm install svelte@^5.55.7`
 
 Optional companion packages from pinned GitHub releases:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -29,7 +29,7 @@ Adapter peers:
 - React routes require `react` and `react-dom`
 - React + AntD/Emotion integrations additionally require `antd`, `@emotion/react`, `@emotion/cache`, and `@emotion/server`
 - Vue routes require `vue` and `@vue/server-renderer`
-- Svelte routes require `svelte`
+- Svelte routes require `svelte` satisfying `>=4 <5.46.0 || >=5.55.7`
 
 ## Package Export Map
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ npm install --save-exact \
 - React: `npm install react react-dom`
 - React + AntD/Emotion: `npm install antd @emotion/react @emotion/cache @emotion/server`
 - Vue: `npm install vue @vue/server-renderer`
-- Svelte: `npm install svelte`
+- Svelte: `npm install svelte@^5.55.7`
 
 ### Step 3: Install optional companion packages
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -15,7 +15,7 @@ Install the peers that match your adapter surface:
 - React: `npm install react react-dom`
 - React + AntD/Emotion: `npm install antd @emotion/react @emotion/cache @emotion/server`
 - Vue: `npm install vue @vue/server-renderer`
-- Svelte: `npm install svelte`
+- Svelte: `npm install svelte@^5.55.7`
 
 Optional companion packages:
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -48,7 +48,7 @@
         "antd": ">=5",
         "react": ">=18",
         "react-dom": ">=18",
-        "svelte": ">=4",
+        "svelte": ">=4 <5.46.0 || >=5.55.7",
         "vue": ">=3"
       },
       "peerDependenciesMeta": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -135,7 +135,7 @@
     "antd": ">=5",
     "react": ">=18",
     "react-dom": ">=18",
-    "svelte": ">=4",
+    "svelte": ">=4 <5.46.0 || >=5.55.7",
     "vue": ">=3"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary

- Tightens the published Svelte peer dependency range to exclude the vulnerable Svelte 5.46.0 through 5.55.6 line from Dependabot alert #45 / GHSA-f3cj-j4f6-wq85.
- Keeps Svelte 4 compatibility while requiring patched Svelte `>=5.55.7` for Svelte 5 consumers.
- Updates install docs to recommend `svelte@^5.55.7` for new Svelte adapter installs.

## Dependabot alert

- https://github.com/theory-cloud/FaceTheory/security/dependabot/45
- Alert package: `svelte` in `ts/package-lock.json`
- Patched direct dev dependency was already present on synced `staging` from PR #163 (`svelte` `5.55.7`, `npm audit` clean). This follow-up also protects the public peer contract so FaceTheory no longer advertises vulnerable Svelte 5 versions as acceptable peers.

## Validation

- `scripts/verify-version-alignment.sh`
- `cd ts && npm audit --package-lock-only --json`
- `make rubric`