### PR TITLE
fix(release): recover untagged draft releases

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -39,13 +39,13 @@ jobs:
       - name: Check stable release baseline
         id: stable
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
 
       - name: Check premain prerelease baseline
         id: prerelease
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json
 
       - name: Mark prerelease PR baseline readiness
@@ -70,7 +70,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: premain
           config-file: release-please-config.premain.json
           manifest-file: .release-please-manifest.premain.json

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check stable release baseline
         id: baseline
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
 
   release-please:
@@ -46,7 +46,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: premain
           config-file: release-please-config.premain.json
           manifest-file: .release-please-manifest.premain.json
@@ -74,7 +74,7 @@ jobs:
 
       - name: Verify draft release targets this commit
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
         run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch
@@ -124,64 +124,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout release workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
       - name: Download release asset bundle
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: facetheory-prerelease-assets
           path: dist
 
-      - name: Upload release assets
+      - name: Upload and publish draft prerelease assets
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          if [[ -z "${TAG_NAME}" ]]; then
-            echo "release-assets: FAIL (missing tag_name output)"
-            exit 1
-          fi
-
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft')"
-          if [[ "${is_draft}" != "true" ]]; then
-            echo "release-assets: FAIL (release is already published; cannot upload assets/notes under immutable releases)"
-            exit 1
-          fi
-
-          mapfile -t existing_assets < <(gh release view "${TAG_NAME}" --json assets --jq '.assets[].name' 2>/dev/null || true)
-
-          assets=(
-            dist/theory-cloud-facetheory*.tgz
-            dist/facetheory-reference-*.tar.gz
-            dist/SHA256SUMS.txt
-          )
-
-          for asset_glob in "${assets[@]}"; do
-            for asset_path in ${asset_glob}; do
-              asset_name="$(basename "${asset_path}")"
-              if printf '%s\n' "${existing_assets[@]}" | grep -Fxq "${asset_name}"; then
-                echo "release-assets: skip existing ${asset_name}"
-                continue
-              fi
-              gh release upload "${TAG_NAME}" "${asset_path}"
-            done
-          done
-
-      - name: Publish prerelease (immutable)
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          if [[ -z "${TAG_NAME}" ]]; then
-            echo "release-assets: FAIL (missing tag_name output)"
-            exit 1
-          fi
-
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft')"
-          if [[ "${is_draft}" != "true" ]]; then
-            echo "release-assets: skip publish (already published)"
-            exit 0
-          fi
-
-          gh release edit "${TAG_NAME}" --draft=false --prerelease
+        run: scripts/publish-draft-release-assets.sh "${TAG_NAME}" dist
 
   cleanup-failed-draft:
     needs:
@@ -205,7 +165,7 @@ jobs:
     steps:
       - name: Cleanup failed draft prerelease (no remnants)
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
           if [[ -z "${TAG_NAME}" ]]; then

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Check current release baseline
         id: baseline
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.json
 
       - name: Compute release-as (align to premain RC)
@@ -87,7 +87,7 @@ jobs:
         id: premain
         if: steps.version.outputs.release_as != ''
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
         run: scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json
 
       - name: Mark release PR baseline readiness
@@ -115,7 +115,7 @@ jobs:
         id: release_aligned
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -127,7 +127,7 @@ jobs:
         id: release_default
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,71 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      release_id: ${{ steps.source.outputs.release_id }}
     steps:
+      - name: Checkout release workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
       - name: Resolve release source ref
         id: source
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ inputs.tag_name }}
-        run: |
-          set -euo pipefail
-
-          if [[ -n "${TAG_NAME}" ]]; then
-            release_json="$(gh release view "${TAG_NAME}" --json tagName,targetCommitish,isDraft,isPrerelease,url 2>/dev/null || true)"
-            if [[ -z "${release_json}" ]]; then
-              echo "source_ref=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
-              echo "release_is_draft=false" >> "${GITHUB_OUTPUT}"
-              exit 0
-            fi
-
-            mapfile -t release_fields < <(
-              RELEASE_JSON="${release_json}" python3 - <<'PY'
-          import json
-          import os
-
-          data = json.loads(os.environ["RELEASE_JSON"])
-          print(data.get("tagName", ""))
-          print(data.get("targetCommitish", ""))
-          print("true" if data.get("isDraft") is True else "false")
-          print("true" if data.get("isPrerelease") is True else "false")
-          print(data.get("url", ""))
-          PY
-            )
-
-            release_tag="${release_fields[0]:-}"
-            target_commitish="${release_fields[1]:-}"
-            is_draft="${release_fields[2]:-false}"
-            is_prerelease="${release_fields[3]:-false}"
-            release_url="${release_fields[4]:-}"
-
-            if [[ "${release_tag}" != "${TAG_NAME}" ]]; then
-              echo "release-assets: FAIL (release tag ${release_tag:-<empty>} != ${TAG_NAME})"
-              exit 1
-            fi
-            if [[ -z "${target_commitish}" ]]; then
-              echo "release-assets: FAIL (${TAG_NAME} missing targetCommitish)"
-              exit 1
-            fi
-            if [[ "${is_draft}" == "true" ]]; then
-              if [[ "${TAG_NAME}" =~ -rc(\.|$) && "${is_prerelease}" != "true" ]]; then
-                echo "release-assets: FAIL (${TAG_NAME} draft must be marked prerelease)"
-                exit 1
-              fi
-              if [[ ! "${TAG_NAME}" =~ -rc(\.|$) && "${is_prerelease}" == "true" ]]; then
-                echo "release-assets: FAIL (${TAG_NAME} stable draft must not be marked prerelease)"
-                exit 1
-              fi
-              echo "release-assets: draft ${TAG_NAME} targets ${target_commitish} (${release_url})"
-            fi
-
-            echo "source_ref=${target_commitish}" >> "${GITHUB_OUTPUT}"
-            echo "release_is_draft=${is_draft}" >> "${GITHUB_OUTPUT}"
-            echo "release_target=${target_commitish}" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          echo "source_ref=${GITHUB_REF}" >> "${GITHUB_OUTPUT}"
-          echo "release_is_draft=false" >> "${GITHUB_OUTPUT}"
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
+        run: scripts/resolve-release-source-ref.sh "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout (for tag-triggered assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -102,7 +53,7 @@ jobs:
 
       - name: Build assets for existing tag release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
           RELEASE_IS_DRAFT: ${{ steps.source.outputs.release_is_draft }}
           RELEASE_TARGET: ${{ steps.source.outputs.release_target }}
