### PR TITLE
fix(release): avoid blob churn in readiness harness

### DIFF
--- a/scripts/test-verify-release-readiness.sh
+++ b/scripts/test-verify-release-readiness.sh
@@ -25,6 +25,17 @@ commit_file() {
     commit -m "${message}" >/dev/null
 }
 
+commit_empty() {
+  local work_dir="$1"
+  local message="$2"
+
+  git -C "${work_dir}" \
+    -c commit.gpgSign=false \
+    -c tag.gpgSign=false \
+    -c core.hooksPath=/dev/null \
+    commit --allow-empty -m "${message}" >/dev/null
+}
+
 assert_contains() {
   local haystack="$1"
   local needle="$2"
@@ -58,20 +69,18 @@ trap 'rm -rf "${tmpdir}"' EXIT
 
 # Regression for a pipefail/SIGPIPE bug: the old implementation piped
 # `git log` into `grep -q`; with `pipefail`, a conventional commit near the
-# beginning of a multi-commit range could make grep exit before git log
-# finished and incorrectly fail release readiness. Keep this range large
-# enough to exercise non-trivial scanning but small enough to avoid GitHub
-# runner temp-repo object flakiness.
+# beginning of a long range could make grep exit before git log finished and
+# incorrectly fail release readiness. Use empty filler commits so this test
+# stresses commit-subject scanning without creating throwaway blob objects in
+# GitHub runner temp repos.
 work_dir="${tmpdir}/with-fix"
 current_case="setup with conventional fix"
 setup_repo "${work_dir}"
 work_script="$(copy_script "${work_dir}")"
-for i in $(seq 1 24); do
-  printf 'doc %s\n' "${i}" > "${work_dir}/docs-${i}.md"
-  commit_file "${work_dir}" "docs: filler ${i}" "docs-${i}.md"
+for i in $(seq 1 180); do
+  commit_empty "${work_dir}" "docs: filler ${i}"
 done
-printf '%s\n' fix > "${work_dir}/fix.txt"
-commit_file "${work_dir}" "fix(release): exercise readiness scan" fix.txt
+commit_empty "${work_dir}" "fix(release): exercise readiness scan"
 current_case="range with conventional fix"
 with_fix_out="$(cd "${work_dir}" && bash "${work_script}" base HEAD release)"
 assert_contains "${with_fix_out}" 'release-readiness: OK' "range with conventional fix"


### PR DESCRIPTION
## Summary

Fixes the remaining `rubric` failure on the `premain` push workflow after #176 merged. The release-readiness harness was still creating throwaway blob objects for the long-range regression test; GitHub Actions intermittently failed while building temp-repo trees with `invalid object ... docs-24.md`.

## Root cause / risk

The production readiness script is already fixed and the PR-context `rubric` pass proved the command can succeed. The failing path is isolated to the disposable test repository in `scripts/test-verify-release-readiness.sh` under the push workflow.

The long-range regression only needs many commit subjects to verify the old `git log | grep -q` / `pipefail` / SIGPIPE class. It does not need per-commit file blobs.

## Changes

- Add a `commit_empty` helper for disposable test repos.
- Use empty filler commits for the long-range readiness regression.
- Restore the long range to 180 commits while avoiding throwaway blob churn.
- Keep file-backed commits for the sync-only and fail-closed cases where changed-file detection is the behavior under test.

## Validation

- `./scripts/test-verify-release-readiness.sh`
- `make test-verify-release-readiness`
- `make rubric`

## Release context

This is required before #173 can merge cleanly to `main`; it does not create or mutate tags, releases, or assets.
