### PR TITLE
fix(release): preserve changelog baselines

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -23,7 +23,7 @@ jobs:
   check-baseline:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     outputs:
       ready: ${{ steps.ready.outputs.ready }}
       stable_ready: ${{ steps.stable.outputs.ready }}

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -38,10 +38,14 @@ jobs:
 
       - name: Check stable release baseline
         id: stable
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
 
       - name: Check premain prerelease baseline
         id: prerelease
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json
 
       - name: Mark prerelease PR baseline readiness

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -25,7 +25,9 @@ jobs:
     permissions:
       contents: read
     outputs:
-      ready: ${{ steps.baseline.outputs.ready }}
+      ready: ${{ steps.ready.outputs.ready }}
+      stable_ready: ${{ steps.stable.outputs.ready }}
+      prerelease_ready: ${{ steps.prerelease.outputs.ready }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,8 +37,21 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && 'premain' || github.sha }}
 
       - name: Check stable release baseline
-        id: baseline
+        id: stable
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
+
+      - name: Check premain prerelease baseline
+        id: prerelease
+        run: scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json
+
+      - name: Mark prerelease PR baseline readiness
+        id: ready
+        run: |
+          if [[ "${{ steps.stable.outputs.ready }}" == "true" && "${{ steps.prerelease.outputs.ready }}" == "true" ]]; then
+            echo "ready=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "ready=false" >> "${GITHUB_OUTPUT}"
+          fi
 
   release-please:
     needs: check-baseline

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,7 +12,7 @@ jobs:
   check-baseline:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     outputs:
       ready: ${{ steps.baseline.outputs.ready }}
     steps:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Check stable release baseline
         id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
 
   release-please:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -55,7 +55,7 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout (for release assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -72,7 +72,7 @@ jobs:
 
       - name: Verify draft release targets this commit
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch
@@ -102,8 +102,6 @@ jobs:
       - name: Generate SHA-256 checksums
         run: scripts/generate-checksums.sh
 
-      - name: Render release notes template
-        run: scripts/render-release-notes.sh "${{ needs.release-please.outputs.tag_name }}"
 
       - name: Upload release asset bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -113,7 +111,6 @@ jobs:
             dist/theory-cloud-facetheory*.tgz
             dist/facetheory-reference-*.tar.gz
             dist/SHA256SUMS.txt
-            dist/RELEASE_NOTES.md
           if-no-files-found: error
 
   publish-prerelease:
@@ -182,7 +179,7 @@ jobs:
             exit 0
           fi
 
-          gh release edit "${TAG_NAME}" --draft=false --prerelease --notes-file dist/RELEASE_NOTES.md
+          gh release edit "${TAG_NAME}" --draft=false --prerelease
 
   cleanup-failed-draft:
     needs:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -23,7 +23,7 @@ jobs:
   check-baseline:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     outputs:
       ready: ${{ steps.ready.outputs.ready }}
       stable_ready: ${{ steps.baseline.outputs.ready }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Check current release baseline
         id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
 
       - name: Compute release-as (align to premain RC)
@@ -84,6 +86,8 @@ jobs:
       - name: Check premain release-candidate baseline
         id: premain
         if: steps.version.outputs.release_as != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json
 
       - name: Mark release PR baseline readiness

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -25,7 +25,9 @@ jobs:
     permissions:
       contents: read
     outputs:
-      ready: ${{ steps.baseline.outputs.ready }}
+      ready: ${{ steps.ready.outputs.ready }}
+      stable_ready: ${{ steps.baseline.outputs.ready }}
+      premain_ready: ${{ steps.premain.outputs.ready }}
       release_as: ${{ steps.version.outputs.release_as }}
     steps:
       - name: Checkout
@@ -78,6 +80,22 @@ jobs:
 
           echo "release_as=${release_as}" >> "${GITHUB_OUTPUT}"
           echo "release-as: ${release_as:-}"
+
+      - name: Check premain release-candidate baseline
+        id: premain
+        if: steps.version.outputs.release_as != ''
+        run: scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json
+
+      - name: Mark release PR baseline readiness
+        id: ready
+        run: |
+          if [[ "${{ steps.baseline.outputs.ready }}" != "true" ]]; then
+            echo "ready=false" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.version.outputs.release_as }}" != "" && "${{ steps.premain.outputs.ready }}" != "true" ]]; then
+            echo "ready=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "ready=true" >> "${GITHUB_OUTPUT}"
+          fi
 
   release-please:
     needs: check-baseline

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') || inputs.tag_name != ''
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Resolve release source ref
         id: source
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tag_name }}
         run: |
           set -euo pipefail