@@ -180,59 +131,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout release workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
       - name: Download existing tag asset bundle
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: facetheory-existing-tag-assets
           path: dist
 
-      - name: Upload assets for existing tag release
+      - name: Upload and publish existing tag draft release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${TAG_NAME}" ]]; then
-            echo "release-assets: FAIL (missing tag ref_name)"
-            exit 1
-          fi
-
-          if ! gh release view "${TAG_NAME}" >/dev/null 2>&1; then
-            gh release create "${TAG_NAME}" --generate-notes --draft
-          fi
-
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft')"
-          if [[ "${is_draft}" != "true" ]]; then
-            echo "release-assets: FAIL (release is already published; immutable releases prevent adding assets/notes)"
-            exit 1
-          fi
-
-          mapfile -t existing_assets < <(gh release view "${TAG_NAME}" --json assets --jq '.assets[].name' 2>/dev/null || true)
-
-          assets=(
-            dist/theory-cloud-facetheory*.tgz
-            dist/facetheory-reference-*.tar.gz
-            dist/SHA256SUMS.txt
-          )
-
-          for asset_glob in "${assets[@]}"; do
-            for asset_path in ${asset_glob}; do
-              asset_name="$(basename "${asset_path}")"
-              if printf '%s\n' "${existing_assets[@]}" | grep -Fxq "${asset_name}"; then
-                echo "release-assets: skip existing ${asset_name}"
-                continue
-              fi
-              gh release upload "${TAG_NAME}" "${asset_path}"
-            done
-          done
-
-          prerelease_flag=""
-          if [[ "${TAG_NAME}" =~ -rc(\.|$) ]]; then
-            prerelease_flag="--prerelease"
-          fi
-
-          gh release edit "${TAG_NAME}" --draft=false ${prerelease_flag}
+        run: scripts/publish-draft-release-assets.sh "${TAG_NAME}" dist
 
   stable-preflight:
     if: github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || inputs.tag_name == '')
@@ -278,7 +194,7 @@ jobs:
 
       - name: Recover missing current stable Release Please state
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
         run: |
           set -euo pipefail
 
@@ -345,7 +261,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -375,7 +291,7 @@ jobs:
 
       - name: Verify draft release targets this commit
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
         run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch
@@ -425,64 +341,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout release workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
       - name: Download release asset bundle
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: facetheory-stable-assets
           path: dist
 
-      - name: Upload release assets
+      - name: Upload and publish draft release assets
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          if [[ -z "${TAG_NAME}" ]]; then
-            echo "release-assets: FAIL (missing tag_name output)"
-            exit 1
-          fi
-
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft')"
-          if [[ "${is_draft}" != "true" ]]; then
-            echo "release-assets: FAIL (release is already published; cannot upload assets/notes under immutable releases)"
-            exit 1
-          fi
-
-          mapfile -t existing_assets < <(gh release view "${TAG_NAME}" --json assets --jq '.assets[].name' 2>/dev/null || true)
-
-          assets=(
-            dist/theory-cloud-facetheory*.tgz
-            dist/facetheory-reference-*.tar.gz
-            dist/SHA256SUMS.txt
-          )
-
-          for asset_glob in "${assets[@]}"; do
-            for asset_path in ${asset_glob}; do
-              asset_name="$(basename "${asset_path}")"
-              if printf '%s\n' "${existing_assets[@]}" | grep -Fxq "${asset_name}"; then
-                echo "release-assets: skip existing ${asset_name}"
-                continue
-              fi
-              gh release upload "${TAG_NAME}" "${asset_path}"
-            done
-          done
-
-      - name: Publish release (immutable)
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          if [[ -z "${TAG_NAME}" ]]; then
-            echo "release-assets: FAIL (missing tag_name output)"
-            exit 1
-          fi
-
-          is_draft="$(gh release view "${TAG_NAME}" --json isDraft --jq '.isDraft')"
-          if [[ "${is_draft}" != "true" ]]; then
-            echo "release-assets: skip publish (already published)"
-            exit 0
-          fi
-
-          gh release edit "${TAG_NAME}" --draft=false
+        run: scripts/publish-draft-release-assets.sh "${TAG_NAME}" dist
 
   cleanup-failed-draft:
     needs:
