### PR TITLE
fix(release): scan readiness commits without pipefail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin build-release-assets ensure-release-branches test-ensure-release-branches test-verify-release-draft-target test-check-release-baseline-ready test-resolve-release-source-ref test-publish-draft-release-assets test-release-workflow-changelog-preservation stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets test-trigger-theorycloud-publish-awscurl rubric
+.PHONY: ts-build ts-typecheck ts-lint ts-format ts-format-check ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin build-release-assets ensure-release-branches test-ensure-release-branches test-verify-release-draft-target test-check-release-baseline-ready test-resolve-release-source-ref test-publish-draft-release-assets test-verify-release-readiness test-release-workflow-changelog-preservation stage-theorycloud-facetheory-subtree verify-theorycloud-facetheory-subtree sync-theorycloud-facetheory-subtree trigger-theorycloud-publish test-theorycloud-targets test-trigger-theorycloud-publish-awscurl rubric
 
 ts-build:
 	cd ts && npm run build
@@ -54,6 +54,9 @@ test-resolve-release-source-ref:
 test-publish-draft-release-assets:
 	./scripts/test-publish-draft-release-assets.sh
 
+test-verify-release-readiness:
+	./scripts/test-verify-release-readiness.sh
+
 stage-theorycloud-facetheory-subtree:
 	./scripts/stage_theorycloud_facetheory_subtree.sh --output "$${THEORYCLOUD_FACETHEORY_SUBTREE_OUTPUT_DIR:-/tmp/facetheory-theorycloud}"
 
@@ -72,4 +75,4 @@ test-theorycloud-targets:
 test-trigger-theorycloud-publish-awscurl:
 	./scripts/test-trigger-theorycloud-publish-awscurl.sh
 
-rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin test-verify-release-draft-target test-check-release-baseline-ready test-resolve-release-source-ref test-publish-draft-release-assets test-release-workflow-changelog-preservation
+rubric: ts-typecheck ts-lint ts-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin test-verify-release-draft-target test-check-release-baseline-ready test-resolve-release-source-ref test-publish-draft-release-assets test-verify-release-readiness test-release-workflow-changelog-preservation