@@ -102,7 +102,7 @@ jobs:
 
       - name: Build assets for existing tag release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
           RELEASE_IS_DRAFT: ${{ steps.source.outputs.release_is_draft }}
           RELEASE_TARGET: ${{ steps.source.outputs.release_target }}
@@ -162,7 +162,6 @@ jobs:
           make rubric
           scripts/build-release-assets.sh "${TAG_NAME#v}" dist
           scripts/generate-checksums.sh
-          scripts/render-release-notes.sh "${TAG_NAME}"
 
       - name: Upload existing tag asset bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -172,7 +171,6 @@ jobs:
             dist/theory-cloud-facetheory*.tgz
             dist/facetheory-reference-*.tar.gz
             dist/SHA256SUMS.txt
-            dist/RELEASE_NOTES.md
           if-no-files-found: error
 
   publish-existing-tag-release:
@@ -234,7 +232,7 @@ jobs:
             prerelease_flag="--prerelease"
           fi
 
-          gh release edit "${TAG_NAME}" --draft=false ${prerelease_flag} --notes-file dist/RELEASE_NOTES.md
+          gh release edit "${TAG_NAME}" --draft=false ${prerelease_flag}
 
   stable-preflight:
     if: github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.tag_name == '')
@@ -358,7 +356,7 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout (for release assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -377,7 +375,7 @@ jobs:
 
       - name: Verify draft release targets this commit
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch
@@ -407,8 +405,6 @@ jobs:
       - name: Generate SHA-256 checksums
         run: scripts/generate-checksums.sh
 
-      - name: Render release notes template
-        run: scripts/render-release-notes.sh "${{ needs.release-please.outputs.tag_name }}"
 
       - name: Upload release asset bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -418,7 +414,6 @@ jobs:
             dist/theory-cloud-facetheory*.tgz
             dist/facetheory-reference-*.tar.gz
             dist/SHA256SUMS.txt
-            dist/RELEASE_NOTES.md
           if-no-files-found: error
 
   publish-release:
@@ -487,7 +482,7 @@ jobs:
             exit 0
           fi
 
-          gh release edit "${TAG_NAME}" --draft=false --notes-file dist/RELEASE_NOTES.md
+          gh release edit "${TAG_NAME}" --draft=false
 
   cleanup-failed-draft:
     needs:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin build-release-assets ensure-release-branches test-ensure-release-branches test-verify-release-draft-target stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets test-trigger-theorycloud-publish-awscurl rubric
+.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin build-release-assets ensure-release-branches test-ensure-release-branches test-verify-release-draft-target test-check-release-baseline-ready test-release-workflow-changelog-preservation stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets test-trigger-theorycloud-publish-awscurl rubric
 
 ts-build:
 	cd ts && npm run build
@@ -42,6 +42,12 @@ test-ensure-release-branches:
 test-verify-release-draft-target:
 	./scripts/test-verify-release-draft-target.sh
 
+test-check-release-baseline-ready:
+	./scripts/test-check-release-baseline-ready.sh
+
+test-release-workflow-changelog-preservation:
+	./scripts/test-release-workflow-changelog-preservation.sh
+
 stage-theorycloud-facetheory-subtree:
 	./scripts/stage_theorycloud_facetheory_subtree.sh --output "$${THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/facetheory-theorycloud}"
 
@@ -60,4 +66,4 @@ test-theorycloud-targets:
 test-trigger-theorycloud-publish-awscurl:
 	./scripts/test-trigger-theorycloud-publish-awscurl.sh
 
-rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin test-verify-release-draft-target
+rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin test-verify-release-draft-target test-check-release-baseline-ready test-release-workflow-changelog-preservation

--- a/scripts/check-release-baseline-ready.sh
+++ b/scripts/check-release-baseline-ready.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
+repo_root="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "${repo_root}"
 
 manifest_path="${1:-.release-please-manifest.json}"
 
@@ -11,7 +12,7 @@ if [[ ! -f "${manifest_path}" ]]; then
 fi
 
 version="$(
-  MANIFEST_PATH="${manifest_path}" python3 - <<'PY'
+  MANIFEST_PATH="${manifest_path}" python3 - <<'PYJSON'
 import json
 import os
 import re
@@ -27,15 +28,19 @@ if not re.match(r"^\d+\.\d+\.\d+(?:-rc(?:\.\d+)?)?$", version):
         f"{manifest} version {version!r} is not X.Y.Z, X.Y.Z-rc, or X.Y.Z-rc.N"
     )
 print(version)