@@ -506,7 +382,7 @@ jobs:
     steps:
       - name: Cleanup failed draft stable release (no remnants)
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
           if [[ -z "${TAG_NAME}" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin build-release-assets ensure-release-branches test-ensure-release-branches test-verify-release-draft-target test-check-release-baseline-ready test-release-workflow-changelog-preservation stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets test-trigger-theorycloud-publish-awscurl rubric
+.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin build-release-assets ensure-release-branches test-ensure-release-branches test-verify-release-draft-target test-check-release-baseline-ready test-resolve-release-source-ref test-publish-draft-release-assets test-release-workflow-changelog-preservation stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets test-trigger-theorycloud-publish-awscurl rubric
 
 ts-build:
 	cd ts && npm run build
@@ -48,6 +48,12 @@ test-check-release-baseline-ready:
 test-release-workflow-changelog-preservation:
 	./scripts/test-release-workflow-changelog-preservation.sh
 
+test-resolve-release-source-ref:
+	./scripts/test-resolve-release-source-ref.sh
+
+test-publish-draft-release-assets:
+	./scripts/test-publish-draft-release-assets.sh
+
 stage-theorycloud-facetheory-subtree:
 	./scripts/stage_theorycloud_facetheory_subtree.sh --output "$${THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/facetheory-theorycloud}"
 
@@ -66,4 +72,4 @@ test-theorycloud-targets:
 test-trigger-theorycloud-publish-awscurl:
 	./scripts/test-trigger-theorycloud-publish-awscurl.sh
 
-rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin test-verify-release-draft-target test-check-release-baseline-ready test-release-workflow-changelog-preservation
+rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin test-verify-release-draft-target test-check-release-baseline-ready test-resolve-release-source-ref test-publish-draft-release-assets test-release-workflow-changelog-preservation

--- a/scripts/check-release-baseline-ready.sh
+++ b/scripts/check-release-baseline-ready.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${REPO_ROOT:-$(cd "${script_dir}/.." && pwd)}"
 cd "${repo_root}"
 
 manifest_path="${1:-.release-please-manifest.json}"
@@ -65,11 +66,7 @@ fi
 
 release_json=""
 if command -v "${gh_bin}" >/dev/null 2>&1; then
-  if [[ -n "${repo}" ]]; then
-    release_json="$("${gh_bin}" release view "${tag}" --repo "${repo}" --json tagName,isDraft,url 2>/dev/null || true)"
-  else
-    release_json="$("${gh_bin}" release view "${tag}" --json tagName,isDraft,url 2>/dev/null || true)"
-  fi
+  release_json="$(GH_BIN="${gh_bin}" GITHUB_REPOSITORY="${repo}" "${script_dir}/release-json-by-tag.sh" "${tag}" 2>/dev/null || true)"
 fi
 
 if [[ -z "${release_json}" && -n "${repo}" ]] && command -v "${curl_bin}" >/dev/null 2>&1; then

--- a/scripts/publish-draft-release-assets.sh
+++ b/scripts/publish-draft-release-assets.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-}"
+dist_dir="${2:-dist}"
+gh_bin="${GH_BIN:-gh}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="${GITHUB_REPOSITORY:-}"
+if [[ -z "${tag}" ]]; then
+  echo "release-assets: FAIL (missing tag name)"
+  exit 1
+fi
+if [[ ! -d "${dist_dir}" ]]; then
+  echo "release-assets: FAIL (missing asset directory ${dist_dir})"
+  exit 1
+fi
+if ! command -v "${gh_bin}" >/dev/null 2>&1; then
+  echo "release-assets: FAIL (${gh_bin} not found)"
+  exit 1
+fi
+
+if [[ -z "${repo}" ]]; then
+  remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+  case "${remote_url}" in
+    https://github.com/*.git)
+      repo="${remote_url#https://github.com/}"
+      repo="${repo%.git}"
+      ;;
+    https://github.com/*)
+      repo="${remote_url#https://github.com/}"
+      ;;
+    git@github.com:*.git)
+      repo="${remote_url#git@github.com:}"
+      repo="${repo%.git}"
+      ;;
+  esac
+fi
+if [[ -z "${repo}" ]]; then
+  echo "release-assets: FAIL (missing GITHUB_REPOSITORY and could not infer repo)"
+  exit 1
+fi
+
+release_json="$(GH_BIN="${gh_bin}" GITHUB_REPOSITORY="${repo}" "${script_dir}/release-json-by-tag.sh" "${tag}" || true)"
+if [[ -z "${release_json}" ]]; then
+  echo "release-assets: FAIL (draft release ${tag} not found)"
+  exit 1
+fi
+
+mapfile -t release_fields < <(
+  RELEASE_JSON="${release_json}" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["RELEASE_JSON"])
+print(data.get("tagName") or data.get("tag_name") or "")
+print(str(data.get("id") or data.get("databaseId") or ""))
+print("true" if data.get("isDraft", data.get("draft")) is True else "false")
+print("true" if data.get("isPrerelease", data.get("prerelease")) is True else "false")
+print(data.get("uploadUrl") or data.get("upload_url") or "")
+print(data.get("url") or data.get("html_url") or "")
+PY
+)
+
+release_tag="${release_fields[0]:-}"
+release_id="${release_fields[1]:-}"
+is_draft="${release_fields[2]:-false}"
+is_prerelease="${release_fields[3]:-false}"
+upload_url="${release_fields[4]:-}"
+release_url="${release_fields[5]:-}"
+
+if [[ "${release_tag}" != "${tag}" ]]; then
+  echo "release-assets: FAIL (release tag ${release_tag:-<empty>} != ${tag})"
+  exit 1
+fi
+if [[ "${is_draft}" != "true" ]]; then
+  echo "release-assets: FAIL (release is already published; immutable releases prevent adding assets/notes)"
+  exit 1
+fi
+if [[ "${tag}" =~ -rc(\.|$) && "${is_prerelease}" != "true" ]]; then
+  echo "release-assets: FAIL (${tag} draft must be marked prerelease)"
+  exit 1
+fi
+if [[ ! "${tag}" =~ -rc(\.|$) && "${is_prerelease}" == "true" ]]; then
+  echo "release-assets: FAIL (${tag} stable draft must not be marked prerelease)"
+  exit 1
+fi
+
+assets=(
+  "${dist_dir}"/theory-cloud-facetheory*.tgz
+  "${dist_dir}"/facetheory-reference-*.tar.gz
+  "${dist_dir}"/SHA256SUMS.txt
+)
+
+shopt -s nullglob
+asset_paths=()
+for asset_glob in "${assets[@]}"; do
+  for asset_path in ${asset_glob}; do
+    asset_paths+=("${asset_path}")
+  done
+done
+shopt -u nullglob
+
+if [[ "${#asset_paths[@]}" -eq 0 ]]; then
+  echo "release-assets: FAIL (no release assets found in ${dist_dir})"
+  exit 1
+fi
+
+if [[ -n "${release_id}" ]]; then
+  mapfile -t existing_assets < <("${gh_bin}" api "repos/${repo}/releases/${release_id}/assets" --jq '.[].name' 2>/dev/null || true)
+  upload_base="${upload_url%%\{*}"
+  if [[ -z "${upload_base}" ]]; then
+    upload_base="https://uploads.github.com/repos/${repo}/releases/${release_id}/assets"
+  fi
+
+  for asset_path in "${asset_paths[@]}"; do
+    asset_name="$(basename "${asset_path}")"
+    if printf '%s\n' "${existing_assets[@]}" | grep -Fxq "${asset_name}"; then
+      echo "release-assets: skip existing ${asset_name}"
+      continue
+    fi
+    encoded_name="$(ASSET_NAME="${asset_name}" python3 - <<'PY'
+import os
+import urllib.parse
+print(urllib.parse.quote(os.environ["ASSET_NAME"]))
+PY
+)"
+    "${gh_bin}" api \
+      --method POST \
+      "${upload_base}?name=${encoded_name}" \
+      --header "Content-Type: application/octet-stream" \
+      --input "${asset_path}" \
+      >/dev/null
+  done
+
+  prerelease_field="false"
+  if [[ "${tag}" =~ -rc(\.|$) ]]; then
+    prerelease_field="true"
+  fi
+  "${gh_bin}" api \
+    --method PATCH \
+    "repos/${repo}/releases/${release_id}" \
+    -F draft=false \
+    -F prerelease="${prerelease_field}" \
+    >/dev/null
+  echo "release-assets: published ${tag}${release_url:+ (${release_url})}"
+  exit 0
+fi
+
+# Fallback for normal tagged drafts where the GitHub CLI can address the release by tag.
+mapfile -t existing_assets < <("${gh_bin}" release view "${tag}" --repo "${repo}" --json assets --jq '.assets[].name' 2>/dev/null || true)
+for asset_path in "${asset_paths[@]}"; do
+  asset_name="$(basename "${asset_path}")"
+  if printf '%s\n' "${existing_assets[@]}" | grep -Fxq "${asset_name}"; then
+    echo "release-assets: skip existing ${asset_name}"
+    continue
+  fi
+  "${gh_bin}" release upload "${tag}" "${asset_path}" --repo "${repo}"
+done
+
+prerelease_flag=""
+if [[ "${tag}" =~ -rc(\.|$) ]]; then
+  prerelease_flag="--prerelease"
+fi
+"${gh_bin}" release edit "${tag}" --repo "${repo}" --draft=false ${prerelease_flag}
+echo "release-assets: published ${tag}"

