### PR TITLE
[codex] Fix draft release asset builds

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -62,12 +62,20 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          # Draft GitHub Releases do not guarantee a git tag exists until the
+          # release is published. Build from the release commit and verify the
+          # draft's target before uploading immutable assets.
+          ref: ${{ github.sha }}
 
       - name: Fetch main + premain (release branch verification)
         run: git fetch origin main premain --force
 
-      - name: Verify tag was cut from the correct branch
+      - name: Verify draft release targets this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
+
+      - name: Verify release source branch
         run: scripts/verify-release-branch.sh "${{ needs.release-please.outputs.tag_name }}"
 
       - name: Set SOURCE_DATE_EPOCH (deterministic artifacts)
@@ -206,12 +214,22 @@ jobs:
             exit 0
           fi
 
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
-          if [[ "${is_draft}" != "true" ]]; then
-            echo "release-cleanup: SKIP (release not draft or not found)"
+          release_id=""
+          for attempt in 1 2 3 4 5 6; do
+            release_id="$(
+              TAG_NAME="${TAG_NAME}" gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+                --jq 'map(select(.tag_name == env.TAG_NAME and .draft == true)) | .[0].id // ""' \
+                2>/dev/null || true
+            )"
+            [[ -n "${release_id}" ]] && break
+            sleep 5
+          done
+
+          if [[ -z "${release_id}" ]]; then
+            echo "release-cleanup: SKIP (draft release not found)"
             exit 0
           fi
 
-          echo "release-cleanup: deleting draft release and tag ${TAG_NAME}"
-          gh release delete "${TAG_NAME}" --yes || true
+          echo "release-cleanup: deleting draft release ${release_id} and tag ${TAG_NAME}"
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/${release_id}" || true
           gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG_NAME}" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,61 @@ jobs:
           set -euo pipefail
 
           if [[ -n "${TAG_NAME}" ]]; then
-            target_commitish="$(gh release view "${TAG_NAME}" --json targetCommitish --jq '.targetCommitish')"
+            release_json="$(gh release view "${TAG_NAME}" --json tagName,targetCommitish,isDraft,isPrerelease,url 2>/dev/null || true)"
+            if [[ -z "${release_json}" ]]; then
+              echo "source_ref=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+              echo "release_is_draft=false" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+
+            mapfile -t release_fields < <(
+              RELEASE_JSON="${release_json}" python3 - <<'PY'
+          import json
+          import os
+
+          data = json.loads(os.environ["RELEASE_JSON"])
+          print(data.get("tagName", ""))
+          print(data.get("targetCommitish", ""))
+          print("true" if data.get("isDraft") is True else "false")
+          print("true" if data.get("isPrerelease") is True else "false")
+          print(data.get("url", ""))
+          PY
+            )
+
+            release_tag="${release_fields[0]:-}"
+            target_commitish="${release_fields[1]:-}"
+            is_draft="${release_fields[2]:-false}"
+            is_prerelease="${release_fields[3]:-false}"
+            release_url="${release_fields[4]:-}"
+
+            if [[ "${release_tag}" != "${TAG_NAME}" ]]; then
+              echo "release-assets: FAIL (release tag ${release_tag:-<empty>} != ${TAG_NAME})"
+              exit 1
+            fi
             if [[ -z "${target_commitish}" ]]; then
               echo "release-assets: FAIL (${TAG_NAME} missing targetCommitish)"
               exit 1
             fi
+            if [[ "${is_draft}" == "true" ]]; then
+              if [[ "${TAG_NAME}" =~ -rc(\.|$) && "${is_prerelease}" != "true" ]]; then
+                echo "release-assets: FAIL (${TAG_NAME} draft must be marked prerelease)"
+                exit 1
+              fi
+              if [[ ! "${TAG_NAME}" =~ -rc(\.|$) && "${is_prerelease}" == "true" ]]; then
+                echo "release-assets: FAIL (${TAG_NAME} stable draft must not be marked prerelease)"
+                exit 1
+              fi
+              echo "release-assets: draft ${TAG_NAME} targets ${target_commitish} (${release_url})"
+            fi
+
             echo "source_ref=${target_commitish}" >> "${GITHUB_OUTPUT}"