-PY
+PYJSON
 )"
 
 tag="v${version}"
 ready="false"
 tag_ready="false"
 release_ready="false"
+release_state="missing"
 repo="${GITHUB_REPOSITORY:-}"
 api_url="${GITHUB_API_URL:-https://api.github.com}"
+git_remote="${GIT_REMOTE:-origin}"
+gh_bin="${GH_BIN:-gh}"
+curl_bin="${CURL_BIN:-curl}"
 
 if [[ -z "${repo}" ]]; then
   remote_url="$(git config --get remote.origin.url || true)"
@@ -54,20 +59,67 @@ if [[ -z "${repo}" ]]; then
   esac
 fi
 
-if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+if git ls-remote --exit-code --tags "${git_remote}" "refs/tags/${tag}" >/dev/null 2>&1; then
   tag_ready="true"
 fi
 
-if [[ -n "${repo}" ]] && command -v curl >/dev/null 2>&1; then
-  if curl \
+release_json=""
+if command -v "${gh_bin}" >/dev/null 2>&1; then
+  if [[ -n "${repo}" ]]; then
+    release_json="$("${gh_bin}" release view "${tag}" --repo "${repo}" --json tagName,isDraft,url 2>/dev/null || true)"
+  else
+    release_json="$("${gh_bin}" release view "${tag}" --json tagName,isDraft,url 2>/dev/null || true)"
+  fi
+fi
+
+if [[ -z "${release_json}" && -n "${repo}" ]] && command -v "${curl_bin}" >/dev/null 2>&1; then
+  tmp_release="$(mktemp)"
+  trap 'rm -f "${tmp_release:-}"' EXIT
+  auth_headers=()
+  api_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [[ -n "${api_token}" ]]; then
+    auth_headers+=(--header "Authorization: Bearer ${api_token}")
+  fi
+
+  if "${curl_bin}" \
     --fail \
     --silent \
     --location \
-    --output /dev/null \
+    --output "${tmp_release}" \
     --header "Accept: application/vnd.github+json" \
     --header "X-GitHub-Api-Version: 2022-11-28" \
+    "${auth_headers[@]}" \
     "${api_url%/}/repos/${repo}/releases/tags/${tag}"; then
-    release_ready="true"
+    release_json="$(cat "${tmp_release}")"
+  fi
+fi
+
+if [[ -n "${release_json}" ]]; then
+  mapfile -t release_fields < <(
+    RELEASE_JSON="${release_json}" python3 - <<'PYJSON'
+import json
+import os
+
+data = json.loads(os.environ["RELEASE_JSON"])
+print(data.get("tagName") or data.get("tag_name") or "")
+print("true" if data.get("isDraft", data.get("draft")) is True else "false")
+print(data.get("url") or data.get("html_url") or "")
+PYJSON
+  )
+
+  release_tag="${release_fields[0]:-}"
+  is_draft="${release_fields[1]:-false}"
+  release_url="${release_fields[2]:-}"
+
+  if [[ "${release_tag}" == "${tag}" ]]; then
+    if [[ "${is_draft}" == "true" ]]; then
+      release_state="draft"
+    else
+      release_ready="true"
+      release_state="published"
+    fi
+  else
+    release_state="tag-mismatch:${release_tag:-<empty>}"
   fi
 fi
 