--- a/scripts/release-json-by-tag.sh
+++ b/scripts/release-json-by-tag.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-}"
+gh_bin="${GH_BIN:-gh}"
+repo="${GITHUB_REPOSITORY:-}"
+max_pages="${RELEASE_SEARCH_MAX_PAGES:-10}"
+
+if [[ -z "${tag}" ]]; then
+  echo "release-json-by-tag: FAIL (missing tag)" >&2
+  exit 1
+fi
+
+if ! command -v "${gh_bin}" >/dev/null 2>&1; then
+  echo "release-json-by-tag: FAIL (${gh_bin} not found)" >&2
+  exit 1
+fi
+
+if [[ -z "${repo}" ]]; then
+  remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+  case "${remote_url}" in
+    https://github.com/*.git)
+      repo="${remote_url#https://github.com/}"
+      repo="${repo%.git}"
+      ;;
+    https://github.com/*)
+      repo="${remote_url#https://github.com/}"
+      ;;
+    git@github.com:*.git)
+      repo="${remote_url#git@github.com:}"
+      repo="${repo%.git}"
+      ;;
+  esac
+fi
+
+if [[ -n "${repo}" ]]; then
+  page=1
+  while [[ "${page}" -le "${max_pages}" ]]; do
+    releases_json="$("${gh_bin}" api "repos/${repo}/releases?per_page=100&page=${page}" 2>/dev/null || true)"
+    [[ -z "${releases_json}" ]] && break
+
+    match="$(
+      printf '%s' "${releases_json}" | TAG_NAME="${tag}" python3 -c '''
+import json
+import os
+import sys
+
+tag = os.environ["TAG_NAME"]
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(0)
+if not isinstance(data, list):
+    sys.exit(0)
+for release in data:
+    if isinstance(release, dict) and release.get("tag_name") == tag:
+        wanted = (
+            "id",
+            "tag_name",
+            "target_commitish",
+            "draft",
+            "prerelease",
+            "html_url",
+            "upload_url",
+        )
+        print(json.dumps({key: release.get(key) for key in wanted if key in release}, separators=(",", ":")))
+        break
+'''
+    )"
+    if [[ -n "${match}" ]]; then
+      printf '%s\n' "${match}"
+      exit 0
+    fi
+
+    count="$(
+      printf '%s' "${releases_json}" | python3 -c '''
+import json
+import sys
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    print(0)
+else:
+    print(len(data) if isinstance(data, list) else 0)
+''' || printf '0'
+    )"
+    [[ "${count}" =~ ^[0-9]+$ ]] || count=0
+    [[ "${count}" -lt 100 ]] && break
+    page=$((page + 1))
+  done
+fi
+
+if [[ -n "${repo}" ]]; then
+  "${gh_bin}" release view "${tag}" \
+    --repo "${repo}" \
+    --json tagName,targetCommitish,isDraft,isPrerelease,url,databaseId,uploadUrl \
+    2>/dev/null || true
+else
+  "${gh_bin}" release view "${tag}" \
+    --json tagName,targetCommitish,isDraft,isPrerelease,url,databaseId,uploadUrl \
+    2>/dev/null || true
+fi