--- a/scripts/test-verify-release-readiness.sh
+++ b/scripts/test-verify-release-readiness.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_path="${repo_root}/scripts/verify-release-readiness.sh"
+
+fail() {
+  echo "test-verify-release-readiness: FAIL ($*)"
+  exit 1
+}
+
+setup_repo() {
+  local work_dir="$1"
+  git init "${work_dir}" >/dev/null 2>&1
+  git -C "${work_dir}" config user.name "FaceTheory Test"
+  git -C "${work_dir}" config user.email "facetheory-test@example.com"
+  printf '%s\n' seed > "${work_dir}/README.md"
+  git -C "${work_dir}" add README.md
+  git -C "${work_dir}" -c commit.gpgSign=false commit -m "chore: seed" >/dev/null 2>&1
+  git -C "${work_dir}" branch -M main
+  git -C "${work_dir}" branch base
+}
+
+copy_script() {
+  local work_dir="$1"
+  mkdir -p "${work_dir}/scripts"
+  cp "${script_path}" "${work_dir}/scripts/verify-release-readiness.sh"
+  chmod +x "${work_dir}/scripts/verify-release-readiness.sh"
+  printf '%s\n' "${work_dir}/scripts/verify-release-readiness.sh"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+# Regression for a pipefail/SIGPIPE bug: the old implementation piped
+# `git log` into `grep -q`; with `pipefail`, a conventional commit near the
+# beginning of a long range could make grep exit before git log finished and
+# incorrectly fail release readiness.
+work_dir="${tmpdir}/with-fix"
+setup_repo "${work_dir}"
+work_script="$(copy_script "${work_dir}")"
+for i in $(seq 1 180); do
+  printf 'doc %s\n' "${i}" > "${work_dir}/docs-${i}.md"
+  git -C "${work_dir}" add "docs-${i}.md"
+  git -C "${work_dir}" -c commit.gpgSign=false commit -m "docs: filler ${i}" >/dev/null 2>&1
+done
+printf '%s\n' fix > "${work_dir}/fix.txt"
+git -C "${work_dir}" add fix.txt
+git -C "${work_dir}" -c commit.gpgSign=false commit -m "fix(release): exercise readiness scan" >/dev/null 2>&1
+with_fix_out="$(cd "${work_dir}" && bash "${work_script}" base HEAD release)"
+printf '%s\n' "${with_fix_out}" | grep -Fq 'release-readiness: OK' ||
+  fail "range with conventional fix did not pass"
+
+# Pure release-sync changes are allowed even without feat/fix/perf commits.
+sync_dir="${tmpdir}/sync-only"
+setup_repo "${sync_dir}"
+sync_script="$(copy_script "${sync_dir}")"
+printf '%s\n' '# release sync test change' >> "${sync_dir}/scripts/verify-release-readiness.sh"
+git -C "${sync_dir}" add scripts/verify-release-readiness.sh
+git -C "${sync_dir}" -c commit.gpgSign=false commit -m "chore(release): update readiness helper" >/dev/null 2>&1
+sync_out="$(cd "${sync_dir}" && bash "${sync_script}" base HEAD release)"
+printf '%s\n' "${sync_out}" | grep -Fq 'release-readiness: OK (release sync only change)' ||
+  fail "release sync-only change did not pass"
+
+# Non-release-sync changes without a conventional release commit still fail.
+fail_dir="${tmpdir}/no-release-signal"
+setup_repo "${fail_dir}"
+fail_script="$(copy_script "${fail_dir}")"
+printf '%s\n' note > "${fail_dir}/src.txt"
+git -C "${fail_dir}" add src.txt
+git -C "${fail_dir}" -c commit.gpgSign=false commit -m "docs: not releasable" >/dev/null 2>&1
+if (cd "${fail_dir}" && bash "${fail_script}" base HEAD release >/tmp/readiness-fail.out 2>&1); then
+  fail "non-release change without conventional release commit unexpectedly passed"
+fi
+grep -Fq 'release-readiness: FAIL' /tmp/readiness-fail.out ||
+  fail "failure output missing release-readiness: FAIL"
+
+echo "test-verify-release-readiness: PASS"

--- a/scripts/verify-release-readiness.sh
+++ b/scripts/verify-release-readiness.sh
@@ -16,10 +16,14 @@ range="${base_ref}..${head_ref}"
 diff_range="${base_ref}...${head_ref}"
 
 echo "Checking commits in ${range}..."
-if git log --format=%s "${range}" | grep -Eq '^(feat|fix|perf)(\([^)]+\))?(!)?: '; then
-  echo "${context_label}-readiness: OK"
-  exit 0
-fi
+release_commit_subject_regex='^(feat|fix|perf)(\([^)]+\))?(!)?:[[:space:]]'
+mapfile -t commit_subjects < <(git log --format=%s "${range}")
+for subject in "${commit_subjects[@]}"; do
+  if [[ "${subject}" =~ ${release_commit_subject_regex} ]]; then
+    echo "${context_label}-readiness: OK"
+    exit 0
+  fi
+done
 
 mapfile -t changed_files < <(git diff --name-only --diff-filter=ACMR "${diff_range}")
 if [[ "${#changed_files[@]}" -gt 0 ]]; then
@@ -53,6 +57,7 @@ if [[ "${#changed_files[@]}" -gt 0 ]]; then
       | scripts/verify-release-draft-target.sh \
       | scripts/verify-release-readiness.sh \
       | scripts/test-verify-release-draft-target.sh \
+      | scripts/test-verify-release-readiness.sh \
       | scripts/verify-ts-pack.sh \
       | scripts/verify-version-alignment.sh \
       | ts/README.md \
@@ -78,5 +83,5 @@ echo "No user-facing conventional commits (feat:/fix:/perf:) found in ${range}."
 echo "release-please will skip, so no new release PR will be cut."
 echo
 echo "Commit subjects:"
-git log --format=%s "${range}" || true
+printf '%s\n' "${commit_subjects[@]}"
 exit 1


### PR DESCRIPTION
## Summary

Fixes the `Release readiness (PR -> main)` failure on the premain-to-main PR.

## Root cause

`scripts/verify-release-readiness.sh` ran:

```bash
git log --format=%s "$range" | grep -Eq '...'
```

under `set -euo pipefail`. When `grep -q` found a conventional commit early, it exited before `git log` finished writing the rest of the range. `git log` could then receive SIGPIPE, making the whole pipeline fail even though a valid `fix:` commit existed. That is why PR #173 printed multiple `fix(...)` subjects and still reported “No user-facing conventional commits”.

## Changes

- Materialize commit subjects with `mapfile` and scan them in Bash instead of using a `git log | grep -q` pipe under `pipefail`.
- Reuse the materialized subjects for the failure report.
- Add `scripts/test-verify-release-readiness.sh` covering:
  - long commit ranges with a conventional `fix:` commit;
  - release-sync-only changes;
  - non-release changes without a release signal.
- Add the new test to `make rubric`.

## Validation

- `scripts/verify-release-readiness.sh origin/main origin/premain release` now passes locally.
- `make rubric` passed.