@@ -76,14 +128,15 @@ if [[ "${tag_ready}" == "true" && "${release_ready}" == "true" ]]; then
 fi
 
 if [[ "${ready}" == "true" ]]; then
-  echo "release-baseline-ready: PASS (${tag} tag and GitHub Release exist)"
+  echo "release-baseline-ready: PASS (${tag} tag and published GitHub Release exist)"
 else
   echo "release-baseline-ready: SKIP (${tag} is not fully published; refusing to synthesize a stale changelist)"
-  echo "release-baseline-ready: tag=${tag_ready} release=${release_ready} repo=${repo:-unknown}"
+  echo "release-baseline-ready: tag=${tag_ready} release=${release_state} repo=${repo:-unknown}"
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "ready=${ready}" >> "${GITHUB_OUTPUT}"
   echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
   echo "version=${version}" >> "${GITHUB_OUTPUT}"
+  echo "release_state=${release_state}" >> "${GITHUB_OUTPUT}"
 fi

--- a/scripts/test-check-release-baseline-ready.sh
+++ b/scripts/test-check-release-baseline-ready.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${repo_root}/scripts/check-release-baseline-ready.sh"
+
+fail() {
+  echo "test-check-release-baseline-ready: FAIL ($*)"
+  exit 1
+}
+
+setup_remote_with_tag() {
+  local base_dir="$1"
+  local remote_dir="${base_dir}/remote.git"
+  local source_dir="${base_dir}/source"
+
+  git init --bare "${remote_dir}" >/dev/null 2>&1
+  git init "${source_dir}" >/dev/null 2>&1
+  git -C "${source_dir}" config user.name "FaceTheory Test"
+  git -C "${source_dir}" config user.email "facetheory-test@example.com"
+  printf '%s\n' seed > "${source_dir}/README.md"
+  git -C "${source_dir}" add README.md
+  git -C "${source_dir}" -c commit.gpgSign=false commit -m "test: seed" >/dev/null 2>&1
+  git -C "${source_dir}" -c tag.gpgSign=false tag --no-sign v1.2.3
+  git -C "${source_dir}" remote add origin "${remote_dir}"
+  git -C "${source_dir}" push origin v1.2.3 >/dev/null 2>&1
+
+  printf '%s\n' "${remote_dir}"
+}
+
+setup_work() {
+  local base_dir="$1"
+  local version="${2:-1.2.3}"
+  local work_dir="${base_dir}/work-${version}"
+
+  mkdir -p "${work_dir}"
+  cat > "${work_dir}/.release-please-manifest.json" <<JSON
+{
+  ".": "${version}"
+}
+JSON
+  printf '%s\n' "${work_dir}"
+}
+
+write_fake_gh() {
+  local bin_dir="$1"
+  local tag="$2"
+  local draft="$3"
+
+  mkdir -p "${bin_dir}"
+  cat > "${bin_dir}/gh" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\$1 \$2 \$3" != "release view ${tag}" ]]; then
+  echo "unexpected gh invocation: \$*" >&2
+  exit 1
+fi
+cat <<'JSON'
+{"tagName":"${tag}","isDraft":${draft},"url":"https://github.test/releases/${tag}"}
+JSON
+SH
+  chmod +x "${bin_dir}/gh"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+remote_dir="$(setup_remote_with_tag "${tmpdir}")"
+
+published_work="$(setup_work "${tmpdir}" "1.2.3")"
+published_bin="${tmpdir}/published-bin"
+write_fake_gh "${published_bin}" "v1.2.3" "false"
+published_out="$(
+  REPO_ROOT="${published_work}" \
+  GIT_REMOTE="${remote_dir}" \
+  GH_BIN="${published_bin}/gh" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}"
+)"
+printf '%s\n' "${published_out}" | grep -Fq 'release-baseline-ready: PASS' ||
+  fail "published tag/release baseline did not pass"
+
+draft_work="$(setup_work "${tmpdir}" "1.2.3")"
+draft_bin="${tmpdir}/draft-bin"
+write_fake_gh "${draft_bin}" "v1.2.3" "true"
+draft_out="$(
+  REPO_ROOT="${draft_work}" \
+  GIT_REMOTE="${remote_dir}" \
+  GH_BIN="${draft_bin}/gh" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}"
+)"
+printf '%s\n' "${draft_out}" | grep -Fq 'release=draft' ||
+  fail "draft release baseline was not rejected as draft"
+if printf '%s\n' "${draft_out}" | grep -Fq 'release-baseline-ready: PASS'; then
+  fail "draft release baseline unexpectedly passed"
+fi
+
+missing_tag_work="$(setup_work "${tmpdir}" "1.2.4")"
+missing_bin="${tmpdir}/missing-bin"
+write_fake_gh "${missing_bin}" "v1.2.4" "false"
+missing_out="$(
+  REPO_ROOT="${missing_tag_work}" \
+  GIT_REMOTE="${remote_dir}" \
+  GH_BIN="${missing_bin}/gh" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}"
+)"
+printf '%s\n' "${missing_out}" | grep -Fq 'tag=false' ||
+  fail "missing tag baseline was not rejected"
+
+output_file="${tmpdir}/github-output"
+REPO_ROOT="${draft_work}" \
+GIT_REMOTE="${remote_dir}" \
+GH_BIN="${draft_bin}/gh" \
+GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+GITHUB_OUTPUT="${output_file}" \
+bash "${script_path}" >/dev/null
+
+grep -Fxq 'ready=false' "${output_file}" || fail "GITHUB_OUTPUT missing ready=false for draft"
+grep -Fxq 'release_state=draft' "${output_file}" || fail "GITHUB_OUTPUT missing release_state=draft"
+
+echo "test-check-release-baseline-ready: PASS"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -27,4 +27,10 @@ grep -Fq 'scripts/check-release-baseline-ready.sh .release-please-manifest.prema
 grep -Fq "needs.check-baseline.outputs.ready == 'true'" .github/workflows/prerelease-pr.yml ||
   fail "prerelease-pr.yml must gate Release Please PR generation on combined baseline readiness"
 