--- a/scripts/resolve-release-source-ref.sh
+++ b/scripts/resolve-release-source-ref.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-}"
+gh_bin="${GH_BIN:-gh}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -z "${tag}" ]]; then
+  echo "source_ref=${GITHUB_REF:-}"
+  echo "release_is_draft=false"
+  exit 0
+fi
+
+if ! command -v "${gh_bin}" >/dev/null 2>&1; then
+  echo "release-source-ref: FAIL (${gh_bin} not found)" >&2
+  exit 1
+fi
+
+release_json="$(GH_BIN="${gh_bin}" "${script_dir}/release-json-by-tag.sh" "${tag}" || true)"
+
+if [[ -z "${release_json}" ]]; then
+  echo "source_ref=${tag}"
+  echo "release_is_draft=false"
+  exit 0
+fi
+
+mapfile -t release_fields < <(
+  RELEASE_JSON="${release_json}" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["RELEASE_JSON"])
+print(data.get("tagName") or data.get("tag_name") or "")
+print(data.get("targetCommitish") or data.get("target_commitish") or "")
+print("true" if data.get("isDraft", data.get("draft")) is True else "false")
+print("true" if data.get("isPrerelease", data.get("prerelease")) is True else "false")
+print(data.get("url") or data.get("html_url") or "")
+print(str(data.get("id") or data.get("databaseId") or ""))
+PY
+)
+
+release_tag="${release_fields[0]:-}"
+target_commitish="${release_fields[1]:-}"
+is_draft="${release_fields[2]:-false}"
+is_prerelease="${release_fields[3]:-false}"
+release_url="${release_fields[4]:-}"
+release_id="${release_fields[5]:-}"
+
+if [[ "${release_tag}" != "${tag}" ]]; then
+  echo "release-source-ref: FAIL (release tag ${release_tag:-<empty>} != ${tag})" >&2
+  exit 1
+fi
+if [[ -z "${target_commitish}" ]]; then
+  echo "release-source-ref: FAIL (${tag} missing targetCommitish)" >&2
+  exit 1
+fi
+if [[ "${is_draft}" == "true" ]]; then
+  if [[ "${tag}" =~ -rc(\.|$) && "${is_prerelease}" != "true" ]]; then
+    echo "release-source-ref: FAIL (${tag} draft must be marked prerelease)" >&2
+    exit 1
+  fi
+  if [[ ! "${tag}" =~ -rc(\.|$) && "${is_prerelease}" == "true" ]]; then
+    echo "release-source-ref: FAIL (${tag} stable draft must not be marked prerelease)" >&2
+    exit 1
+  fi
+  echo "release-source-ref: draft ${tag} targets ${target_commitish} (${release_url})" >&2
+fi
+
+echo "source_ref=${target_commitish}"
+echo "release_is_draft=${is_draft}"
+echo "release_target=${target_commitish}"
+echo "release_id=${release_id}"

--- a/scripts/test-check-release-baseline-ready.sh
+++ b/scripts/test-check-release-baseline-ready.sh
@@ -46,18 +46,53 @@ write_fake_gh() {
   local bin_dir="$1"
   local tag="$2"
   local draft="$3"
+  local mode="${4:-api}"
 
   mkdir -p "${bin_dir}"
   cat > "${bin_dir}/gh" <<SH
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "\$1 \$2 \$3" != "release view ${tag}" ]]; then
-  echo "unexpected gh invocation: \$*" >&2
-  exit 1
+if [[ "\$1" == "api" ]]; then
+  endpoint="\$2"
+  case "\${endpoint}" in
+    repos/theory-cloud/FaceTheory/releases\\?per_page=100\\&page=1)
+      case "${mode}" in
+        api)
+          cat <<'JSON'
+[{"tag_name":"${tag}","draft":${draft},"html_url":"https://github.test/releases/${tag}","target_commitish":"1111111111111111111111111111111111111111","prerelease":false,"id":99}]
+JSON
+          ;;
+        empty|view)
+          printf '[]\\n'
+          ;;
+        *)
+          echo "unknown mode ${mode}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "unexpected gh api invocation: \$*" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
 fi
-cat <<'JSON'
+if [[ "\$1 \$2 \$3" == "release view ${tag}" ]]; then
+  case "${mode}" in
+    view)
+      cat <<'JSON'
 {"tagName":"${tag}","isDraft":${draft},"url":"https://github.test/releases/${tag}"}
 JSON
+      ;;
+    api|empty)
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+echo "unexpected gh invocation: \$*" >&2
+exit 1
 SH
   chmod +x "${bin_dir}/gh"
 }
@@ -69,7 +104,7 @@ remote_dir="$(setup_remote_with_tag "${tmpdir}")"
 
 published_work="$(setup_work "${tmpdir}" "1.2.3")"
 published_bin="${tmpdir}/published-bin"
-write_fake_gh "${published_bin}" "v1.2.3" "false"
+write_fake_gh "${published_bin}" "v1.2.3" "false" "api"
 published_out="$(
   REPO_ROOT="${published_work}" \
   GIT_REMOTE="${remote_dir}" \
@@ -82,7 +117,7 @@ printf '%s\n' "${published_out}" | grep -Fq 'release-baseline-ready: PASS' ||
 
 draft_work="$(setup_work "${tmpdir}" "1.2.3")"
 draft_bin="${tmpdir}/draft-bin"