+            echo "release_is_draft=${is_draft}" >> "${GITHUB_OUTPUT}"
+            echo "release_target=${target_commitish}" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
           echo "source_ref=${GITHUB_REF}" >> "${GITHUB_OUTPUT}"
+          echo "release_is_draft=false" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout (for tag-triggered assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -59,6 +104,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
+          RELEASE_IS_DRAFT: ${{ steps.source.outputs.release_is_draft }}
+          RELEASE_TARGET: ${{ steps.source.outputs.release_target }}
         run: |
           set -euo pipefail
 
@@ -99,13 +146,15 @@ jobs:
           update_manifest(".release-please-manifest.premain.json")
           PY
 
-          scripts/verify-release-branch.sh "${TAG_NAME}"
-          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
-            is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft')"
-            if [[ "${is_draft}" == "true" ]]; then
-              scripts/verify-release-draft-target.sh "${TAG_NAME}" HEAD
+          if [[ "${RELEASE_IS_DRAFT}" == "true" && "${RELEASE_TARGET}" =~ ^[0-9a-f]{40}$ ]]; then
+            actual_commit="$(git rev-parse HEAD)"
+            if [[ "${actual_commit}" != "${RELEASE_TARGET}" ]]; then
+              echo "release-assets: FAIL (${TAG_NAME} draft targets ${RELEASE_TARGET}, checked out ${actual_commit})"
+              exit 1
             fi
           fi
+
+          scripts/verify-release-branch.sh "${TAG_NAME}"
 
           export SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
           cd ts && npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,14 +289,22 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          # Draft GitHub Releases do not guarantee a git tag exists until the
+          # release is published. Build from the release commit and verify the
+          # draft's target before uploading immutable assets.
+          ref: ${{ github.sha }}
 
       - name: Fetch main + premain (release branch verification)
         run: |
           git fetch origin main --force
           git fetch origin premain --force || true
 
-      - name: Verify tag was cut from the correct branch
+      - name: Verify draft release targets this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
+
+      - name: Verify release source branch
         run: scripts/verify-release-branch.sh "${{ needs.release-please.outputs.tag_name }}"
 
       - name: Set SOURCE_DATE_EPOCH (deterministic artifacts)
@@ -435,12 +443,22 @@ jobs:
             exit 0
           fi
 
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
-          if [[ "${is_draft}" != "true" ]]; then
-            echo "release-cleanup: SKIP (release not draft or not found)"
+          release_id=""
+          for attempt in 1 2 3 4 5 6; do
+            release_id="$(
+              TAG_NAME="${TAG_NAME}" gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+                --jq 'map(select(.tag_name == env.TAG_NAME and .draft == true)) | .[0].id // ""' \
+                2>/dev/null || true
+            )"
+            [[ -n "${release_id}" ]] && break
+            sleep 5
+          done
+
+          if [[ -z "${release_id}" ]]; then
+            echo "release-cleanup: SKIP (draft release not found)"
             exit 0
           fi
 
-          echo "release-cleanup: deleting draft release and tag ${TAG_NAME}"
-          gh release delete "${TAG_NAME}" --yes || true
+          echo "release-cleanup: deleting draft release ${release_id} and tag ${TAG_NAME}"
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/${release_id}" || true
           gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG_NAME}" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,32 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Resolve release source ref
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${TAG_NAME}" ]]; then
+            target_commitish="$(gh release view "${TAG_NAME}" --json targetCommitish --jq '.targetCommitish')"
+            if [[ -z "${target_commitish}" ]]; then
+              echo "release-assets: FAIL (${TAG_NAME} missing targetCommitish)"
+              exit 1
+            fi
+            echo "source_ref=${target_commitish}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "source_ref=${GITHUB_REF}" >> "${GITHUB_OUTPUT}"
+
       - name: Checkout (for tag-triggered assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ inputs.tag_name || github.ref }}
+          ref: ${{ steps.source.outputs.source_ref }}
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
@@ -37,6 +57,7 @@ jobs:
 
       - name: Build assets for existing tag release
         env:
+          GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
         run: |
           set -euo pipefail