+grep -Fq 'scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json' .github/workflows/release-pr.yml ||
+  fail "release-pr.yml must verify the premain RC baseline before generating an aligned stable release PR"
+
+grep -Fq 'steps.version.outputs.release_as }}" != "" &&' .github/workflows/release-pr.yml ||
+  fail "release-pr.yml must fail closed when an aligned stable release depends on an unpublished premain RC"
+
 echo "test-release-workflow-changelog-preservation: PASS"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+fail() {
+  echo "test-release-workflow-changelog-preservation: FAIL ($*)"
+  exit 1
+}
+
+for workflow in .github/workflows/prerelease.yml .github/workflows/release.yml; do
+  if grep -Fq -- '--notes-file' "${workflow}"; then
+    fail "${workflow} must not overwrite Release Please/GitHub-generated changelog notes with --notes-file"
+  fi
+  if grep -Fq 'render-release-notes.sh' "${workflow}"; then
+    fail "${workflow} must not render static release notes in the publication path"
+  fi
+  if grep -Fq 'RELEASE_NOTES.md' "${workflow}"; then
+    fail "${workflow} must not shuttle static RELEASE_NOTES.md artifacts into publication"
+  fi
+done
+
+grep -Fq 'scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json' .github/workflows/prerelease-pr.yml ||
+  fail "prerelease-pr.yml must verify the current premain prerelease baseline before generating the next RC PR"
+
+grep -Fq "needs.check-baseline.outputs.ready == 'true'" .github/workflows/prerelease-pr.yml ||
+  fail "prerelease-pr.yml must gate Release Please PR generation on combined baseline readiness"
+
+echo "test-release-workflow-changelog-preservation: PASS"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -33,4 +33,17 @@ grep -Fq 'scripts/check-release-baseline-ready.sh .release-please-manifest.prema
 grep -Fq 'steps.version.outputs.release_as }}" != "" &&' .github/workflows/release-pr.yml ||
   fail "release-pr.yml must fail closed when an aligned stable release depends on an unpublished premain RC"
 