-write_fake_gh "${draft_bin}" "v1.2.3" "true"
+write_fake_gh "${draft_bin}" "v1.2.3" "true" "api"
 draft_out="$(
   REPO_ROOT="${draft_work}" \
   GIT_REMOTE="${remote_dir}" \
@@ -96,9 +131,35 @@ if printf '%s\n' "${draft_out}" | grep -Fq 'release-baseline-ready: PASS'; then
   fail "draft release baseline unexpectedly passed"
 fi
 
+untagged_draft_work="$(setup_work "${tmpdir}" "1.2.3")"
+untagged_draft_bin="${tmpdir}/untagged-draft-bin"
+write_fake_gh "${untagged_draft_bin}" "v1.2.3" "true" "api"
+untagged_draft_out="$(
+  REPO_ROOT="${untagged_draft_work}" \
+  GIT_REMOTE="${remote_dir}" \
+  GH_BIN="${untagged_draft_bin}/gh" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}"
+)"
+printf '%s\n' "${untagged_draft_out}" | grep -Fq 'release=draft' ||
+  fail "untagged draft discovered only through releases list was not rejected as draft"
+
+fallback_work="$(setup_work "${tmpdir}" "1.2.3")"
+fallback_bin="${tmpdir}/fallback-bin"
+write_fake_gh "${fallback_bin}" "v1.2.3" "false" "view"
+fallback_out="$(
+  REPO_ROOT="${fallback_work}" \
+  GIT_REMOTE="${remote_dir}" \
+  GH_BIN="${fallback_bin}/gh" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}"
+)"
+printf '%s\n' "${fallback_out}" | grep -Fq 'release-baseline-ready: PASS' ||
+  fail "release view fallback baseline did not pass"
+
 missing_tag_work="$(setup_work "${tmpdir}" "1.2.4")"
 missing_bin="${tmpdir}/missing-bin"
-write_fake_gh "${missing_bin}" "v1.2.4" "false"
+write_fake_gh "${missing_bin}" "v1.2.4" "false" "api"
 missing_out="$(
   REPO_ROOT="${missing_tag_work}" \
   GIT_REMOTE="${remote_dir}" \

--- a/scripts/test-publish-draft-release-assets.sh
+++ b/scripts/test-publish-draft-release-assets.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${repo_root}/scripts/publish-draft-release-assets.sh"
+
+fail() {
+  echo "test-publish-draft-release-assets: FAIL ($*)"
+  exit 1
+}
+
+write_fake_gh() {
+  local bin_dir="$1"
+  mkdir -p "${bin_dir}"
+  cat > "${bin_dir}/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_GH_LOG}"
+if [[ "$1" == "api" ]]; then
+  shift
+  method="GET"
+  endpoint=""
+  input=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --method)
+        method="$2"
+        shift 2
+        ;;
+      --header|-H)
+        shift 2
+        ;;
+      --input)
+        input="$2"
+        shift 2
+        ;;
+      -F|--field)
+        shift 2
+        ;;
+      --jq)
+        jq_expr="$2"
+        shift 2
+        ;;
+      *)
+        if [[ -z "${endpoint}" ]]; then
+          endpoint="$1"
+        fi
+        shift
+        ;;
+    esac
+  done
+  case "${method} ${endpoint}" in
+    "GET repos/theory-cloud/FaceTheory/releases?per_page=100&page=1")
+      cat <<'JSON'
+[
+  {
+    "id": 99,
+    "tag_name": "v1.2.3-rc",
+    "target_commitish": "1111111111111111111111111111111111111111",
+    "draft": true,
+    "prerelease": true,
+    "upload_url": "https://uploads.github.com/repos/theory-cloud/FaceTheory/releases/99/assets{?name,label}",
+    "html_url": "https://github.test/releases/untagged"
+  }
+]
+JSON
+      ;;
+    "GET repos/theory-cloud/FaceTheory/releases/99/assets")
+      if [[ "${jq_expr:-}" == ".[].name" ]]; then
+        printf '%s\n' 'facetheory-reference-1.2.3-rc.tar.gz'
+      else
+        cat <<'JSON'
+[{"name":"facetheory-reference-1.2.3-rc.tar.gz"}]
+JSON
+      fi
+      ;;
+    "POST https://uploads.github.com/repos/theory-cloud/FaceTheory/releases/99/assets?name=theory-cloud-facetheory-1.2.3-rc.tgz"|"POST https://uploads.github.com/repos/theory-cloud/FaceTheory/releases/99/assets?name=SHA256SUMS.txt")
+      [[ -n "${input}" && -f "${input}" ]] || exit 1
+      printf '{"state":"uploaded"}\n'
+      ;;
+    "PATCH repos/theory-cloud/FaceTheory/releases/99")
+      printf '{"draft":false,"prerelease":true}\n'
+      ;;
+    *)
+      echo "unexpected gh api invocation: method=${method} endpoint=${endpoint}" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+if [[ "$1 $2" == "release view" ]]; then
+  echo "release view should not be used when releases list returns an id" >&2
+  exit 1
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+SH
+  chmod +x "${bin_dir}/gh"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+bin_dir="${tmpdir}/bin"
+dist_dir="${tmpdir}/dist"
+log_file="${tmpdir}/gh.log"
+mkdir -p "${dist_dir}"
+printf 'pkg' > "${dist_dir}/theory-cloud-facetheory-1.2.3-rc.tgz"
+printf 'ref' > "${dist_dir}/facetheory-reference-1.2.3-rc.tar.gz"
+printf 'sum' > "${dist_dir}/SHA256SUMS.txt"
+write_fake_gh "${bin_dir}"
+
+out="$(
+  FAKE_GH_LOG="${log_file}" \
+  GH_BIN="${bin_dir}/gh" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}" v1.2.3-rc "${dist_dir}"
+)"
+
+grep -Fq 'release-assets: skip existing facetheory-reference-1.2.3-rc.tar.gz' <<<"${out}" || fail "existing asset was not skipped"
+grep -Fq 'release-assets: published v1.2.3-rc' <<<"${out}" || fail "release was not published"
+grep -Fq 'POST https://uploads.github.com/repos/theory-cloud/FaceTheory/releases/99/assets?name=theory-cloud-facetheory-1.2.3-rc.tgz' "${log_file}" || fail "package asset upload missing"
+grep -Fq 'POST https://uploads.github.com/repos/theory-cloud/FaceTheory/releases/99/assets?name=SHA256SUMS.txt' "${log_file}" || fail "checksum upload missing"
+if grep -Fq 'POST https://uploads.github.com/repos/theory-cloud/FaceTheory/releases/99/assets?name=facetheory-reference-1.2.3-rc.tar.gz' "${log_file}"; then
+  fail "existing reference asset was uploaded"
+fi
+grep -Fq 'PATCH repos/theory-cloud/FaceTheory/releases/99' "${log_file}" || fail "publish patch missing"
+if grep -Fq 'release view' "${log_file}"; then
+  fail "script fell back to gh release view despite release id"
+fi
+
+echo "test-publish-draft-release-assets: PASS"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -21,6 +21,26 @@ for workflow in .github/workflows/prerelease.yml .github/workflows/release.yml; 
   fi
 done
 
