### PR TITLE
docs(oac): complete mutating form transport closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ export const handler = createLambdaUrlStreamingHandler({ app });
 
 The `v3.1.1` GitHub release also ships the matching `facetheory-reference-${FACETHEORY_VERSION}.tar.gz` bundle, which contains the canonical docs, runnable examples, and reference deployment stacks for offline use. <!-- x-release-please-version -->
 
+## OAC Mutating Forms
+
+AppTheorySsrSite deployments keep the Lambda Function URL origin protected with `AWS_IAM` and CloudFront OAC. Native
+browser forms cannot add the `x-amz-content-sha256` payload hash required for mutating Lambda URL requests, so
+FaceTheory exposes `startAwsOacFormTransport()` for explicitly marked same-origin URL-encoded forms:
+
+```html
+<form action="/control/items/new" method="post" data-facetheory-oac-form>
+  <input name="name" required />
+  <button>Create</button>
+</form>
+```
+
+Route the action path to Lambda/AppTheory, keep OAC enabled, and install the helper from a client bootstrap module. The
+payload hash is AWS signing plumbing only; app authentication, CSRF, idempotency, and business validation remain
+application responsibilities. See [Getting Started](./docs/getting-started.md#add-an-oac-safe-mutating-ssr-form) and
+[Core Patterns](./docs/core-patterns.md#pattern-mark-same-origin-mutating-forms-for-oac-transport).
+
 ## ISR Tenant Partition Safety
 
 Blocking ISR is fail-closed when known tenant boundary headers such as `x-tenant-id` or `x-facetheory-tenant` reach

--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -27,6 +27,20 @@ When using `AppTheorySsrSite` in `ssg-isr` mode:
 - prefer an `AWS_IAM` Function URL origin for read-only SSR traffic rather than a public direct URL
 - do not forward viewer-supplied tenant headers by default; derive tenancy from trusted request context when possible
 
+Mutating form routes behind Lambda Function URL OAC are dynamic routes. If an SSR, SSG, ISR, or SPA page renders a
+same-origin form that performs `POST`, `PUT`, `PATCH`, or `DELETE`, route the form action path through `ssrPathPatterns`
+so CloudFront sends it to Lambda/AppTheory instead of S3 or an origin group static hit. Keep the Lambda Function URL on
+`AWS_IAM` + OAC and install FaceTheory's `startAwsOacFormTransport()` helper on forms marked with
+`data-facetheory-oac-form`; native browser form posts cannot add the `x-amz-content-sha256` payload hash header that
+CloudFront signs for mutating Lambda URL requests.
+
+Treat `x-amz-content-sha256` as AWS signing plumbing only. It is not application authentication, authorization, CSRF
+protection, or idempotency. Browser-generated `multipart/form-data` is intentionally out of scope for the URL-encoded
+helper; marked multipart/text/plain forms fail closed until a separately scoped transport constructs and hashes the
+exact body bytes itself. Setting `ssrUrlAuthType: NONE` is only an explicitly authorized, time-boxed rollback while a
+broken deployment is repaired, and the rollback plan must restore `AWS_IAM` + OAC rather than making unauthenticated
+Function URLs durable.
+
 Reference example (FaceTheory repo):
 - `infra/apptheory-ssr-site/`
 - `infra/apptheory-ssg-isr-site/` (SSG origin-group + ISR example)

--- a/docs/cdk/aws-deployment.md
+++ b/docs/cdk/aws-deployment.md
@@ -42,6 +42,27 @@ The reference stacks use AppTheory CDK and wire these runtime conventions:
 Reference-stack stance:
 - prefer a CloudFront-signed `AWS_IAM` Function URL origin for read-only SSR traffic
 - do not model viewer-supplied tenant-header passthrough as the default copy-paste shape
+- keep same-origin mutating form action paths on Lambda/AppTheory behaviors, usually through `ssrPathPatterns`
+- use FaceTheory's marked URL-encoded OAC form helper for browser forms that submit through Lambda Function URL OAC
+
+### Mutating Forms Behind Lambda Function URL OAC
+
+`AppTheorySsrSite` keeps the Lambda Function URL origin protected by `AWS_IAM` and CloudFront Lambda URL OAC. Browser
+forms that submit mutating methods cannot attach the `x-amz-content-sha256` header that CloudFront must sign for the
+exact payload bytes, so native form POSTs can fail before the request reaches AppTheory or FaceTheory.
+
+Supported contract:
+
+- render the form action as a same-origin CloudFront path, never a direct Lambda Function URL
+- route the action path to Lambda through `ssrPathPatterns` even when the page containing the form is SSG or ISR
+- mark URL-encoded forms with `data-facetheory-oac-form`
+- install `startAwsOacFormTransport()` from a client bootstrap module
+- keep app authentication, authorization, CSRF, idempotency, and business validation in application-owned code
+
+The helper hashes the exact `application/x-www-form-urlencoded` bytes it sends and adds `x-amz-content-sha256` for AWS
+signing. It fails closed for marked multipart, text/plain, unknown encodings, cross-origin actions, unsafe redirect
+handling, and default document replacement of CSP-protected HTML responses. Do not turn `ssrUrlAuthType` to `NONE` as a
+durable solution; use it only as an explicitly authorized temporary rollback with an owner and removal date.
 
 ## CloudFront Behavior Options
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,6 +96,115 @@ runtime.get("/{proxy+}", createAppTheoryFaceHandler({ app }));
 export const handler = createLambdaFunctionURLStreamingHandler(runtime);
 ```
 
+## Add An OAC-Safe Mutating SSR Form
+
+When a FaceTheory app is deployed through `AppTheorySsrSite` with Lambda Function URL OAC and `AWS_IAM`, native browser
+form POSTs cannot attach the `x-amz-content-sha256` header that CloudFront signs for mutating Lambda URL payloads. Keep
+the form action same-origin and opt the form into FaceTheory's URL-encoded OAC transport instead of posting directly to
+the Lambda Function URL.
+
+Server-render the form and the action route through the same SSR Face:
+
+```ts
+import {
+  createFaceApp,
+  escapeHTML,
+  type FaceModule,
+} from "@theory-cloud/facetheory";
+
+const oacBootstrapModule = "/assets/oac-form-bootstrap.js";
+
+function formDocument(message = "") {
+  const alert = message
+    ? `<p role="alert">${escapeHTML(message)}</p>`
+    : "";
+
+  return `
+    <main>
+      <h1>Create control-plane item</h1>
+      ${alert}
+      <form action="/control/items/new" method="post" data-facetheory-oac-form>
+        <label>
+          Name
+          <input name="name" required />
+        </label>
+        <button name="intent" value="create">Create</button>
+      </form>
+    </main>
+  `;
+}
+
+const faces: FaceModule[] = [
+  {
+    route: "/control/items/new",
+    mode: "ssr",
+    render: async ({ request }) => {
+      if (request.method === "POST") {
+        const fields = new URLSearchParams(
+          new TextDecoder().decode(request.body),
+        );
+        const name = fields.get("name")?.trim() ?? "";
+
+        if (!name) {
+          return {
+            status: 400,
+            html: formDocument("Name is required."),
+            hydration: { bootstrapModule: oacBootstrapModule, data: null },
+          };
+        }
+
+        // Persist through application-owned auth, CSRF, idempotency, and
+        // business validation here. The OAC payload hash is AWS signing
+        // plumbing only; it is not application authentication.
+        return {
+          html: `
+            <main>
+              <h1>Created</h1>
+              <p>${escapeHTML(name)} was accepted.</p>
+              <a href="/control/items">Back to items</a>
+            </main>
+          `,
+          hydration: { bootstrapModule: oacBootstrapModule, data: null },
+        };
+      }
+
+      return {
+        html: formDocument(),
+        hydration: { bootstrapModule: oacBootstrapModule, data: null },
+      };
+    },
+  },
+];
+
+export const app = createFaceApp({ faces });
+```
+
+Install the browser helper from the bootstrap module emitted with that Face:
+
+```ts
+import { startAwsOacFormTransport } from "@theory-cloud/facetheory";
+
+startAwsOacFormTransport();
+```
+
+Route both `GET` and `POST` for the same-origin action path to Lambda/AppTheory, not to S3 or a direct Lambda Function
+URL:
+
+```ts
+import { createAppTheoryFaceHandler } from "@theory-cloud/facetheory/apptheory";
+
+const actionFace = createAppTheoryFaceHandler({ app });
+
+runtime.get("/control/items/new", actionFace);
+runtime.post("/control/items/new", actionFace);
+```
+
+The helper sends the exact URL-encoded bytes that it hashes, sets `x-amz-content-sha256`, and includes same-origin
+credentials. Marked forms that resolve to `multipart/form-data`, `text/plain`, or another unsupported encoding fail
+closed before a request is sent; file uploads need a separately scoped transport. If the HTML response carries a
+`Content-Security-Policy` header, handle the result explicitly through `onResponse` or `onNavigate` because fetched CSP
+headers cannot become the active document policy during default document replacement.
+
 ## Add Stitch Control-Plane Primitives
 
 FaceTheory's Stitch UI surface is split into shared contracts plus framework-specific visual primitives:

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -132,6 +132,52 @@ npm run typecheck
 npm test
 ```
 
+## Migration 6: Replace App-Local OAC Form Workarounds
+
+Use this path when an SSR control-plane page behind AppTheorySsrSite Lambda Function URL OAC has an app-local fetch
+shim, disabled form, direct Lambda Function URL action, or temporary Function URL auth rollback because native browser
+forms could not provide `x-amz-content-sha256`.
+
+1. Keep the public form action on the same-origin CloudFront URL.
+2. Route the mutating action path to Lambda/AppTheory with `ssrPathPatterns` when the deployment has an S3 or SSG/ISR
+   origin path that could otherwise intercept the request.
+3. Mark only supported URL-encoded forms with `data-facetheory-oac-form`.
+4. Install `startAwsOacFormTransport()` from the Face's client bootstrap module.
+5. Remove any direct Function URL form action or app-local transport workaround after the FaceTheory helper is verified.
+6. Keep authentication, authorization, CSRF, idempotency, and business validation in the application layer; the
+   `x-amz-content-sha256` value is only AWS signing plumbing.
+7. Leave browser-generated multipart uploads out of this migration unless a separately scoped transport constructs and
+   hashes the exact multipart bytes.
+
+Validation:
+
+```bash
+cd ts
+npx tsx test/unit/oac-form.test.ts
+```
+
+Deployed verification:
+
+```bash
+curl -I https://<cloudfront-domain>/control/items/new
+```
+
+Then submit the marked form in a browser through the CloudFront URL and confirm:
+
+- the request reaches the AppTheory/FaceTheory Lambda instead of failing with `InvalidSignatureException`
+- the request includes `x-amz-content-sha256` and `content-type: application/x-www-form-urlencoded;charset=UTF-8`
+- unsupported marked encodings fail closed before sending
+- Lambda Function URL auth remains `AWS_IAM` behind CloudFront OAC
+
+Rollback:
+
+- remove the `data-facetheory-oac-form` marker or the bootstrap call to return to native browser behavior while the app
+  remains pinned to the previous known-good FaceTheory release tarball, or
+- temporarily disable the affected mutating form in the consuming app.
+
+Do not make `ssrUrlAuthType: NONE` a durable rollback. If an operator explicitly authorizes it to recover a broken
+deployment, record an owner, expiration date, and restoration plan back to `AWS_IAM` + OAC.
+
 ## Rollback Notes
 
 - Keep the prior handler or deployable artifact available until the new path is verified.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -52,6 +52,44 @@ Use this when changing:
 - hydration data output
 - static file layout
 
+### OAC Mutating Form Transport
+
+```bash
+cd ts
+npx tsx test/unit/oac-form.test.ts
+```
+
+Use this when changing:
+
+- `startAwsOacFormTransport()`
+- URL-encoded form field collection or payload hashing
+- AppTheorySsrSite OAC mutating-form documentation
+- response navigation, CSP, redirect, or unsupported-encoding behavior for marked forms
+
+Local expected result:
+
+- marked same-origin POSTs send `content-type: application/x-www-form-urlencoded;charset=UTF-8`
+- marked same-origin POSTs send `x-amz-content-sha256` for the exact body bytes passed to `fetch`
+- unmarked, `GET`, and `dialog` forms keep native behavior
+- cross-origin actions and marked unsupported encodings fail before sending
+- mutating fetches use `redirect: "error"`
+- default HTML document replacement refuses CSP-protected responses unless the host handles the response
+
+Release-candidate validation for an AppTheorySsrSite consumer should use the published GitHub Release tarball, not a
+workspace link:
+
+1. install the FaceTheory RC tarball exactly in the consuming app;
+2. mark a same-origin URL-encoded form with `data-facetheory-oac-form`;
+3. install `startAwsOacFormTransport()` from the client bootstrap module;
+4. route the action path through AppTheory/CloudFront to Lambda, usually with `ssrPathPatterns`;
+5. submit through the deployed CloudFront URL and confirm the request reaches Lambda without changing the Function URL
+   auth type away from `AWS_IAM`;
+6. confirm marked multipart/text/plain forms fail closed and do not send a request;
+7. if the response uses CSP headers, confirm the host handles it through `onResponse` or `onNavigate`.
+
+For the original lab driver, theory-mcp-server should validate `POST /agents/new` through CloudFront OAC before stable
+promotion. A successful RC validation means the app-local workaround can be removed while keeping OAC enabled.
+
 ### React SSR And Streaming
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -210,6 +210,18 @@ Verification:
 - marked multipart or text/plain forms do not send a request and surface through `onError`
 - redirects fail before body replay, and validation responses either stay same-origin with full-document outcomes or fail closed when response CSP cannot be preserved
 
+Release handoff:
+
+- validate the FaceTheory RC from its GitHub Release tarball in the consuming app rather than from a workspace link
+- verify the same-origin action path is routed through AppTheory/CloudFront to Lambda, not S3 or a direct Function URL
+- confirm Lambda receives the request with `AWS_IAM` + CloudFront OAC still enabled
+- confirm any app-local workaround or disabled-form path is removed only after the helper succeeds in the deployed
+  CloudFront flow
+- for the original theory-mcp-server lab driver, validate `POST /agents/new` through CloudFront OAC before stable
+  promotion
+- if emergency rollback is needed, pin the previous FaceTheory tarball or remove the opt-in marker/bootstrap; do not
+  keep `ssrUrlAuthType: NONE` as a durable solution
+
 ## Issue: Streaming HTML Ships Without Expected Late Styles
 
 Symptoms:

--- a/infra/apptheory-ssg-isr-site/README.md
+++ b/infra/apptheory-ssg-isr-site/README.md
@@ -37,6 +37,10 @@ npm run synth
 ## Deployment Notes
 
 - Use the canonical AWS deployment and operations docs for routing, cache, and smoke-test expectations.
+- SSG or ISR pages may render forms, but same-origin mutating form action paths must route to Lambda/AppTheory through
+  `ssrPathPatterns`; do not let those paths resolve to S3 static objects or direct Function URLs.
+- Keep `AWS_IAM` + CloudFront OAC enabled for the Lambda Function URL and use FaceTheory's
+  `data-facetheory-oac-form` / `startAwsOacFormTransport()` path for URL-encoded browser submissions.
 - This reference stack intentionally avoids forwarding viewer-supplied tenant headers by default; derive tenant identity from trusted request context if a deployment needs it.
 - The bundled ISR demo is tenant-invariant. Tenant-varying ISR deployments must configure FaceTheory `tenantKey` or a custom `cacheKey` after AppTheory/CloudFront has stripped viewer-supplied tenant headers and injected trusted tenant context.
 - If tenant-like headers such as `x-tenant-id` or `x-facetheory-tenant` reach FaceTheory without that explicit partition, the ISR runtime fails closed before metadata lookup or HTML writes.

--- a/infra/apptheory-ssr-site/README.md
+++ b/infra/apptheory-ssr-site/README.md
@@ -34,4 +34,7 @@ npm run synth
 
 - Deploy and smoke-test instructions should follow the canonical AWS docs first.
 - This reference stack intentionally does **not** forward viewer-supplied tenant headers such as `x-facetheory-tenant`.
+- Same-origin mutating form actions belong on the Lambda/AppTheory path with `AWS_IAM` + CloudFront OAC intact. Mark
+  URL-encoded forms with `data-facetheory-oac-form` and install `startAwsOacFormTransport()` rather than posting
+  directly to the Function URL or weakening Function URL auth.
 - Use this README for stack-local commands and folder context only.


### PR DESCRIPTION
## Summary

Completes the stale Linear project closeout for FaceTheory OAC Mutating Form Transport by finishing the remaining reference, AWS-contract, and release-handoff documentation tasks.

Branch was created from `origin/staging` at `e5555b7`.

## Linear

Project: https://linear.app/theorycloud/project/facetheory-oac-mutating-form-transport-8ada16787a42

Issues:
- [x] THE-982 — Add an SSR OAC mutating form reference
- [x] THE-983 — Document the AppTheorySsrSite OAC mutating-form contract
- [x] THE-984 — Add OAC mutating-form troubleshooting and release handoff notes

Related cleanup:
- THE-986 marked done; PR #158 shipped the default fetch receiver-binding fix in `v3.1.1`.

## Render modes and adapters affected

SSR / SPA / SSG pages that render URL-encoded mutating forms. ISR pages may contain forms, but ISR cache behavior is unchanged. No React/Vue/Svelte adapter-specific implementation changes.

## Determinism impact

Documentation-only closeout. The documented helper remains submit-time transport behavior and does not alter server-rendered HTML, head/style emission, or the hydration boundary.

## Backward compatibility

Additive documentation only. No runtime API, dependency, manifest, release-marker, or adapter behavior changes.

## What changed

- Added a copyable SSR form/action reference in `docs/getting-started.md` that marks the form, installs `startAwsOacFormTransport()`, keeps action handling same-origin, and calls out application-owned auth/CSRF/idempotency/business validation.
- Documented the AppTheorySsrSite OAC mutating-form routing contract in root/AWS/CDK/reference-stack docs, including `ssrPathPatterns`, `AWS_IAM` + OAC, multipart exclusion, and `ssrUrlAuthType: NONE` as temporary rollback only.
- Added focused OAC form testing guidance, migration guidance for removing app-local OAC workarounds, and release-handoff notes for RC validation against deployed AppTheorySsrSite consumers.

## Validation

- `scripts/verify-version-alignment.sh` — pass (`3.1.1`)
- `cd ts && npx tsx test/unit/oac-form.test.ts` — pass (23 tests)
- `make rubric` — pass

Note: `cd ts && npm run check` is referenced by local guidance but `ts/package.json` currently has no `check` script on staging; `make rubric` runs the repository-equivalent typecheck, lint, unit tests, version alignment, pack verification, npm audit policy, and Go version pin checks.

## Cross-repo coordination

No AppTheory or TableTheory code change. Docs preserve AppTheorySsrSite `AWS_IAM` + CloudFront OAC as the supported posture. theory-mcp-server still needs to validate the eventual FaceTheory RC/stable tarball against lab `POST /agents/new` through CloudFront OAC before consuming it as release evidence.