+for workflow in .github/workflows/prerelease-pr.yml .github/workflows/release-pr.yml .github/workflows/prerelease.yml; do
+  python3 - "${workflow}" <<'PY' || fail "${workflow} check-baseline job must use contents: write for draft release visibility"
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1])
+text = workflow.read_text(encoding="utf-8")
+needle = "  check-baseline:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: write\n"
+if needle not in text:
+    raise SystemExit(1)
+PY
+done
+
 echo "test-release-workflow-changelog-preservation: PASS"

--- a/scripts/verify-release-readiness.sh
+++ b/scripts/verify-release-readiness.sh
@@ -39,9 +39,11 @@ if [[ "${#changed_files[@]}" -gt 0 ]]; then
       | docs/getting-started.md \
       | scripts/build-release-assets.sh \
       | scripts/check-release-baseline-ready.sh \
+      | scripts/test-check-release-baseline-ready.sh \
       | scripts/generate-checksums.sh \
       | scripts/read-version.sh \
       | scripts/render-release-notes.sh \
+      | scripts/test-release-workflow-changelog-preservation.sh \
       | scripts/verify-release-branch.sh \
       | scripts/verify-release-draft-target.sh \
       | scripts/verify-release-readiness.sh \


### PR DESCRIPTION
## What failed

The recovery fix in #169 was still incomplete:

- `Prerelease PR (premain)` only checked the stable manifest baseline before asking Release Please to compute the next RC. After the failed `v3.1.2-rc` publish, `.release-please-manifest.premain.json` said `3.1.2-rc` but the tag/release was not fully published, so Release Please swept old history and opened the bogus `v4.0.0-rc` PR.
- `Release PR (main)` could also align a stable release to a premain RC manifest without first proving that the RC baseline had been published.
- The release workflows rendered `dist/RELEASE_NOTES.md` and published it with `--notes-file`, replacing Release Please's generated changelog body with static generic release notes. That is why the GitHub Release notes looked unchanged across recent releases.
- The existing-draft recovery job also needed release credentials to read draft release metadata before checkout.

## Fix

- Require both the stable baseline and the current premain prerelease baseline to be fully published before `Prerelease PR (premain)` can generate the next RC PR.
- Require the premain RC baseline to be fully published before `Release PR (main)` can generate an aligned stable release PR.
- Harden `scripts/check-release-baseline-ready.sh` so a baseline is ready only when the git tag exists and the GitHub Release is published, not draft.
- Stop using static `RELEASE_NOTES.md` in release publication; publish drafts without `--notes-file` so Release Please/GitHub generated changelog notes are preserved.
- Give asset/recovery build jobs the release credentials needed to see draft release metadata.
- Add regression tests for baseline draft rejection and changelog-preserving workflow publication.

## Validation

- Local `make rubric` passed.
- PR CI `rubric`, typecheck/lint/test, npm pack, version alignment, and subtree path checks passed.
- `./scripts/check-release-baseline-ready.sh .release-please-manifest.json` passes for published `v3.1.1`.
- `./scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json` skips/fails closed for the current draft-only `v3.1.2-rc`.
- Confirmed the existing `v3.1.2-rc` draft body still contains the Release Please changelog; the fixed publication path will no longer overwrite it.

## Recovery after merge

1. Confirm no new bogus prerelease PR is generated from the premain merge.
2. Dispatch the existing draft recovery:

```bash
gh workflow run "Release (main)" --repo theory-cloud/FaceTheory --ref premain -f tag_name=v3.1.2-rc
```

3. Verify `v3.1.2-rc` is published as a prerelease with the expected assets, tag, and Release Please changelog body.