@@ -79,6 +100,12 @@ jobs:
           PY
 
           scripts/verify-release-branch.sh "${TAG_NAME}"
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft')"
+            if [[ "${is_draft}" == "true" ]]; then
+              scripts/verify-release-draft-target.sh "${TAG_NAME}" HEAD
+            fi
+          fi
 
           export SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
           cd ts && npm ci

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin build-release-assets ensure-release-branches test-ensure-release-branches stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets test-trigger-theorycloud-publish-awscurl rubric
+.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin build-release-assets ensure-release-branches test-ensure-release-branches test-verify-release-draft-target stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets test-trigger-theorycloud-publish-awscurl rubric
 
 ts-build:
 	cd ts && npm run build
@@ -39,6 +39,9 @@ ensure-release-branches:
 test-ensure-release-branches:
 	./scripts/test-ensure-release-branches.sh
 
+test-verify-release-draft-target:
+	./scripts/test-verify-release-draft-target.sh
+
 stage-theorycloud-facetheory-subtree:
 	./scripts/stage_theorycloud_facetheory_subtree.sh --output "$${THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/facetheory-theorycloud}"
 
@@ -57,4 +60,4 @@ test-theorycloud-targets:
 test-trigger-theorycloud-publish-awscurl:
 	./scripts/test-trigger-theorycloud-publish-awscurl.sh
 
-rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin
+rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin test-verify-release-draft-target