+if grep -R -Fq 'secrets.GITHUB_TOKEN' .github/workflows; then
+  fail "workflows must fall back to github.token, not a non-existent secrets.GITHUB_TOKEN"
+fi
+
+if grep -R -F 'gh release create' .github/workflows scripts | grep -v 'scripts/test-release-workflow-changelog-preservation.sh'; then
+  fail "release recovery must not create GitHub Releases outside Release Please"
+fi
+
+grep -Fq 'scripts/resolve-release-source-ref.sh "${TAG_NAME}"' .github/workflows/release.yml ||
+  fail "release.yml must resolve existing draft source refs before checkout"
+
+grep -Fq 'Checkout release workflow scripts' .github/workflows/release.yml ||
+  fail "release.yml must checkout current workflow scripts before resolving an existing draft source"
+
+grep -Fq 'scripts/publish-draft-release-assets.sh "${TAG_NAME}" dist' .github/workflows/release.yml ||
+  fail "release.yml must publish draft assets through the release-id aware publisher"
+
+grep -Fq 'scripts/publish-draft-release-assets.sh "${TAG_NAME}" dist' .github/workflows/prerelease.yml ||
+  fail "prerelease.yml must publish draft assets through the release-id aware publisher"
+
 grep -Fq 'scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json' .github/workflows/prerelease-pr.yml ||
   fail "prerelease-pr.yml must verify the current premain prerelease baseline before generating the next RC PR"
 

--- a/scripts/test-resolve-release-source-ref.sh
+++ b/scripts/test-resolve-release-source-ref.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${repo_root}/scripts/resolve-release-source-ref.sh"
+
+fail() {
+  echo "test-resolve-release-source-ref: FAIL ($*)"
+  exit 1
+}
+
+write_fake_gh() {
+  local bin_dir="$1"
+  mkdir -p "${bin_dir}"
+  cat > "${bin_dir}/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_GH_LOG}"
+if [[ "$1" == "api" ]]; then
+  endpoint="$2"
+  case "${endpoint}" in
+    repos/theory-cloud/FaceTheory/releases\?per_page=100\&page=1)
+      case "${FAKE_RELEASE_MODE}" in
+        draft)
+          cat <<'JSON'
+[
+  {
+    "id": 99,
+    "tag_name": "v1.2.3-rc",
+    "target_commitish": "1111111111111111111111111111111111111111",
+    "draft": true,
+    "prerelease": true,
+    "html_url": "https://github.test/releases/untagged"
+  }
+]
+JSON
+          ;;
+        none|fallback)
+          printf '[]\n'
+          ;;
+        *)
+          echo "unknown FAKE_RELEASE_MODE=${FAKE_RELEASE_MODE}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "unexpected gh api endpoint: ${endpoint}" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+if [[ "$1 $2" == "release view" ]]; then
+  if [[ "${FAKE_RELEASE_MODE}" == "fallback" ]]; then
+    cat <<'JSON'
+{"tagName":"v1.2.3","targetCommitish":"2222222222222222222222222222222222222222","isDraft":false,"isPrerelease":false,"url":"https://github.test/releases/v1.2.3","databaseId":100}
+JSON
+    exit 0
+  fi
+  exit 1
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+SH
+  chmod +x "${bin_dir}/gh"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+bin_dir="${tmpdir}/bin"
+log_file="${tmpdir}/gh.log"
+write_fake_gh "${bin_dir}"
+
+draft_out="$(
+  FAKE_GH_LOG="${log_file}" \
+  FAKE_RELEASE_MODE=draft \
+  GH_BIN="${bin_dir}/gh" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}" v1.2.3-rc \
+    2>"${tmpdir}/draft.err"
+)"
+
+grep -Fxq 'source_ref=1111111111111111111111111111111111111111' <<<"${draft_out}" || fail "draft source_ref did not use target_commitish"
+grep -Fxq 'release_is_draft=true' <<<"${draft_out}" || fail "draft output missing release_is_draft=true"
+grep -Fxq 'release_target=1111111111111111111111111111111111111111' <<<"${draft_out}" || fail "draft output missing release_target"
+grep -Fxq 'release_id=99' <<<"${draft_out}" || fail "draft output missing release_id"
+grep -Fq 'release-source-ref: draft v1.2.3-rc targets 1111111111111111111111111111111111111111' "${tmpdir}/draft.err" || fail "draft stderr did not describe resolved target"
+if grep -Fq 'release view v1.2.3-rc' "${log_file}"; then
+  fail "draft lookup fell through to release view despite list API match"
+fi
+
+none_out="$(
+  FAKE_GH_LOG="${log_file}" \
+  FAKE_RELEASE_MODE=none \
+  GH_BIN="${bin_dir}/gh" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}" v9.9.9
+)"
+grep -Fxq 'source_ref=v9.9.9' <<<"${none_out}" || fail "missing release should fall back to tag ref"
+grep -Fxq 'release_is_draft=false' <<<"${none_out}" || fail "missing release should not be draft"
+
+fallback_out="$(
+  FAKE_GH_LOG="${log_file}" \
+  FAKE_RELEASE_MODE=fallback \
+  GH_BIN="${bin_dir}/gh" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}" v1.2.3
+)"
+grep -Fxq 'source_ref=2222222222222222222222222222222222222222' <<<"${fallback_out}" || fail "release view fallback did not resolve source_ref"
+grep -Fxq 'release_is_draft=false' <<<"${fallback_out}" || fail "published release fallback should not be draft"
+
+empty_out="$(GITHUB_REF='refs/heads/premain' bash "${script_path}")"
+grep -Fxq 'source_ref=refs/heads/premain' <<<"${empty_out}" || fail "empty tag should use GITHUB_REF"
+grep -Fxq 'release_is_draft=false' <<<"${empty_out}" || fail "empty tag should not be draft"
+
+echo "test-resolve-release-source-ref: PASS"