--- a/scripts/test-verify-release-draft-target.sh
+++ b/scripts/test-verify-release-draft-target.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${repo_root}/scripts/verify-release-draft-target.sh"
+
+fail() {
+  echo "test-verify-release-draft-target: FAIL ($*)"
+  exit 1
+}
+
+setup_repo() {
+  local label="$1"
+  local base_dir="$2"
+  local work_dir="${base_dir}/${label}-work"
+
+  mkdir -p "${work_dir}/scripts"
+  git init "${work_dir}" >/dev/null 2>&1
+  git -C "${work_dir}" config user.name "FaceTheory Test"
+  git -C "${work_dir}" config user.email "facetheory-test@example.com"
+
+  cp "${repo_root}/scripts/read-version.sh" "${work_dir}/scripts/read-version.sh"
+  chmod +x "${work_dir}/scripts/read-version.sh"
+  printf '%s # x-release-please-version\n' "3.1.2-rc" > "${work_dir}/VERSION"
+  printf '%s\n' "release source" > "${work_dir}/README.md"
+  git -C "${work_dir}" add VERSION README.md scripts/read-version.sh
+  git -C "${work_dir}" commit -m "test: seed release source" >/dev/null 2>&1
+
+  printf '%s\n' "${work_dir}"
+}
+
+write_fake_gh() {
+  local bin_dir="$1"
+  local tag="$2"
+  local target="$3"
+  local is_draft="$4"
+  local is_prerelease="$5"
+
+  mkdir -p "${bin_dir}"
+  cat > "${bin_dir}/gh" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\$1 \$2 \$3" != "release view ${tag}" ]]; then
+  echo "unexpected gh invocation: \$*" >&2
+  exit 1
+fi
+cat <<'JSON'
+{"tagName":"${tag}","targetCommitish":"${target}","isDraft":${is_draft},"isPrerelease":${is_prerelease},"url":"https://github.test/releases/${tag}"}
+JSON
+SH
+  chmod +x "${bin_dir}/gh"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+# Release Please draft releases are untagged until publish time. The asset builder
+# must accept a draft release whose targetCommitish is the checked-out release
+# commit, even though no git tag exists yet.
+work_a="$(setup_repo untagged-draft "${tmpdir}")"
+head_a="$(git -C "${work_a}" rev-parse HEAD)"
+bin_a="${tmpdir}/bin-a"
+write_fake_gh "${bin_a}" "v3.1.2-rc" "${head_a}" "true" "true"
+REPO_ROOT="${work_a}" GH_BIN="${bin_a}/gh" bash "${script_path}" "v3.1.2-rc" "HEAD" >/dev/null ||
+  fail "untagged draft target did not pass"
+
+# A draft release pointing somewhere other than the checked-out commit must fail
+# closed; otherwise assets can be built from different code than the release.
+work_b="$(setup_repo wrong-target "${tmpdir}")"
+head_b="$(git -C "${work_b}" rev-parse HEAD)"
+printf '%s\n' "wrong target" >> "${work_b}/README.md"
+git -C "${work_b}" add README.md
+git -C "${work_b}" commit -m "test: wrong target" >/dev/null 2>&1
+wrong_b="$(git -C "${work_b}" rev-parse HEAD)"
+bin_b="${tmpdir}/bin-b"
+write_fake_gh "${bin_b}" "v3.1.2-rc" "${wrong_b}" "true" "true"
+if REPO_ROOT="${work_b}" GH_BIN="${bin_b}/gh" bash "${script_path}" "v3.1.2-rc" "${head_b}" >/dev/null 2>&1; then
+  fail "wrong target unexpectedly passed"
+fi
+
+# The release must still be a draft before assets are uploaded; published releases
+# are immutable and must not be modified by this path.
+work_c="$(setup_repo published "${tmpdir}")"
+head_c="$(git -C "${work_c}" rev-parse HEAD)"
+bin_c="${tmpdir}/bin-c"
+write_fake_gh "${bin_c}" "v3.1.2-rc" "${head_c}" "false" "true"
+if REPO_ROOT="${work_c}" GH_BIN="${bin_c}/gh" bash "${script_path}" "v3.1.2-rc" "HEAD" >/dev/null 2>&1; then
+  fail "published release unexpectedly passed"
+fi
+
+echo "test-verify-release-draft-target: PASS"

--- a/scripts/verify-release-draft-target.sh
+++ b/scripts/verify-release-draft-target.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "${repo_root}"
+
+tag="${1:-${GITHUB_REF_NAME:-}}"
+expected_ref="${2:-HEAD}"
+
+if [[ -z "${tag}" ]]; then
+  echo "release-draft-target: FAIL (missing tag name)"
+  exit 1
+fi
+
+if [[ ! -f "VERSION" ]]; then
+  echo "release-draft-target: FAIL (missing VERSION)"
+  exit 1
+fi
+
+expected_version="$(./scripts/read-version.sh)"
+expected_tag="v${expected_version}"
+if [[ "${tag}" != "${expected_tag}" ]]; then
+  echo "release-draft-target: FAIL (tag ${tag} != ${expected_tag})"
+  exit 1
+fi
+
+expected_commit="$(git rev-parse "${expected_ref}^{commit}")"
+
+gh_bin="${GH_BIN:-gh}"
+if ! command -v "${gh_bin}" >/dev/null 2>&1; then
+  echo "release-draft-target: FAIL (${gh_bin} not found)"
+  exit 1
+fi
+
+release_json="$("${gh_bin}" release view "${tag}" --json tagName,targetCommitish,isDraft,isPrerelease,url 2>/dev/null || true)"
+if [[ -z "${release_json}" ]]; then
+  echo "release-draft-target: FAIL (draft release ${tag} not found)"
+  exit 1
+fi
+
+export RELEASE_JSON="${release_json}"
+mapfile -t release_fields < <(
+  python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["RELEASE_JSON"])
+print(data.get("tagName", ""))
+print(data.get("targetCommitish", ""))
+print("true" if data.get("isDraft") is True else "false")
+print("true" if data.get("isPrerelease") is True else "false")
+print(data.get("url", ""))
+PY
+)
+
+release_tag="${release_fields[0]:-}"
+target_commitish="${release_fields[1]:-}"
+is_draft="${release_fields[2]:-false}"
+is_prerelease="${release_fields[3]:-false}"
+release_url="${release_fields[4]:-}"
+
+if [[ "${release_tag}" != "${tag}" ]]; then
+  echo "release-draft-target: FAIL (release tag ${release_tag:-<empty>} != ${tag})"
+  exit 1
+fi
+
+if [[ "${is_draft}" != "true" ]]; then
+  echo "release-draft-target: FAIL (${tag} must still be a draft before asset upload)"
+  exit 1
+fi
+
+if [[ "${expected_version}" =~ -rc(\.|$) ]]; then
+  if [[ "${is_prerelease}" != "true" ]]; then
+    echo "release-draft-target: FAIL (${tag} must be marked prerelease)"
+    exit 1
+  fi
+elif [[ "${is_prerelease}" == "true" ]]; then
+  echo "release-draft-target: FAIL (${tag} stable release must not be marked prerelease)"
+  exit 1
+fi
+
+if [[ -z "${target_commitish}" ]]; then
+  echo "release-draft-target: FAIL (${tag} missing targetCommitish)"
+  exit 1
+fi
+
+resolve_target_commit() {
+  local ref="$1"
+
+  git rev-parse --verify --quiet "${ref}^{commit}" 2>/dev/null && return 0
+  git rev-parse --verify --quiet "refs/remotes/origin/${ref}^{commit}" 2>/dev/null && return 0
+
+  local remote="${GIT_REMOTE:-origin}"
+  local resolved=""
+  resolved="$(git ls-remote "${remote}" "refs/heads/${ref}" 2>/dev/null | awk 'NR == 1 { print $1 }' || true)"
+  if [[ -n "${resolved}" ]]; then
+    printf '%s\n' "${resolved}"
+    return 0
+  fi
+
+  resolved="$(git ls-remote "${remote}" "refs/tags/${ref}" 2>/dev/null | awk 'NR == 1 { print $1 }' || true)"
+  if [[ -n "${resolved}" ]]; then
+    printf '%s\n' "${resolved}"
+    return 0
+  fi
+
+  return 1
+}
+
+target_commit="$(resolve_target_commit "${target_commitish}" || true)"
+if [[ -z "${target_commit}" ]]; then
+  echo "release-draft-target: FAIL (could not resolve ${tag} targetCommitish ${target_commitish})"
+  exit 1
+fi
+
+if [[ "${target_commit}" != "${expected_commit}" ]]; then
+  echo "release-draft-target: FAIL (${tag} targets ${target_commit}, expected ${expected_commit})"
+  [[ -n "${release_url}" ]] && echo "release-draft-target: release ${release_url}"
+  exit 1
+fi
+
+echo "release-draft-target: PASS (${tag} -> ${expected_commit})"