--- a/scripts/verify-release-draft-target.sh
+++ b/scripts/verify-release-draft-target.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${REPO_ROOT:-$(cd "${script_dir}/.." && pwd)}"
 cd "${repo_root}"
 
 tag="${1:-${GITHUB_REF_NAME:-}}"
@@ -32,7 +33,7 @@ if ! command -v "${gh_bin}" >/dev/null 2>&1; then
   exit 1
 fi
 
-release_json="$("${gh_bin}" release view "${tag}" --json tagName,targetCommitish,isDraft,isPrerelease,url 2>/dev/null || true)"
+release_json="$(GH_BIN="${gh_bin}" "${script_dir}/release-json-by-tag.sh" "${tag}" 2>/dev/null || true)"
 if [[ -z "${release_json}" ]]; then
   echo "release-draft-target: FAIL (draft release ${tag} not found)"
   exit 1
@@ -45,11 +46,11 @@ import json
 import os
 
 data = json.loads(os.environ["RELEASE_JSON"])
-print(data.get("tagName", ""))
-print(data.get("targetCommitish", ""))
-print("true" if data.get("isDraft") is True else "false")
-print("true" if data.get("isPrerelease") is True else "false")
-print(data.get("url", ""))
+print(data.get("tagName") or data.get("tag_name") or "")
+print(data.get("targetCommitish") or data.get("target_commitish") or "")
+print("true" if data.get("isDraft", data.get("draft")) is True else "false")
+print("true" if data.get("isPrerelease", data.get("prerelease")) is True else "false")
+print(data.get("url") or data.get("html_url") or "")
 PY
 )
 

--- a/scripts/verify-release-readiness.sh
+++ b/scripts/verify-release-readiness.sh
@@ -39,7 +39,12 @@ if [[ "${#changed_files[@]}" -gt 0 ]]; then
       | docs/getting-started.md \
       | scripts/build-release-assets.sh \
       | scripts/check-release-baseline-ready.sh \
+      | scripts/release-json-by-tag.sh \
+      | scripts/resolve-release-source-ref.sh \
+      | scripts/publish-draft-release-assets.sh \
       | scripts/test-check-release-baseline-ready.sh \
+      | scripts/test-resolve-release-source-ref.sh \
+      | scripts/test-publish-draft-release-assets.sh \
       | scripts/generate-checksums.sh \
       | scripts/read-version.sh \
       | scripts/render-release-notes.sh \


### PR DESCRIPTION
## Summary

Fixes the second failed `v3.1.2-rc` recovery path by making release recovery address Release Please draft releases by release metadata/ID instead of assuming a git tag already exists.

## Root cause

The existing recovery path still depended on `gh release view <tag>` before checkout/publish. The failed `v3.1.2-rc` Release Please output is an untagged draft release: it has `tag_name=v3.1.2-rc` and target commit `a265319752d82a74d288a198939cdca8ccecf071`, but no git tag yet. In Actions, that caused the recovery job to fall back to checking out `v3.1.2-rc` as a git ref, which does not exist.

## Changes

- Add `scripts/release-json-by-tag.sh` to discover releases by listing release metadata first, which finds untagged drafts.
- Add `scripts/resolve-release-source-ref.sh` and have the existing-tag asset job checkout current workflow scripts before resolving the draft target commit.
- Add `scripts/publish-draft-release-assets.sh` so publishing uploads by release ID/upload URL and publishes the draft without overwriting Release Please changelog notes.
- Use `github.token` as the workflow fallback instead of the non-existent `secrets.GITHUB_TOKEN` fallback.
- Make baseline and draft-target checks use the same untagged-draft-safe release lookup.
- Add regression coverage for untagged draft source resolution, release-ID asset publishing, draft baseline rejection, and changelog preservation.

## Validation

- `make rubric`
- Real metadata check: `scripts/resolve-release-source-ref.sh v3.1.2-rc` resolves `a265319752d82a74d288a198939cdca8ccecf071` and release id `323556875`.
- Real baseline check still fails closed for `.release-please-manifest.premain.json` while `v3.1.2-rc` is draft/unpublished.