--- a/scripts/verify-release-readiness.sh
+++ b/scripts/verify-release-readiness.sh
@@ -43,7 +43,9 @@ if [[ "${#changed_files[@]}" -gt 0 ]]; then
       | scripts/read-version.sh \
       | scripts/render-release-notes.sh \
       | scripts/verify-release-branch.sh \
+      | scripts/verify-release-draft-target.sh \
       | scripts/verify-release-readiness.sh \
+      | scripts/test-verify-release-draft-target.sh \
       | scripts/verify-ts-pack.sh \
       | scripts/verify-version-alignment.sh \
       | ts/README.md \


### PR DESCRIPTION
## Investigation

`Prerelease (premain)` failed on run `25949309731` after PR #168 (`chore(premain): release 3.1.2-rc`) merged. The failing job was `build-release-assets`; it tried to checkout `ref: v3.1.2-rc` before the release had been published.

Release Please created a draft GitHub Release with `tagName: v3.1.2-rc` and `targetCommitish: a265319...`, but GitHub represented it as an untagged draft release (`/releases/tag/untagged-...`) and there was no `refs/tags/v3.1.2-rc` yet. That made `actions/checkout` fail with: `A branch or tag with the name 'v3.1.2-rc' could not be found`.

## Fix

- Build stable and prerelease assets from the release commit (`github.sha`) instead of from the not-yet-created tag.
- Add `scripts/verify-release-draft-target.sh` to fail closed unless the draft release exists, is still draft, has the expected prerelease/stable flag, and targets the exact checked-out commit.
- Keep the existing branch/version verification after fetching `main`/`premain`.
- Harden failed draft cleanup to find untagged draft releases by release ID with retries, instead of relying on tag checkout semantics.
- Fix the existing-tag/manual asset workflow path to resolve an input draft release's `targetCommitish` before checkout. This path intentionally does not require the target commit itself to already contain the new verifier script, so the current untagged `v3.1.2-rc` draft can be recovered without inventing a tag by hand.
- Add `scripts/test-verify-release-draft-target.sh` and wire it into `make rubric` so this failure mode stays covered.

## Validation

- `./scripts/verify-version-alignment.sh`
- `make test-verify-release-draft-target`
- `scripts/verify-release-draft-target.sh v3.1.2-rc a265319752d82a74d288a198939cdca8ccecf071`
- `scripts/verify-release-branch.sh v3.1.2-rc`
- Local simulation of existing-draft source resolution for `v3.1.2-rc` returned `source_ref=a265319752d82a74d288a198939cdca8ccecf071`
- `make rubric`
- `git diff --check`

## Follow-up after merge

After this lands on `premain`, recover the current RC by dispatching the fixed asset path against `tag_name=v3.1.2-rc` from the corrected workflow ref, then verify the tag/release/assets before promotion.