### PR TITLE
feat(csp): add strict csp core contracts

### DIFF
--- a/docs/planning/ENUMERATED_CHANGES_STRICT_CSP_HYDRATION_NAVIGATION.md
+++ b/docs/planning/ENUMERATED_CHANGES_STRICT_CSP_HYDRATION_NAVIGATION.md
@@ -1,0 +1,182 @@
+# Enumerated Changes: Strict CSP Hydration and Navigation
+
+Source scope: `docs/planning/SCOPED_NEED_STRICT_CSP_HYDRATION_NAVIGATION.md`.
+
+Decision locked for this enumeration: deliver strict no-inline CSP as an additive FaceTheory core capability, not a new render mode. The first implementation uses an explicit policy object, evolves hydration into an inline/external discriminated union while preserving the legacy inline shape, starts SSR with consumer-provided same-origin `dataUrl`, derives ISR sidecars from cached HTML pointers when possible, certifies FaceTheory-owned surfaces first, fails closed for uncertifiable streaming, rejects raw Svelte SSR `head` in strict mode, and keeps final CSP header attachment explicit.
+
+### 1. Add strict-CSP policy and hydration type contracts
+
+- **Paths**: `ts/src/types.ts`, `ts/src/index.ts`, `ts/test/unit/head.test.ts` or new focused type/contract tests
+- **Layer**: core / public API
+- **Render mode impact**: all
+- **Determinism-sensitive**: yes — this defines the public hydration boundary and CSP invariant consumed by all render modes and adapters.
+- **Acceptance**: FaceTheory exposes adapter-neutral `FaceCspPolicy`/strict-CSP option types and a backward-compatible `FaceHydration` shape that can represent legacy inline hydration and external hydration by URL without changing current output.
+- **Validation**: `cd ts && npm run check`; targeted TypeScript tests or compile-only fixtures for legacy and external hydration shapes.
+- **Conventional Commit subject**: `feat(csp): add strict policy and hydration contracts`
+
+### 2. Render external hydration references and validate strict head output
+
+- **Paths**: `ts/src/head.ts`, `ts/src/html.ts`, `ts/test/unit/head.test.ts`
+- **Layer**: core
+- **Render mode impact**: all
+- **Determinism-sensitive**: yes — changes deterministic head ordering, hydration data emission, script/style handling, and fail-closed validation.
+- **Acceptance**: `renderFaceHead()` preserves the legacy inline hydration path by default, emits external hydration metadata without an inline JSON body when requested, and rejects inline scripts, inline styles, raw head HTML, unsafe inline head attributes, or unsafe/cross-origin bootstrap/data URLs when strict policy disallows them.
+- **Validation**: `cd ts && npm run check`; focused head tests for legacy inline compatibility, external hydration tags, strict rejection cases, stable ordering, escaping, and nonce coexistence outside strict mode.
+- **Conventional Commit subject**: `feat(head): validate strict csp hydration output`
+
+### 3. Add Vite external hydration helper
+
+- **Paths**: `ts/src/vite.ts`, `ts/test/unit/vite.test.ts`, `ts/src/index.ts`
+- **Layer**: core / public API
+- **Render mode impact**: ssr / ssg / isr / spa
+- **Determinism-sensitive**: yes — Vite helper output couples the server-rendered bootstrap module and client hydration data reference.
+- **Acceptance**: A helper such as `externalHydrationForEntry(...)` or equivalent produces a deterministic external hydration object from a Vite manifest entry, data, base path, and same-origin `dataUrl`, without requiring consumers to hand-roll bootstrap/data coupling.
+- **Validation**: `cd ts && npm run check`; targeted Vite tests for base path handling, manifest lookup, data URL preservation, and legacy `viteHydrationForEntry()` compatibility.
+- **Conventional Commit subject**: `feat(vite): add external hydration helper`
+
+### 4. Load external hydration data in SPA navigation helpers
+
+- **Paths**: `ts/src/spa.ts`, `ts/test/unit/spa.test.ts`
+- **Layer**: core browser helpers
+- **Render mode impact**: spa / ssr / ssg / isr
+- **Determinism-sensitive**: yes — changes client-side hydration data discovery and navigation bootstrap data passed to applications.
+- **Acceptance**: SPA helpers can parse a FaceTheory document with no inline `__FACETHEORY_DATA__` body, discover same-origin external hydration metadata, fetch the JSON through an explicit async path, and pass loaded data to `hydrateFaceNavigation(context)` while retaining legacy inline behavior.
+- **Validation**: `cd ts && npm run check`; targeted SPA tests for inline legacy snapshots, external hydration success, missing/invalid data fail-closed behavior, same-origin enforcement, and cross-origin rejection before DOM mutation.
+- **Conventional Commit subject**: `feat(spa): load external hydration data`
+
+### 5. Enforce strict CSP before FaceApp flushes bytes
+
+- **Paths**: `ts/src/app.ts`, `ts/src/bytes.ts` if needed, `ts/test/unit/app.test.ts`, `ts/test/unit/streaming.test.ts`
+- **Layer**: core runtime
+- **Render mode impact**: ssr / spa shell / streaming SSR
+- **Determinism-sensitive**: yes — validation happens at the server/client boundary before HTML is emitted, including streamed responses.
+- **Acceptance**: A Face that returns strict-CSP policy violations fails closed with a deterministic error before response bytes are flushed; streaming configurations that cannot be certified before first byte are rejected or coerced to a documented safe all-ready/buffered path.
+- **Validation**: `cd ts && npm run check`; targeted app and streaming tests for strict success, strict violation, preflush failure, and legacy non-strict behavior.
+- **Conventional Commit subject**: `feat(app): enforce strict csp before streaming`
+
+### 6. Add strict CSP header builder and optional document validator
+
+- **Paths**: `ts/src/security.ts`, `ts/src/html.ts` if shared parsing/escaping helpers are needed, `ts/test/unit/html.test.ts`, `ts/test/unit/head.test.ts`, `docs/OPERATIONS.md` if minimal API guidance rides with the helper
+- **Layer**: core / security
+- **Render mode impact**: all
+- **Determinism-sensitive**: yes — the validator certifies rendered HTML surfaces that affect hydration and browser execution policy.
+- **Acceptance**: FaceTheory exposes a no-inline CSP header builder for canonical tests/docs while keeping header attachment explicit, and provides an optional full-document/body validator or test utility for inline `style=` and event-handler attributes without making it a prerequisite for strict policy adoption.
+- **Validation**: `cd ts && npm run check`; security helper tests for header directives, no `unsafe-inline`/`unsafe-eval`, same-origin defaults, and body validator positive/negative fixtures.
+- **Conventional Commit subject**: `feat(security): add strict csp helpers`
+
+### 7. Emit strict external hydration sidecars during SSG
+
+- **Paths**: `ts/src/ssg.ts`, `ts/src/ssg-cli.ts`, `ts/test/unit/ssg.test.ts`, `ts/examples/ssg-basic/` if the example is adjusted
+- **Layer**: core / SSG
+- **Render mode impact**: ssg
+- **Determinism-sensitive**: yes — SSG must serialize the exact server render data into deterministic sidecar files and HTML references.
+- **Acceptance**: SSG can build strict no-inline HTML plus deterministic hydration JSON sidecars, records sidecar paths in the manifest, avoids leaving inline hydration scripts in strict output, and preserves the current `--emit-hydration-data` compatibility behavior for non-strict builds.
+- **Validation**: `cd ts && npm run check`; `cd ts && npm run example:ssg:build`; SSG snapshot tests for deterministic sidecar paths/content and no inline strict output.
+- **Conventional Commit subject**: `feat(ssg): emit strict hydration sidecars`
+
+### 8. Cache ISR hydration sidecars with pointer-derived keys
+
+- **Paths**: `ts/src/isr.ts`, `ts/test/unit/isr.test.ts`, `ts/src/aws-s3/index.ts` only if object-store client shape needs metadata coverage
+- **Layer**: core / ISR / AWS-S3 integration
+- **Render mode impact**: isr
+- **Determinism-sensitive**: yes — ISR cache identity and hydration sidecars must preserve the exact data paired with cached HTML.
+- **Acceptance**: ISR regeneration writes and serves strict external hydration sidecars using keys derived from the cached HTML pointer when possible, without TableTheory schema changes, and fails closed if the HTML/data pair cannot be kept consistent.
+- **Validation**: `cd ts && npm run check`; targeted ISR tests for miss/hit/stale/wait-hit sidecar pairing, stale fallback consistency, failed sidecar write behavior, and no raw data in metadata records.
+- **Conventional Commit subject**: `feat(isr): cache strict hydration sidecars`
+
+### 9. Add CSP-safe OAC navigation policies
+
+- **Paths**: `ts/src/oac-form.ts`, `ts/src/spa.ts`, `ts/test/unit/oac-form.test.ts`, `ts/test/unit/spa.test.ts`
+- **Layer**: core browser helpers / AWS-first OAC transport
+- **Render mode impact**: ssr / spa / ssg forms / isr forms
+- **Determinism-sensitive**: no — this runs after user submission/navigation, not during initial server/client hydration, but it must preserve fail-closed CSP semantics.
+- **Acceptance**: OAC form transport supports explicit named navigation policies for same-origin full browser navigation and FaceTheory SPA snapshot navigation; strict mode defaults to full navigation and SPA navigation is an external-hydration-aware, same-origin, fail-closed opt-in.
+- **Validation**: `cd ts && npm run check`; OAC tests for CSP-protected HTML full navigation, SPA handoff, cross-origin rejection, preserved existing `onNavigate`, and no `document.write()` for CSP-protected responses.
+- **Conventional Commit subject**: `feat(oac): add strict csp navigation policies`
+
+### 10. Wire React strict-CSP adapter behavior
+
+- **Paths**: `ts/src/adapters/react.ts`, `ts/src/react/emotion.ts`, `ts/src/react/antd.ts`, `ts/test/unit/react.test.ts`, `ts/test/unit/streaming.test.ts`, `ts/test/unit/emotion.test.ts`, `ts/test/unit/antd.test.ts`
+- **Layer**: react adapter
+- **Render mode impact**: ssr / spa shell
+- **Determinism-sensitive**: yes — React streaming, Suspense, Emotion, and AntD style extraction directly affect head/style output and hydration matching.
+- **Acceptance**: React strict-CSP renders fail closed when Emotion/AntD inline style extraction or streaming script behavior would violate the policy, and allow strict routes that rely on external CSS/assets and safe all-ready/buffered rendering.
+- **Validation**: `cd ts && npm run check`; React/streaming/Emotion/AntD targeted tests; `cd ts && npm run example:streaming:serve` smoke path if the implementation changes streaming strategy.
+- **Conventional Commit subject**: `feat(react): enforce strict csp rendering`
+
+### 11. Wire Vue strict-CSP parity behavior
+
+- **Paths**: `ts/src/vue/index.ts`, `ts/test/unit/vue.test.ts`, `ts/test/unit/vite-ssr-vue-example.test.ts`
+- **Layer**: vue adapter
+- **Render mode impact**: ssr / spa shell
+- **Determinism-sensitive**: yes — adapter-contributed head/style output must respect the same strict policy as core.
+- **Acceptance**: Vue adapter output participates in strict-CSP validation, preserves legacy behavior when no strict policy is present, and tests prove external hydration works through the Vue adapter path without inline data.
+- **Validation**: `cd ts && npm run check`; `cd ts && npm run example:vite:vue:build`; targeted Vue tests for strict success/failure.
+- **Conventional Commit subject**: `feat(vue): support strict csp hydration`
+
+### 12. Wire Svelte strict-CSP parity behavior
+
+- **Paths**: `ts/src/svelte/index.ts`, `ts/test/unit/svelte.test.ts`, `ts/test/unit/vite-ssr-svelte-example.test.ts`, `ts/test/unit/vite-ssr-svelte-library-example.test.ts`
+- **Layer**: svelte adapter
+- **Render mode impact**: ssr / spa shell
+- **Determinism-sensitive**: yes — Svelte SSR `head` and CSS fallback currently feed raw head/style output.
+- **Acceptance**: In strict mode, Svelte rejects raw SSR `head` output and CSS fallback that would emit inline styles, requires structured `headTags` and external CSS/assets, and preserves legacy non-strict Svelte behavior.
+- **Validation**: `cd ts && npm run check`; `cd ts && npm run example:vite:svelte:build`; `cd ts && npm run example:vite:svelte:library:build`; targeted Svelte strict rejection/success tests.
+- **Conventional Commit subject**: `feat(svelte): reject raw strict csp head output`
+
+### 13. Add a strict-CSP Svelte/Vite installed-client example
+
+- **Paths**: `ts/examples/vite-strict-csp-svelte/` or `ts/examples/vite-ssr-svelte/`, `ts/package.json`, `ts/test/unit/vite-strict-csp-svelte-example.test.ts`
+- **Layer**: example / test
+- **Render mode impact**: ssr / spa
+- **Determinism-sensitive**: yes — example verifies no-inline hydration/style output and client hydration data equivalence.
+- **Acceptance**: A canonical Simulacrum-shaped Svelte/Vite example renders with external CSS/assets, same-origin module bootstrap, external hydration JSON, no inline scripts/styles, and a browser/test gate that catches strict-CSP regressions.
+- **Validation**: `cd ts && npm run check`; new `npm run example:vite:svelte:strict-csp:build` script; targeted example test verifying no inline CSP violations.
+- **Conventional Commit subject**: `feat(examples): add strict csp svelte vite app`
+
+### 14. Add strict-CSP browser validation harness
+
+- **Paths**: `ts/test/helpers/`, `ts/test/unit/*strict-csp*.test.ts`, optionally `ts/examples/vite-strict-csp-svelte/`
+- **Layer**: tests / example validation
+- **Render mode impact**: all through validation coverage
+- **Determinism-sensitive**: yes — the harness guards against hydration and CSP policy drift across server/client output.
+- **Acceptance**: Tests can assert a rendered document contains no inline scripts/styles, no raw head, no event-handler/style attributes in validated scopes, and can hydrate/navigate with external data under the strict example.
+- **Validation**: `cd ts && npm run check`; targeted strict-CSP harness tests; relevant Vite strict example build.
+- **Conventional Commit subject**: `test(csp): add strict browser validation harness`
+
+### 15. Document strict-CSP APIs and migration guidance
+
+- **Paths**: `docs/api-reference.md`, `docs/core-patterns.md`, `docs/getting-started.md`, `docs/testing-guide.md`, `docs/troubleshooting.md`, `docs/migration-guide.md`, `README.md` if quickstart needs a pointer
+- **Layer**: docs
+- **Render mode impact**: all
+- **Determinism-sensitive**: no — documentation only, but it documents determinism-sensitive APIs.
+- **Acceptance**: Public docs explain nonce-compatible CSP versus strict no-inline CSP, external hydration usage, SPA navigation behavior, Svelte strict head requirements, React streaming limits, body validator responsibility, and migration from legacy inline hydration.
+- **Validation**: `cd ts && npm run check`; docs review against scoped need; do not hand-edit `x-release-please-version` markers.
+- **Conventional Commit subject**: `docs(csp): document strict hydration mode`
+
+### 16. Document AWS deployment and release validation for strict CSP
+
+- **Paths**: `docs/AWS_DEPLOYMENT_SHAPE.md`, `docs/OPERATIONS.md`, `docs/cdk/aws-deployment.md`, `docs/cdk/operations.md`, `docs/UPSTREAM_RELEASE_PINS.md` only if dependency freshness is relevant, `docs/planning/ROADMAP_STRICT_CSP_HYDRATION_NAVIGATION.md`
+- **Layer**: docs / AWS deployment guidance
+- **Render mode impact**: ssr / ssg / isr / spa
+- **Determinism-sensitive**: no — documentation only, but it defines deployment validation for deterministic strict-CSP output.
+- **Acceptance**: AWS docs cover S3/CloudFront routing for SSG hydration sidecars, ISR sidecar object expectations, explicit CSP header attachment, OAC navigation policy choice, RC validation by Simulacrum, and stable release promotion criteria.
+- **Validation**: `cd ts && npm run check`; deployment docs review against AWS-first posture and release-flow rules.
+- **Conventional Commit subject**: `docs(aws): document strict csp deployment`
+
+## Cross-cutting notes
+
+- No release manifests, version markers, generated changelogs, tags, or release assets are part of this feature enumeration.
+- No npm publication, non-AWS deployment abstraction, fifth render mode, fourth adapter, or TableTheory schema change is enumerated.
+- If item 8 proves that pointer-derived ISR sidecars cannot preserve consistency, stop and coordinate with the TableTheory steward before expanding ISR metadata.
+- Simulacrum remains the primary RC validator and will continue its app-local workaround until this project ships.
+
+## Self-check
+
+- [x] Core primitives are ordered before adapter implementations that depend on them.
+- [x] Every determinism-sensitive item is flagged.
+- [x] React, Vue, and Svelte strict-CSP parity are all enumerated.
+- [x] Examples are enumerated for the new capability.
+- [x] Docs are enumerated for user-visible behavior and deployment shape.
+- [x] No item requires release manifest edits or hand-created releases.
+- [x] The full list satisfies the scoped need's success criteria without adding a render mode, adapter, or non-AWS platform.

--- a/docs/planning/ROADMAP_STRICT_CSP_HYDRATION_NAVIGATION.md
+++ b/docs/planning/ROADMAP_STRICT_CSP_HYDRATION_NAVIGATION.md
@@ -1,0 +1,142 @@
+# Roadmap: Strict CSP Hydration and Navigation
+
+Source scope: `docs/planning/SCOPED_NEED_STRICT_CSP_HYDRATION_NAVIGATION.md`.
+Source enumeration: `docs/planning/ENUMERATED_CHANGES_STRICT_CSP_HYDRATION_NAVIGATION.md`.
+
+## Goal
+
+Deliver a first-class strict no-inline CSP path for FaceTheory hydration, head/style emission, SPA navigation, SSG/ISR sidecars, OAC navigation handoff, and adapter parity across React, Vue, and Svelte. The roadmap keeps FaceTheory inside the existing SSR/SSG/ISR/SPA and React/Vue/Svelte shape while giving Simulacrum and future installed-client consumers an auditable invariant: strict routes do not rely on inline scripts/styles and fail closed when FaceTheory-owned surfaces would violate that policy.
+
+## Render modes and adapters affected
+
+| Surface | SSR | SSG | ISR | SPA |
+|---|---:|---:|---:|---:|
+| Core hydration/head policy | yes | yes | yes | yes |
+| External hydration data | yes, consumer `dataUrl` first | yes, sidecar JSON | yes, pointer-derived sidecar | yes, async fetch/load |
+| React adapter | yes | via generated output | via generated output | shell/navigation |
+| Vue adapter | yes | via generated output | via generated output | shell/navigation |
+| Svelte adapter | yes | via generated output | via generated output | shell/navigation |
+| OAC navigation | form outcomes | static form pages | cached form pages | navigation handoff |
+
+## Determinism impact
+
+This roadmap introduces a new determinism-sensitive surface: the server-rendered HTML and externally served hydration JSON must remain an exact pair. The strict path strengthens determinism by preventing app-local recomputation of client props, but every core, adapter, SSG, ISR, and SPA helper change must preserve the server/client data equivalence that the legacy inline hydration script currently provides. Streaming paths must fail closed when they cannot be certified before first byte.
+
+## Phases
+
+### Phase 1: Core strict-CSP contracts and external hydration
+
+**Milestone candidates:**
+
+- **strict-csp-core-contracts** — Establish the adapter-neutral policy, hydration union, head validation, Vite helper, and SPA external hydration loading.
+  - Items: 1, 2, 3, 4
+  - Dependencies: approved scoped need and enumeration
+  - Determinism-sensitive: yes
+  - Risks:
+    - Public type shape could be hard to migrate if the discriminant is wrong; mitigate by preserving legacy inline shape and keeping helper names explicit.
+    - SPA sync APIs cannot fetch external data; mitigate with additive async helpers while retaining legacy synchronous parsing.
+    - Cross-origin data/module references could weaken CSP; mitigate with same-origin defaults and fail-closed tests.
+
+### Phase 2: Runtime enforcement and delivery-mode storage
+
+**Milestone candidates:**
+
+- **strict-csp-runtime-enforcement** — Enforce strict policy before response flush and expose canonical strict-CSP security helpers.
+  - Items: 5, 6
+  - Dependencies: strict-csp-core-contracts
+  - Determinism-sensitive: yes
+  - Risks:
+    - Streaming failures after flush would be unrecoverable; mitigate by validating/certifying before streaming begins or rejecting uncertifiable configurations.
+    - Header builder could imply FaceTheory owns deployment headers; mitigate by keeping attachment explicit in docs and APIs.
+
+- **strict-csp-static-isr-sidecars** — Make SSG and ISR produce/cache strict external hydration sidecars without TableTheory schema changes.
+  - Items: 7, 8
+  - Dependencies: strict-csp-core-contracts, strict-csp-runtime-enforcement for policy semantics
+  - Determinism-sensitive: yes
+  - Risks:
+    - Pointer-derived ISR sidecars may not cover all consistency cases; mitigate with stale/failure tests and stop for TableTheory coordination if needed.
+    - SSG must avoid changing existing non-strict output; mitigate with compatibility snapshots and explicit strict options.
+
+### Phase 3: Navigation and adapter parity
+
+**Milestone candidates:**
+
+- **strict-csp-navigation-oac** — Add named CSP-safe OAC navigation policies and external-hydration-aware SPA handoff.
+  - Items: 9
+  - Dependencies: strict-csp-core-contracts and SPA external hydration loading
+  - Determinism-sensitive: no for initial render, but CSP/fail-closed sensitive
+  - Risks:
+    - Partial DOM navigation can drift from full document CSP semantics; mitigate by making full same-origin navigation the strict default and SPA handoff explicit.
+
+- **strict-csp-adapter-parity** — Wire React, Vue, and Svelte into the strict policy with parity tests and adapter-specific fail-closed behavior.
+  - Items: 10, 11, 12
+  - Dependencies: strict-csp-runtime-enforcement
+  - Determinism-sensitive: yes
+  - Risks:
+    - React streaming/Suspense may emit inline scripts in some paths; mitigate by rejecting or using safe all-ready/buffered strategy for strict routes.
+    - Svelte raw head parsing is risky; mitigate by rejecting raw Svelte SSR `head` under strict mode in the first implementation.
+    - Vue may appear trivial and miss parity tests; mitigate with explicit Vue strict success/failure coverage.
+
+### Phase 4: Examples and validation gates
+
+**Milestone candidates:**
+
+- **strict-csp-example-validation** — Add the canonical Simulacrum-shaped Svelte/Vite example and reusable strict-CSP validation harness.
+  - Items: 13, 14
+  - Dependencies: strict-csp-static-isr-sidecars and strict-csp-adapter-parity
+  - Determinism-sensitive: yes
+  - Risks:
+    - Example may become too Simulacrum-specific; mitigate by using Simulacrum-shaped constraints without Simulacrum business logic.
+    - Browser validation can be brittle; mitigate with DOM/CSP structural tests plus an example build gate.
+
+### Phase 5: Documentation, deployment guidance, and release readiness
+
+**Milestone candidates:**
+
+- **strict-csp-docs-release** — Document APIs, migration, AWS deployment, RC validation, and release promotion criteria.
+  - Items: 15, 16
+  - Dependencies: all behavior milestones or at least stable final API names
+  - Determinism-sensitive: no, but documents determinism-sensitive behavior
+  - Risks:
+    - Docs lagging code would make strict mode hard to adopt; mitigate by landing docs before RC promotion.
+    - Deployment guidance could imply non-AWS portability; mitigate by naming S3, CloudFront, Lambda, OAC, and TableTheory boundaries explicitly.
+
+## Release rollout plan
+
+1. Land milestone PRs into `staging` in phase order.
+2. Run `cd ts && npm run check` on every milestone PR; run affected examples for adapter/example milestones.
+3. Before opening or updating any PR into `staging`, run `scripts/verify-version-alignment.sh` and confirm stable and premain manifests remain aligned with the intended line.
+4. Promote `staging` to `premain` after all milestones land and examples/docs are complete.
+5. Let Release Please create the prerelease candidate from `premain`; do not create tags or assets manually.
+6. Simulacrum validates the RC tarball against its strict-CSP dogfood path without loosening CSP or patching FaceTheory locally.
+7. RC soak should include at least: strict Svelte/Vite example build, SPA navigation with external hydration, SSG sidecar output, ISR sidecar cache hit/stale paths, and OAC strict navigation policy tests.
+8. After RC validation, promote `premain` to `main`, inspect the stable Release Please PR version/changelog against the latest stable baseline, merge only if correct, and verify the stable GitHub Release assets.
+9. Back-merge `main` into `staging` after stable release so the next cycle starts from the released baseline.
+
+## Version-bump implication
+
+Minor release. The capability is additive and preserves legacy nonce-compatible inline hydration, but it introduces a substantial new public API surface. FaceTheory is pre-1.0 in stewardship posture historically, but the current release line is `3.1.2`; under semver, this should be a minor feature release unless implementation discovers a breaking API change. If any commit removes or changes existing behavior, it must use `feat!:`/`fix!:` and the roadmap must be revisited before release.
+
+## Cross-phase risks
+
+- **Hydration pair consistency:** external JSON must match server-rendered HTML across SSR, SSG, ISR, and SPA. Mitigation: pair data URL/key generation with render output and test stale/failed sidecar paths.
+- **Streaming certification:** strict mode cannot discover violations after flush. Mitigation: preflight validation, all-ready/buffered fallback, or fail-closed rejection.
+- **Adapter parity:** React has streaming/style complexity, Svelte has raw head/CSS fallback complexity, Vue can be under-tested. Mitigation: separate adapter items with explicit success/failure tests.
+- **Raw consumer body limits:** FaceTheory-owned surfaces are certified first; arbitrary body validation remains optional/test utility. Mitigation: document the boundary and provide a validation harness.
+- **ISR/TableTheory boundary:** pointer-derived sidecars are preferred to avoid schema changes. Mitigation: stop and coordinate with TableTheory if consistency requires metadata changes.
+- **OAC/navigation semantics:** fetched CSP-protected HTML cannot be installed with `document.write()`. Mitigation: full same-origin navigation default and explicit SPA policy.
+- **Version/release hygiene:** this project spans many deterministic surfaces. Mitigation: normal staging → premain → main flow, RC validation, Release Please only, no manual tags/assets.
+
+## Cross-repo coordination
+
+- **Simulacrum:** primary RC validator and source of strict-CSP acceptance criteria.
+- **TableTheory:** no schema change expected. Coordinate only if ISR sidecar consistency cannot be solved by pointer-derived keys.
+- **AppTheory:** no runtime change expected. Coordination may be needed only if CSP header attachment or OAC navigation docs reveal an AppTheory construct gap.
+- **Autheory / Pay Theory:** notify if final API changes affect hosted-auth/control-plane or checkout integration patterns, but no direct dependency is known at roadmap time.
+
+## Open questions
+
+- Final public names for the policy object, hydration discriminants, helper, and navigation policies.
+- Whether optional body/document validation should be public API in the first release or test utility only.
+- Whether the canonical strict example should be a new `vite-strict-csp-svelte` example or an extension of the existing Svelte Vite example. Default recommendation: a new example to avoid weakening current non-strict example coverage.
+- Whether any consumer besides Simulacrum needs FaceTheory-owned SSR hydration data storage in the first release. Default recommendation: defer until a concrete need appears.

--- a/docs/planning/SCOPED_NEED_STRICT_CSP_HYDRATION_NAVIGATION.md
+++ b/docs/planning/SCOPED_NEED_STRICT_CSP_HYDRATION_NAVIGATION.md
@@ -1,0 +1,196 @@
+# Scoped Need: Strict CSP Hydration and Navigation
+
+## Background
+
+Issue #181 reports a framework-feedback signal from `equaltoai/simulacrum` at commit `95b94f6dbbf45e4803f5233e18a1826319f0e579`. Simulacrum is a Svelte 5 + FaceTheory installed-client frontend deployed under Lesser at `/l/*` with a deliberately strict browser policy: no inline scripts, no inline styles, no `unsafe-eval`, and no third-party script origins. FaceTheory v3.1.2 already provides hydration, SPA navigation, deterministic head rendering, style collection, and OAC form helpers, but the current canonical paths assume nonce-compatible inline payloads are acceptable. Simulacrum is therefore recomputing client props from the browser URL and avoiding FaceTheory hydration data instead of weakening its CSP.
+
+## Driver
+
+Simulacrum is the immediate driver, with reuse expected by security-sensitive installed-client and component-heavy FaceTheory applications, including future Theory Cloud UIs that need a browser-validation-contract gate. This is a high-priority framework capability because strict CSP is not an app-local preference once FaceTheory owns the hydration envelope, head/style emission, SPA navigation, and OAC navigation helper surfaces.
+
+## Problem
+
+FaceTheory's current CSP support is nonce-oriented, not no-inline. In v3.1.2:
+
+- `renderFaceHead()` emits an inline JSON hydration script whenever `FaceRenderResult.hydration` is present:
+  - `<script id="__FACETHEORY_DATA__" type="application/json">...</script>`
+  - the body is produced with `safeJson(out.hydration.data)`.
+- `readFaceHydrationData()` and SPA navigation snapshots expect that inline script.
+- `readHydrationBootstrapModule()` only finds the bootstrap module by walking after the inline hydration data script.
+- `styleTags` render as inline `<style>` tags.
+- React Emotion / AntD style extraction and Svelte SSR CSS fallback feed `styleTags`.
+- Svelte SSR `rendered.head` currently becomes raw head HTML.
+- `headTags: [{ type: "raw", html }]` remains a necessary escape hatch but is easy to misuse under strict CSP.
+- SSG `emitHydrationData` can copy the inline hydration JSON to sidecar files, but it does not remove the inline data script or make the sidecar the canonical hydration path.
+- OAC form transport correctly fails closed for fetched HTML protected by CSP because `document.write()` cannot install response CSP headers, but strict-CSP consumers still need a reusable CSP-safe navigation strategy.
+
+The result is a framework consumption gap: a consumer that wants the invariant "this rendered Face is no-inline-CSP safe" cannot express that invariant through FaceTheory. They must either relax CSP, recompute hydration data outside FaceTheory, or build app-local navigation glue.
+
+## Render modes affected
+
+All FaceTheory delivery modes are in scope:
+
+- **SSR:** per-request HTML must be able to reference hydration data without inline scripts. Strict validation must happen before bytes are flushed, especially for streaming responses where errors cannot be rewound after the first chunk.
+- **SSG:** build output must support sidecar hydration JSON as the canonical hydration data source while producing HTML with no inline hydration/style payloads.
+- **Blocking ISR:** regenerated cached HTML must support deterministic external hydration references. Per-request nonces are not a durable answer for cached ISR HTML, so no-inline delivery is especially valuable here.
+- **SPA:** the deterministic shell and SPA navigation helpers must be able to discover, fetch, and apply external hydration data without depending on `__FACETHEORY_DATA__`.
+
+This fits within the existing render-mode shape. It is not a fifth render mode.
+
+## Adapters affected
+
+All three first-class adapters are affected, with the core owning the shared contract:
+
+- **Core:** hydration envelope, head rendering, strict-CSP validation, SPA navigation, SSG sidecar behavior, security/CSP helpers, and OAC navigation integration.
+- **React:** strict mode must account for Emotion/AntD inline style extraction and React 18 streaming behavior. React streaming can emit inline instruction scripts for some Suspense streaming paths, so strict no-inline mode must either choose an all-ready/buffered-compatible strategy or fail closed when a React streaming configuration would emit inline scripts.
+- **Vue:** core hydration and head/style validation must apply without Vue-specific semantics leaking into core.
+- **Svelte:** strict mode must address Svelte SSR CSS fallback and Svelte `rendered.head`. For the first trusted strict-CSP implementation, raw Svelte head output is rejected and consumers must return structured `headTags`; a conservative parser can be considered later as a migration diagnostic.
+
+## Shape impact
+
+Additive core capability inside the existing four-mode, three-adapter shape. The likely product shape is a strict CSP policy on the render result/app plus external hydration primitives:
+
+- a no-inline hydration representation that can reference external JSON instead of embedding script body text;
+- Vite helpers for external hydration references;
+- SPA helpers that can asynchronously load inline or external hydration data;
+- strict render validation that rejects FaceTheory-owned inline scripts, inline styles, raw head, unsafe head attributes, unsafe module origins, and adapter-produced inline style/head output according to the selected policy;
+- SSG/ISR support for deterministic sidecar hydration objects;
+- OAC/navigation behavior that never installs CSP-protected fetched HTML via `document.write()`.
+
+This does not add a new render mode, a new adapter, a non-AWS deployment target, or a generic platform abstraction.
+
+## Determinism impact
+
+Preserves determinism and strengthens the boundary contract if implemented as a first-class render policy. The strict-CSP path must preserve the server/client data equivalence that the inline hydration script currently provides:
+
+- External hydration JSON must contain exactly the data the server render used, safely serialized with the same XSS protections as `safeJson`.
+- The client helper must load that data before hydration/navigation code observes props.
+- SSG and ISR sidecar paths must be deterministic for a given route/cache key and must not depend on browser-local recomputation.
+- React, Vue, and Svelte adapters must see the same framework-agnostic policy and fail closed on violations rather than silently dropping required data or styles.
+- Streaming SSR must not discover strict-CSP violations after the response has started. If a strict validation mode cannot certify a streamed body path, it must choose a safe all-ready/buffered strategy or refuse the configuration.
+
+There is one important limit: FaceTheory can fully validate FaceTheory-owned surfaces (`headTags`, `styleTags`, hydration metadata, adapter style integrations, SSG/ISR sidecars, SPA navigation snapshots). Certifying arbitrary consumer HTML bodies as no-inline safe may require a document/body validator. A complete implementation should provide that validator for buffered HTML and generated/cached documents, and should either provide a streaming scanner for streamed bodies or clearly fail closed for "certified strict" streaming configurations that cannot be validated before flush.
+
+## AWS-first posture
+
+Preserves the AWS-first posture. External hydration data should be modeled around the existing AWS delivery shape:
+
+- SSG sidecar JSON served from S3 + CloudFront.
+- ISR sidecar JSON stored alongside cached HTML through the existing HTML object store path where possible, with TableTheory remaining the ISR metadata/lease authority.
+- SSR strict external hydration either references an app-provided same-origin data URL or uses an explicit AWS-shaped FaceTheory hydration data store/route. It must not invent a Vercel/Cloudflare/Netlify abstraction.
+- OAC navigation remains CloudFront/AppTheory/Lambda Function URL OAC aware and must not bypass the same-origin CloudFront path.
+
+No TableTheory schema change is assumed for the first complete design. If implementation needs a new ISR metadata field for hydration sidecar pointers, that becomes a TableTheory coordination point before implementation proceeds.
+
+## Success criteria
+
+- A Face can opt into a strict no-inline CSP render policy that fails closed when FaceTheory would emit inline hydration scripts, inline styles, raw head HTML, unsafe inline event/style attributes in head tags, or unsafe/cross-origin bootstrap scripts under the selected origin policy.
+- The policy is adapter-neutral and visible to React, Vue, and Svelte adapter paths without putting framework-specific logic in core.
+- FaceTheory exposes an external hydration primitive that references a same-origin hydration JSON URL instead of emitting `__FACETHEORY_DATA__` body text.
+- `viteHydrationForEntry()` or a sibling helper can produce external hydration metadata from a Vite manifest without requiring consumers to hand-roll the bootstrap/data relationship.
+- Browser helpers can load hydration data from either the legacy inline script or the new external reference; strict mode uses only the external path.
+- SPA navigation can parse a FaceTheory document that has no inline hydration script, discover the bootstrap module and hydration data URL, fetch the JSON, and pass the loaded data to `hydrateFaceNavigation(context)`.
+- SSG can emit no-inline HTML plus deterministic hydration JSON sidecar files, and the generated manifest records enough information for deployment and verification.
+- ISR can cache/regenerate no-inline HTML and any corresponding hydration sidecar without per-request CSP nonces baked into cached output.
+- SSR can support strict external hydration through a documented same-origin data URL strategy and fails closed when a Face returns hydration data without a valid inline-free delivery path.
+- React strict mode prevents React/Emotion/AntD inline style/script output from violating the policy. Where React streaming would need inline Suspense instruction scripts, FaceTheory uses a safe strategy or rejects that configuration before bytes flush.
+- Svelte strict mode prevents Svelte SSR CSS fallback and raw head output from silently violating the policy. The first implementation rejects raw Svelte SSR `head` output and requires structured `headTags`; a conservative parser for safe raw head subsets is deferred.
+- OAC form transport has a CSP-safe navigation handoff: CSP-protected HTML is not installed with `document.write()`, and consumers can delegate successful responses to FaceTheory SPA navigation or a same-origin full navigation without weakening OAC.
+- `security.ts` grows from nonce generation only into strict-CSP-aware helpers or policy validation docs, including a no-inline header shape that excludes `unsafe-inline`, `unsafe-eval`, and third-party script origins by default.
+- Tests cover core head validation, external hydration serialization/discovery, SPA navigation with external data, SSG sidecar output, ISR sidecar caching, OAC CSP-safe navigation handoff, and representative React/Vue/Svelte strict-mode renders.
+- Documentation explains nonce-compatible CSP vs strict no-inline CSP, why cached SSG/ISR should prefer no-inline over per-request nonces, how to migrate from inline hydration, and what remains the consumer's responsibility inside component body markup.
+- At least one strict-CSP example demonstrates a Svelte/Vite installed-client shape similar to Simulacrum: external CSS/assets from Vite, external hydration data, same-origin module bootstrap, no inline scripts/styles, and passing browser validation under the documented CSP.
+
+## Nearest existing surface
+
+- `ts/src/head.ts`
+  - `renderFaceHead()`
+  - `normalizeHeadTags()`
+  - `renderHeadTag()`
+  - current nonce application and hydration script emission
+- `ts/src/types.ts`
+  - `FaceRenderResult.hydration`
+  - `FaceHydration`
+  - `FaceHeadTag`
+  - `FaceStyleTag`
+- `ts/src/spa.ts`
+  - `readFaceHydrationData()`
+  - `snapshotFaceDocument()`
+  - `parseFaceNavigationSnapshot()`
+  - `fetchFaceNavigationSnapshot()`
+  - `applyFaceNavigationSnapshot()`
+  - `loadFaceNavigationModule()`
+  - `startFaceNavigation()`
+- `ts/src/vite.ts`
+  - `viteAssetsForEntry()`
+  - `viteHydrationForEntry()`
+- `ts/src/ssg.ts`
+  - `emitHydrationData`
+  - `extractHydrationDataJson()`
+  - SSG manifest/page output
+- `ts/src/isr.ts`
+  - `HtmlStore`
+  - `S3HtmlStore`
+  - cached HTML pointer generation
+  - TableTheory-backed metadata/lease integration
+- `ts/src/oac-form.ts`
+  - CSP-protected document replacement fail-closed behavior
+  - `onNavigate` handoff
+- Adapter/integration paths:
+  - `ts/src/adapters/react.ts`
+  - `ts/src/react/emotion.ts`
+  - `ts/src/react/antd.ts`
+  - `ts/src/vue/index.ts`
+  - `ts/src/svelte/index.ts`
+- Existing examples that currently demonstrate the non-strict path:
+  - `ts/examples/vite-ssr-react`
+  - `ts/examples/vite-ssr-vue`
+  - `ts/examples/vite-ssr-svelte`
+  - `ts/examples/vite-ssr-svelte-library`
+
+## Out of scope
+
+- Adding a fifth render mode.
+- Adding a fourth adapter.
+- Porting FaceTheory to Vercel, Cloudflare Workers, Netlify, or another non-AWS deployment target.
+- Publishing to npm or changing the GitHub Release distribution model.
+- Removing the existing nonce-compatible inline hydration path for consumers that do not opt into strict mode.
+- Hiding hydration mismatches or weakening deterministic hydration requirements.
+- Moving ISR cache metadata or regeneration leases out of TableTheory.
+- Hand-rolling a generic cross-cloud object/cache abstraction for hydration data.
+- Guaranteeing that arbitrary consumer component bodies contain no inline styles/events unless the consumer enables the explicit body/document validator.
+- Supporting third-party script origins by default in strict mode.
+- Treating strict CSP as an app-only convention with no framework validation.
+
+## Resolved scope decisions
+
+Simulacrum confirmed the following decisions for the first complete strict-CSP implementation:
+
+- Use an explicit policy object rather than only `strictCsp: true`, for example:
+
+  ```ts
+  csp: {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  }
+  ```
+
+  A named preset can be added later, but the primary API should read like an auditable invariant.
+- Evolve `FaceHydration` into an inline/external discriminated union while preserving the legacy inline shape for compatibility.
+- Add a helper such as `externalHydrationForEntry(...)` so Vite asset/bootstrap coupling is not hand-rolled by consumers.
+- For personalized SSR, start with a consumer-provided same-origin `dataUrl`. A first-class AWS-shaped FaceTheory hydration data store/route is not a prerequisite for the first strict-CSP milestone.
+- For ISR, derive a hydration sidecar key from the cached HTML pointer if possible. Avoid a TableTheory metadata/schema change unless implementation proves pointer-derived sidecars are insufficient.
+- Certify FaceTheory-owned surfaces first: structured `headTags`, `styleTags`, hydration emission, adapter style/head output, and raw-head escape hatches.
+- Full rendered-body validation for inline `style=` and event-handler attributes is valuable, but it can be optional/test utility coverage rather than blocking the first strict-CSP API.
+- Fail closed on streaming configurations that cannot be certified before first byte, even when strict routes must use an all-ready or buffered strategy.
+- Reject raw Svelte SSR `head` output in strict mode for the first implementation. Require structured `headTags`; consider conservative parsing later.
+- Provide a strict no-inline CSP header builder, but keep final header attachment explicit so app/CDN infrastructure remains responsible for deployed response headers.
+- Support both same-origin full browser navigation and FaceTheory SPA snapshot navigation with explicit named policies. For strict mode, default to same-origin full browser navigation; make SPA snapshot navigation an explicit same-origin, external-hydration-aware, fail-closed opt-in.
+
+## Open questions
+
+- What exact names should the public policy object, hydration discriminant, helper, and navigation policies use?
+- Should the optional full-document/body validator land in the first project as a test utility, a public validator, or a later follow-up?
+- Which strict-CSP example should be canonical for release validation: a new Simulacrum-shaped Svelte/Vite installed-client example, or an extension of the existing Svelte Vite example?
+- Does any downstream consumer besides Simulacrum need FaceTheory-owned SSR hydration data storage in the first release, or can that remain deferred until a concrete AWS-side storage need appears?

--- a/ts/src/head.ts
+++ b/ts/src/head.ts
@@ -1,8 +1,15 @@
 import { escapeHTML, safeJson } from './html.js';
-import type { FaceAttributes, FaceHeadTag, FaceRenderResult } from './types.js';
+import type {
+  FaceAttributes,
+  FaceCspPolicy,
+  FaceHeadTag,
+  FaceHydration,
+  FaceRenderResult,
+} from './types.js';
 
 export interface RenderFaceHeadOptions {
   cspNonce?: string | null;
+  allowedOrigin?: string | URL;
 }
 
 export interface NormalizeHeadTagsOptions {
@@ -28,6 +35,160 @@ function safeHttpUrl(value: string): string | null {
       : null;
   } catch {
     return null;
+  }
+}
+
+function requireSafeHttpUrl(value: string, label: string): string {
+  const safe = safeHttpUrl(value);
+  if (!safe) {
+    throw new Error(`FaceTheory ${label} must be an http(s) or same-origin URL`);
+  }
+  return safe;
+}
+
+function isExternalHydration(
+  hydration: FaceHydration,
+): hydration is Extract<FaceHydration, { type: 'external' }> {
+  return hydration.type === 'external';
+}
+
+function normalizeAllowedOrigin(origin: string | URL | undefined): string | null {
+  if (origin === undefined) return null;
+  return new URL(String(origin)).origin;
+}
+
+function isAbsoluteOrProtocolRelativeUrl(value: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value) || value.startsWith('//');
+}
+
+function assertStrictSameOriginUrl(
+  value: string,
+  label: string,
+  allowedOrigin: string | null,
+): void {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) {
+    throw new Error(`FaceTheory strict CSP ${label} URL must not be empty`);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed, 'https://facetheory.invalid');
+  } catch {
+    throw new Error(`FaceTheory strict CSP ${label} URL is invalid: ${trimmed}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `FaceTheory strict CSP ${label} URL must be http(s) or same-origin: ${trimmed}`,
+    );
+  }
+
+  if (!isAbsoluteOrProtocolRelativeUrl(trimmed)) return;
+
+  if (!allowedOrigin) {
+    throw new Error(
+      `FaceTheory strict CSP ${label} URL must be same-origin or relative: ${trimmed}`,
+    );
+  }
+
+  if (parsed.origin !== allowedOrigin) {
+    throw new Error(
+      `FaceTheory strict CSP ${label} URL resolved cross-origin: expected ${allowedOrigin}, received ${parsed.origin}`,
+    );
+  }
+}
+
+function isCspDisabled(
+  policy: FaceCspPolicy | undefined,
+  key: keyof FaceCspPolicy,
+): boolean {
+  return policy?.[key] === false;
+}
+
+function validateStrictAttributes(
+  tag: FaceHeadTag,
+  attrs: FaceAttributes | undefined,
+  policy: FaceCspPolicy | undefined,
+  allowedOrigin: string | null,
+): void {
+  if (!attrs) return;
+
+  for (const [name, rawValue] of Object.entries(attrs)) {
+    if (rawValue === undefined || rawValue === null || rawValue === false) continue;
+    const lowerName = name.trim().toLowerCase();
+
+    if (isCspDisabled(policy, 'inlineScripts') && /^on[a-z]/.test(lowerName)) {
+      throw new Error(
+        `FaceTheory strict CSP rejects inline event handler attribute "${name}" in head`,
+      );
+    }
+
+    if (isCspDisabled(policy, 'inlineStyles') && lowerName === 'style') {
+      throw new Error('FaceTheory strict CSP rejects inline style attributes in head');
+    }
+
+    if (
+      isCspDisabled(policy, 'inlineScripts') &&
+      tag.type === 'script' &&
+      lowerName === 'src'
+    ) {
+      assertStrictSameOriginUrl(String(rawValue), 'script src', allowedOrigin);
+    }
+
+    if (
+      (isCspDisabled(policy, 'inlineScripts') ||
+        isCspDisabled(policy, 'inlineStyles')) &&
+      tag.type === 'link' &&
+      lowerName === 'href'
+    ) {
+      assertStrictSameOriginUrl(String(rawValue), 'link href', allowedOrigin);
+    }
+  }
+}
+
+function validateStrictHeadTags(
+  tags: FaceHeadTag[],
+  policy: FaceCspPolicy | undefined,
+  options: {
+    allowedOrigin?: string | URL;
+    allowedEscapedRawHtml?: string | null;
+  } = {},
+): void {
+  if (!policy) return;
+
+  const allowedOrigin = normalizeAllowedOrigin(options.allowedOrigin);
+  const allowedEscapedRawHtml = options.allowedEscapedRawHtml ?? null;
+
+  for (const tag of tags) {
+    switch (tag.type) {
+      case 'raw':
+        if (
+          isCspDisabled(policy, 'rawHead') &&
+          tag.html !== allowedEscapedRawHtml
+        ) {
+          throw new Error('FaceTheory strict CSP rejects raw head HTML');
+        }
+        break;
+      case 'script':
+        if (isCspDisabled(policy, 'inlineScripts') && tag.body !== undefined) {
+          throw new Error('FaceTheory strict CSP rejects inline script tags');
+        }
+        validateStrictAttributes(tag, tag.attrs, policy, allowedOrigin);
+        break;
+      case 'style':
+        if (isCspDisabled(policy, 'inlineStyles')) {
+          throw new Error('FaceTheory strict CSP rejects inline style tags');
+        }
+        validateStrictAttributes(tag, tag.attrs, policy, allowedOrigin);
+        break;
+      case 'meta':
+      case 'link':
+        validateStrictAttributes(tag, tag.attrs, policy, allowedOrigin);
+        break;
+      case 'title':
+        break;
+    }
   }
 }
 
@@ -197,6 +358,9 @@ export function renderFaceHead(
   options: RenderFaceHeadOptions = {},
 ): string {
   const tags: FaceHeadTag[] = [];
+  const escapedLegacyHeadHtml = out.head?.html
+    ? escapeHTML(out.head.html)
+    : null;
 
   if (out.headTags) tags.push(...out.headTags);
 
@@ -213,24 +377,54 @@ export function renderFaceHead(
   if (out.head?.title) {
     tags.push({ type: 'title', text: out.head.title });
   }
-  if (out.head?.html) {
-    tags.push({ type: 'raw', html: escapeHTML(out.head.html) });
+  if (escapedLegacyHeadHtml) {
+    tags.push({ type: 'raw', html: escapedLegacyHeadHtml });
   }
 
   if (out.hydration) {
-    tags.push({
-      type: 'script',
-      attrs: { id: '__FACETHEORY_DATA__', type: 'application/json' },
-      body: safeJson(out.hydration.data),
-    });
-    const bootstrapModule = safeHttpUrl(out.hydration.bootstrapModule);
-    if (bootstrapModule) {
+    if (isExternalHydration(out.hydration)) {
+      const dataUrl = requireSafeHttpUrl(out.hydration.dataUrl, 'external hydration dataUrl');
+      const bootstrapModule = requireSafeHttpUrl(
+        out.hydration.bootstrapModule,
+        'external hydration bootstrapModule',
+      );
+      tags.push({
+        type: 'link',
+        attrs: {
+          id: '__FACETHEORY_DATA_URL__',
+          rel: 'facetheory-hydration',
+          href: dataUrl,
+          type: 'application/json',
+        },
+      });
       tags.push({
         type: 'script',
         attrs: { type: 'module', src: bootstrapModule },
       });
+    } else {
+      tags.push({
+        type: 'script',
+        attrs: { id: '__FACETHEORY_DATA__', type: 'application/json' },
+        body: safeJson(out.hydration.data),
+      });
+      const bootstrapModule = safeHttpUrl(out.hydration.bootstrapModule);
+      if (bootstrapModule) {
+        tags.push({
+          type: 'script',
+          attrs: { type: 'module', src: bootstrapModule },
+        });
+      }
     }
   }
+
+  const validationOptions: {
+    allowedOrigin?: string | URL;
+    allowedEscapedRawHtml?: string | null;
+  } = { allowedEscapedRawHtml: escapedLegacyHeadHtml };
+  if (options.allowedOrigin !== undefined) {
+    validationOptions.allowedOrigin = options.allowedOrigin;
+  }
+  validateStrictHeadTags(tags, out.csp, validationOptions);
 
   return normalizeHeadTags(tags, { cspNonce: options.cspNonce ?? null })
     .map(renderHeadTag)

--- a/ts/src/spa.ts
+++ b/ts/src/spa.ts
@@ -3,6 +3,8 @@ import type { FaceAttributes, FaceHydration } from './types.js';
 export const DEFAULT_FACE_VIEW_SELECTOR = '[data-facetheory-view]';
 
 const HYDRATION_DATA_SCRIPT_ID = '__FACETHEORY_DATA__';
+const HYDRATION_DATA_LINK_ID = '__FACETHEORY_DATA_URL__';
+const HYDRATION_DATA_LINK_REL = 'facetheory-hydration';
 const NAVIGATION_CACHE_BUST_PARAM = 'facetheory-nav';
 
 export interface FaceNavigationSnapshot {
@@ -26,6 +28,14 @@ export interface ParseFaceNavigationSnapshotOptions extends SnapshotFaceDocument
 }
 
 export interface FetchFaceNavigationSnapshotOptions extends ParseFaceNavigationSnapshotOptions {
+  allowedOrigin?: string | URL;
+  fetcher?: typeof fetch;
+  hydrationRequestInit?: RequestInit;
+  loadExternalHydration?: boolean;
+  requestInit?: RequestInit;
+}
+
+export interface LoadFaceNavigationHydrationDataOptions {
   allowedOrigin?: string | URL;
   fetcher?: typeof fetch;
   requestInit?: RequestInit;
@@ -96,14 +106,38 @@ export function readFaceHydrationData<T = unknown>(doc: Document = document): T 
   }
 }
 
+export function readFaceHydrationDataUrl(doc: Document = document): string | null {
+  const byId = doc.getElementById(HYDRATION_DATA_LINK_ID);
+  if (byId?.tagName.toLowerCase() === 'link') {
+    const href = byId.getAttribute('href');
+    if (href) return href;
+  }
+
+  const byRel = doc.querySelector(`link[rel="${HYDRATION_DATA_LINK_REL}"]`);
+  if (!byRel) return null;
+  const href = byRel.getAttribute('href');
+  return href || null;
+}
+
 export function snapshotFaceDocument(
   doc: Document,
   options: SnapshotFaceDocumentOptions = {},
 ): FaceNavigationSnapshot {
   const viewSelector = options.viewSelector ?? DEFAULT_FACE_VIEW_SELECTOR;
   const bootstrapModule = readHydrationBootstrapModule(doc);
+  const dataUrl = readFaceHydrationDataUrl(doc);
   const data = readFaceHydrationData(doc);
   const view = doc.querySelector(viewSelector);
+  const hydration: FaceHydration | null = dataUrl
+    ? {
+        type: 'external',
+        data: undefined,
+        dataUrl,
+        bootstrapModule: bootstrapModule ?? '',
+      }
+    : bootstrapModule
+      ? { bootstrapModule, data }
+      : null;
 
   return {
     url: resolveSnapshotUrl(doc, options.url),
@@ -113,7 +147,7 @@ export function snapshotFaceDocument(
     headHtml: doc.head.innerHTML,
     bodyHtml: doc.body.innerHTML,
     viewHtml: view ? view.innerHTML : null,
-    hydration: bootstrapModule ? { bootstrapModule, data } : null,
+    hydration,
   };
 }
 
@@ -173,7 +207,76 @@ export async function fetchFaceNavigationSnapshot(
     parseOptions.parser = options.parser;
   }
 
-  return parseFaceNavigationSnapshot(await response.text(), parseOptions);
+  const snapshot = parseFaceNavigationSnapshot(await response.text(), parseOptions);
+  if (options.loadExternalHydration === false) return snapshot;
+
+  const hydrationOptions: LoadFaceNavigationHydrationDataOptions = {};
+  if (allowedOrigin) hydrationOptions.allowedOrigin = allowedOrigin;
+  if (options.fetcher !== undefined) hydrationOptions.fetcher = options.fetcher;
+  if (options.hydrationRequestInit !== undefined) {
+    hydrationOptions.requestInit = options.hydrationRequestInit;
+  }
+  return loadFaceNavigationHydrationData(snapshot, hydrationOptions);
+}
+
+export async function loadFaceNavigationHydrationData(
+  snapshot: FaceNavigationSnapshot,
+  options: LoadFaceNavigationHydrationDataOptions = {},
+): Promise<FaceNavigationSnapshot> {
+  if (!isExternalHydration(snapshot.hydration)) return snapshot;
+
+  const fetcher = options.fetcher ?? globalThis.fetch;
+  if (typeof fetcher !== 'function') {
+    throw new Error('FaceTheory SPA helpers require fetch in the current environment');
+  }
+
+  const allowedOrigin =
+    resolveAllowedNavigationOrigin(options.allowedOrigin) ??
+    resolveNavigationUrl(snapshot.url, 'http://localhost/').origin;
+  const dataUrl = assertSameOriginNavigationUrl(
+    snapshot.hydration.dataUrl,
+    allowedOrigin,
+    snapshot.url,
+    'FaceTheory SPA hydration data resolved cross-origin',
+  );
+
+  const response = await fetcher(dataUrl.toString(), {
+    ...options.requestInit,
+    headers: {
+      accept: 'application/json',
+      ...(options.requestInit?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `FaceTheory hydration data fetch failed (${response.status}) for ${dataUrl.toString()}`,
+    );
+  }
+
+  assertSameOriginNavigationUrl(
+    response.url || dataUrl,
+    allowedOrigin,
+    snapshot.url,
+    'FaceTheory SPA hydration data fetch resolved cross-origin',
+  );
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new Error('FaceTheory hydration data response was not valid JSON', {
+      cause: error,
+    });
+  }
+
+  return {
+    ...snapshot,
+    hydration: {
+      ...snapshot.hydration,
+      data,
+    },
+  };
 }
 
 export function applyFaceNavigationSnapshot(
@@ -205,14 +308,20 @@ export async function loadFaceNavigationModule(
   snapshot: FaceNavigationSnapshot,
   options: LoadFaceNavigationModuleOptions = {},
 ): Promise<void> {
-  if (!snapshot.hydration?.bootstrapModule) return;
+  if (!snapshot.hydration) return;
+  if (isExternalHydration(snapshot.hydration) && snapshot.hydration.data === undefined) {
+    throw new Error(
+      'FaceTheory SPA external hydration data must be loaded before hydration',
+    );
+  }
+  if (!snapshot.hydration.bootstrapModule) return;
 
   const doc = options.document ?? document;
   const allowedOrigin =
     resolveAllowedNavigationOrigin(options.allowedOrigin) ??
     doc.defaultView?.location.origin ??
     resolveNavigationUrl(snapshot.url, 'http://localhost/').origin;
-  assertSameOriginHydrationModule(snapshot, allowedOrigin);
+  assertSameOriginHydrationReferences(snapshot, allowedOrigin);
   const importModule = options.importModule ?? importFaceNavigationModule;
   const context = createBootstrapContext(
     snapshot,
@@ -282,7 +391,7 @@ export function startFaceNavigation(
     }
 
     const snapshot = await fetchFaceNavigationSnapshot(url, fetchOptions);
-    assertSameOriginHydrationModule(snapshot, win.location.origin);
+    assertSameOriginHydrationReferences(snapshot, win.location.origin);
 
     if (options.render) {
       await options.render(
@@ -446,10 +555,13 @@ function syncAttributes(element: Element, nextAttrs: FaceAttributes): void {
 }
 
 function readHydrationBootstrapModule(doc: Document): string | null {
-  const dataScript = doc.getElementById(HYDRATION_DATA_SCRIPT_ID);
-  if (!dataScript) return null;
+  const marker =
+    doc.getElementById(HYDRATION_DATA_SCRIPT_ID) ??
+    doc.getElementById(HYDRATION_DATA_LINK_ID) ??
+    doc.querySelector(`link[rel="${HYDRATION_DATA_LINK_REL}"]`);
+  if (!marker) return null;
 
-  let current = dataScript.nextElementSibling;
+  let current = marker.nextElementSibling;
   while (current) {
     if (
       current.tagName.toLowerCase() === 'script' &&
@@ -521,19 +633,34 @@ function createBootstrapContext(
   };
 }
 
-function assertSameOriginHydrationModule(
+function isExternalHydration(
+  hydration: FaceHydration | null,
+): hydration is Extract<FaceHydration, { type: 'external' }> {
+  return hydration?.type === 'external';
+}
+
+function assertSameOriginHydrationReferences(
   snapshot: FaceNavigationSnapshot,
   allowedOrigin: string,
 ): void {
   const specifier = snapshot.hydration?.bootstrapModule;
-  if (!specifier) return;
+  if (specifier) {
+    assertSameOriginNavigationUrl(
+      specifier,
+      allowedOrigin,
+      snapshot.url,
+      'FaceTheory SPA hydration module resolved cross-origin',
+    );
+  }
 
-  assertSameOriginNavigationUrl(
-    specifier,
-    allowedOrigin,
-    snapshot.url,
-    'FaceTheory SPA hydration module resolved cross-origin',
-  );
+  if (isExternalHydration(snapshot.hydration)) {
+    assertSameOriginNavigationUrl(
+      snapshot.hydration.dataUrl,
+      allowedOrigin,
+      snapshot.url,
+      'FaceTheory SPA hydration data resolved cross-origin',
+    );
+  }
 }
 
 async function importFaceNavigationModule(

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -29,6 +29,49 @@ export interface FaceStyleTag {
   attrs?: FaceAttributes;
 }
 
+export interface FaceCspPolicy {
+  /**
+   * Whether FaceTheory-owned `<script>` tags may contain inline body text.
+   * Set this to `false` for strict no-inline CSP routes.
+   */
+  inlineScripts?: boolean;
+  /**
+   * Whether FaceTheory-owned `<style>` tags may contain inline CSS text or
+   * structured head attributes may contain inline style declarations.
+   * Set this to `false` for strict no-inline CSP routes.
+   */
+  inlineStyles?: boolean;
+  /**
+   * Whether raw, caller-owned head HTML may be emitted through
+   * `headTags: [{ type: "raw", html }]`.
+   */
+  rawHead?: boolean;
+}
+
+export interface FaceInlineHydration {
+  /**
+   * Optional for backward compatibility: the legacy hydration object shape is
+   * still `{ data, bootstrapModule }`, and is treated as inline hydration.
+   */
+  type?: 'inline';
+  data: unknown;
+  bootstrapModule: string;
+}
+
+export interface FaceExternalHydration {
+  type: 'external';
+  /**
+   * The exact data used for the server render. Strict renderers do not inline
+   * this value, but SSG/ISR/SSR sidecar helpers can persist it at `dataUrl`.
+   */
+  data: unknown;
+  /**
+   * Same-origin JSON URL from which the client loads `data` before hydration.
+   */
+  dataUrl: string;
+  bootstrapModule: string;
+}
+
 export interface FaceRequest {
   method: string;
   path: string;
@@ -69,10 +112,7 @@ export interface FaceHead {
   html?: string;
 }
 
-export interface FaceHydration {
-  data: unknown;
-  bootstrapModule: string;
-}
+export type FaceHydration = FaceInlineHydration | FaceExternalHydration;
 
 export interface FaceRenderResult {
   status?: number;
@@ -84,6 +124,7 @@ export interface FaceRenderResult {
   head?: FaceHead;
   headTags?: FaceHeadTag[];
   styleTags?: FaceStyleTag[];
+  csp?: FaceCspPolicy;
   html: string | AsyncIterable<Uint8Array>;
   hydration?: FaceHydration;
 }

--- a/ts/src/vite.ts
+++ b/ts/src/vite.ts
@@ -1,4 +1,4 @@
-import type { FaceHeadTag, FaceHydration } from './types.js';
+import type { FaceExternalHydration, FaceHeadTag, FaceHydration } from './types.js';
 
 export interface ViteManifestChunk {
   file: string;
@@ -17,6 +17,11 @@ export interface ViteAssetsOptions {
   crossorigin?: boolean;
   includeAssets?: boolean;
   dynamicImports?: DynamicImportPolicy;
+}
+
+export interface ViteExternalHydrationOptions extends ViteAssetsOptions {
+  dataUrl: string;
+  allowedOrigin?: string | URL;
 }
 
 export type DynamicImportPolicy = 'ignore';
@@ -117,6 +122,58 @@ function requireEntryChunk(manifest: ViteManifest, entry: string): ViteManifestC
     throw new Error(`vite manifest entry missing file: ${entry}`);
   }
   return chunk;
+}
+
+function isAbsoluteOrProtocolRelativeUrl(value: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value) || value.startsWith('//');
+}
+
+function originFromAbsoluteHttpUrl(value: string | URL | undefined): string | null {
+  if (value === undefined) return null;
+  const normalized = String(value);
+  if (!isAbsoluteOrProtocolRelativeUrl(normalized)) return null;
+  const parsed = new URL(normalized, 'https://facetheory.invalid');
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  return parsed.origin;
+}
+
+function assertSameOriginDataUrl(
+  dataUrl: string,
+  allowedOrigin: string | null,
+): string {
+  const trimmed = String(dataUrl ?? '').trim();
+  if (!trimmed) {
+    throw new Error('external hydration dataUrl must not be empty');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed, 'https://facetheory.invalid');
+  } catch {
+    throw new Error(`external hydration dataUrl is invalid: ${trimmed}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `external hydration dataUrl must be http(s) or same-origin: ${trimmed}`,
+    );
+  }
+
+  if (!isAbsoluteOrProtocolRelativeUrl(trimmed)) return trimmed;
+
+  if (!allowedOrigin) {
+    throw new Error(
+      `external hydration dataUrl must be same-origin or relative: ${trimmed}`,
+    );
+  }
+
+  if (parsed.origin !== allowedOrigin) {
+    throw new Error(
+      `external hydration dataUrl resolved cross-origin: expected ${allowedOrigin}, received ${parsed.origin}`,
+    );
+  }
+
+  return trimmed;
 }
 
 function stripSearchAndHash(path: string): string {
@@ -255,4 +312,23 @@ export function viteHydrationForEntry(
 ): FaceHydration {
   const { bootstrapModule } = viteAssetsForEntry(manifest, entry, options);
   return { data, bootstrapModule };
+}
+
+export function externalHydrationForEntry(
+  manifest: ViteManifest,
+  entry: string,
+  data: unknown,
+  options: ViteExternalHydrationOptions,
+): FaceExternalHydration {
+  const { bootstrapModule } = viteAssetsForEntry(manifest, entry, options);
+  const allowedOrigin =
+    options.allowedOrigin !== undefined
+      ? new URL(String(options.allowedOrigin)).origin
+      : originFromAbsoluteHttpUrl(options.base);
+  return {
+    type: 'external',
+    data,
+    dataUrl: assertSameOriginDataUrl(options.dataUrl, allowedOrigin),
+    bootstrapModule,
+  };
 }

--- a/ts/test/unit/head.test.ts
+++ b/ts/test/unit/head.test.ts
@@ -89,6 +89,159 @@ test('head: applies CSP nonce to inline styles and hydration scripts', () => {
   );
 });
 
+test('head: external hydration emits metadata without inline JSON', () => {
+  const head = renderFaceHead({
+    html: '<div>ok</div>',
+    hydration: {
+      type: 'external',
+      data: { a: '<script>&</script>' },
+      dataUrl: '/_facetheory/hydration/page.json',
+      bootstrapModule: '/assets/entry.js',
+    },
+  });
+
+  assert.ok(
+    head.includes(
+      '<link href="/_facetheory/hydration/page.json" id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration" type="application/json">',
+    ),
+  );
+  assert.ok(head.includes('<script src="/assets/entry.js" type="module"></script>'));
+  assert.equal(head.includes('__FACETHEORY_DATA__'), false);
+  assert.equal(head.includes('\\u003cscript'), false);
+});
+
+test('head: strict CSP rejects inline script, style, raw head, and unsafe attributes', () => {
+  const csp = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } as const;
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        hydration: { data: { page: 'inline' }, bootstrapModule: '/assets/entry.js' },
+      }),
+    /strict CSP rejects inline script tags/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        styleTags: [{ cssText: 'body{color:red}' }],
+      }),
+    /strict CSP rejects inline style tags/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        headTags: [{ type: 'raw', html: '<meta name="unsafe" content="1">' }],
+      }),
+    /strict CSP rejects raw head HTML/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        headTags: [{ type: 'meta', attrs: { onclick: 'alert(1)' } }],
+      }),
+    /inline event handler attribute/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        headTags: [{ type: 'meta', attrs: { style: 'color:red' } }],
+      }),
+    /inline style attributes/,
+  );
+});
+
+test('head: strict CSP allows external hydration with same-origin URLs', () => {
+  const head = renderFaceHead(
+    {
+      html: '<div>ok</div>',
+      csp: {
+        inlineScripts: false,
+        inlineStyles: false,
+        rawHead: false,
+      },
+      head: {
+        title: 'Strict',
+        html: '<meta name="escaped">',
+      },
+      headTags: [{ type: 'link', attrs: { rel: 'stylesheet', href: '/assets/app.css' } }],
+      hydration: {
+        type: 'external',
+        data: { page: 'strict' },
+        dataUrl: '/_facetheory/hydration/strict.json',
+        bootstrapModule: '/assets/entry.js',
+      },
+    },
+    { allowedOrigin: 'https://app.example' },
+  );
+
+  assert.ok(head.includes('<title>Strict</title>'));
+  assert.ok(head.includes('&lt;meta name=&quot;escaped&quot;&gt;'));
+  assert.ok(head.includes('href="/_facetheory/hydration/strict.json"'));
+  assert.equal(head.includes('__FACETHEORY_DATA__'), false);
+});
+
+test('head: strict CSP rejects cross-origin bootstrap and data URLs', () => {
+  const csp = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } as const;
+
+  assert.throws(
+    () =>
+      renderFaceHead(
+        {
+          html: '<div>ok</div>',
+          csp,
+          hydration: {
+            type: 'external',
+            data: { page: 'strict' },
+            dataUrl: '/_facetheory/hydration/strict.json',
+            bootstrapModule: 'https://evil.example/entry.js',
+          },
+        },
+        { allowedOrigin: 'https://app.example' },
+      ),
+    /script src URL resolved cross-origin/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead(
+        {
+          html: '<div>ok</div>',
+          csp,
+          hydration: {
+            type: 'external',
+            data: { page: 'strict' },
+            dataUrl: 'https://evil.example/data.json',
+            bootstrapModule: '/assets/entry.js',
+          },
+        },
+        { allowedOrigin: 'https://app.example' },
+      ),
+    /link href URL resolved cross-origin/,
+  );
+});
+
 test('head: escapes legacy head fields and blocks unsafe hydration module URLs', () => {
   const head = renderFaceHead({
     html: '<div>ok</div>',

--- a/ts/test/unit/head.test.ts
+++ b/ts/test/unit/head.test.ts
@@ -2,6 +2,43 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { renderFaceHead } from '../../src/head.js';
+import type { FaceCspPolicy, FaceHydration, FaceRenderResult } from '../../src/types.js';
+
+test('head contracts: strict CSP policy and hydration shapes are additive', () => {
+  const strictPolicy = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } satisfies FaceCspPolicy;
+
+  const legacyHydration = {
+    data: { page: 'legacy' },
+    bootstrapModule: '/assets/legacy.js',
+  } satisfies FaceHydration;
+
+  const explicitInlineHydration = {
+    type: 'inline',
+    data: { page: 'inline' },
+    bootstrapModule: '/assets/inline.js',
+  } satisfies FaceHydration;
+
+  const externalHydration = {
+    type: 'external',
+    data: { page: 'external' },
+    dataUrl: '/_facetheory/hydration/external.json',
+    bootstrapModule: '/assets/external.js',
+  } satisfies FaceHydration;
+
+  const renderResult = {
+    html: '<main>ok</main>',
+    csp: strictPolicy,
+    hydration: externalHydration,
+  } satisfies FaceRenderResult;
+
+  assert.equal(legacyHydration.bootstrapModule, '/assets/legacy.js');
+  assert.equal(explicitInlineHydration.type, 'inline');
+  assert.equal(renderResult.csp.inlineScripts, false);
+});
 
 test('head: charset meta then title, with dedupe (last wins)', () => {
   const head = renderFaceHead({

--- a/ts/test/unit/spa.test.ts
+++ b/ts/test/unit/spa.test.ts
@@ -6,9 +6,11 @@ import { JSDOM } from 'jsdom';
 import {
   applyFaceNavigationSnapshot,
   DEFAULT_FACE_VIEW_SELECTOR,
+  loadFaceNavigationHydrationData,
   loadFaceNavigationModule,
   parseFaceNavigationSnapshot,
   readFaceHydrationData,
+  readFaceHydrationDataUrl,
   startFaceNavigation,
 } from '../../src/spa.js';
 
@@ -51,6 +53,99 @@ test('spa helpers: parse FaceTheory documents into navigation snapshots', () => 
     assert.deepEqual(snapshot.hydration, {
       bootstrapModule: '/assets/entry-client.js',
       data: { page: 'next' },
+    });
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('spa helpers: parse external hydration metadata without inline data', () => {
+  const html = `<!doctype html>
+    <html lang="en">
+      <head>
+        <title>External</title>
+        <link id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration" href="/_facetheory/hydration/next.json" type="application/json">
+        <script src="/assets/entry-client.js" type="module"></script>
+      </head>
+      <body>
+        <main data-facetheory-view><h1>External Page</h1></main>
+      </body>
+    </html>`;
+
+  const dom = new JSDOM(html, { url: 'http://localhost/next' });
+
+  try {
+    assert.equal(readFaceHydrationData(dom.window.document), null);
+    assert.equal(
+      readFaceHydrationDataUrl(dom.window.document),
+      '/_facetheory/hydration/next.json',
+    );
+
+    const snapshot = parseFaceNavigationSnapshot(html, {
+      parser: new dom.window.DOMParser(),
+      url: 'http://localhost/next',
+      viewSelector: DEFAULT_FACE_VIEW_SELECTOR,
+    });
+
+    assert.deepEqual(snapshot.hydration, {
+      type: 'external',
+      data: undefined,
+      dataUrl: '/_facetheory/hydration/next.json',
+      bootstrapModule: '/assets/entry-client.js',
+    });
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('spa helpers: load external hydration data before module hydration', async () => {
+  const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>', {
+    url: 'http://localhost/',
+  });
+
+  try {
+    const snapshot = parseFaceNavigationSnapshot(
+      `<!doctype html>
+        <html lang="en">
+          <head>
+            <title>External</title>
+            <link rel="facetheory-hydration" href="/_facetheory/hydration/next.json" type="application/json">
+            <script src="/assets/entry-client.js" type="module"></script>
+          </head>
+          <body>
+            <main data-facetheory-view><h1>External Page</h1></main>
+          </body>
+        </html>`,
+      {
+        parser: new dom.window.DOMParser(),
+        url: 'http://localhost/next',
+        viewSelector: DEFAULT_FACE_VIEW_SELECTOR,
+      },
+    );
+
+    await assert.rejects(
+      loadFaceNavigationModule(snapshot, { document: dom.window.document }),
+      /external hydration data must be loaded/,
+    );
+
+    const fetched: string[] = [];
+    const loaded = await loadFaceNavigationHydrationData(snapshot, {
+      allowedOrigin: 'http://localhost',
+      fetcher: async (input) => {
+        fetched.push(String(input));
+        return new Response(JSON.stringify({ page: 'external' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    });
+
+    assert.deepEqual(fetched, ['http://localhost/_facetheory/hydration/next.json']);
+    assert.deepEqual(loaded.hydration, {
+      type: 'external',
+      data: { page: 'external' },
+      dataUrl: '/_facetheory/hydration/next.json',
+      bootstrapModule: '/assets/entry-client.js',
     });
   } finally {
     dom.window.close();
@@ -204,6 +299,95 @@ test('spa helpers: startFaceNavigation intercepts links and invokes hydration ho
   }
 });
 
+test('spa helpers: startFaceNavigation loads external hydration before DOM mutation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <nav><a href="/next" id="next-link">Next</a></nav>
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+  dom.window.scrollTo = (() => {}) as typeof dom.window.scrollTo;
+
+  const fetched: string[] = [];
+  const hydrated: Array<{ data: unknown; text: string | null; url: string }> = [];
+
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    viewSelector: DEFAULT_FACE_VIEW_SELECTOR,
+    fetcher: async (input) => {
+      fetched.push(String(input));
+      if (String(input).endsWith('/_facetheory/hydration/next.json')) {
+        return new Response(JSON.stringify({ page: 'external-next' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(
+        `<!doctype html>
+          <html data-theme="night" lang="en">
+            <head>
+              <title>Next</title>
+              <link rel="facetheory-hydration" href="/_facetheory/hydration/next.json" type="application/json">
+              <script src="/assets/entry-client.js" type="module"></script>
+            </head>
+            <body class="shell-next">
+              <nav><a href="/next" id="next-link">Next</a></nav>
+              <main data-facetheory-view><p>Next Page</p></main>
+            </body>
+          </html>`,
+        { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } },
+      );
+    },
+    importModule: async () => ({
+      hydrateFaceNavigation: async (context) => {
+        hydrated.push({
+          data: context.data,
+          text: context.view?.textContent?.trim() ?? null,
+          url: context.url.toString(),
+        });
+      },
+    }),
+  });
+
+  try {
+    const link = dom.window.document.getElementById('next-link');
+    assert.ok(link instanceof dom.window.HTMLAnchorElement);
+
+    link.dispatchEvent(
+      new dom.window.MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      }),
+    );
+
+    await flushEventLoop();
+
+    assert.deepEqual(fetched, [
+      'http://localhost/next',
+      'http://localhost/_facetheory/hydration/next.json',
+    ]);
+    assert.equal(dom.window.location.pathname, '/next');
+    assert.equal(dom.window.document.title, 'Next');
+    assert.deepEqual(hydrated, [
+      {
+        data: { page: 'external-next' },
+        text: 'Next Page',
+        url: 'http://localhost/next',
+      },
+    ]);
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
 test('spa helpers: startFaceNavigation rejects cross-origin programmatic navigation', async () => {
   const dom = new JSDOM(
     `<!doctype html>
@@ -331,6 +515,119 @@ test('spa helpers: startFaceNavigation rejects remote hydration modules before D
     await assert.rejects(
       controller.navigate('/next'),
       /FaceTheory SPA hydration module resolved cross-origin/,
+    );
+
+    assert.equal(dom.window.location.href, 'http://localhost/');
+    assert.equal(dom.window.document.title, 'Home');
+    assert.equal(
+      dom.window.document.querySelector(DEFAULT_FACE_VIEW_SELECTOR)?.textContent?.trim(),
+      'Home',
+    );
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
+test('spa helpers: startFaceNavigation rejects cross-origin hydration data before DOM mutation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+
+  const fetched: string[] = [];
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    onError: () => {},
+    fetcher: async (input) => {
+      fetched.push(String(input));
+      return new Response(
+        `<!doctype html>
+          <html lang="en">
+            <head>
+              <title>Next</title>
+              <link rel="facetheory-hydration" href="https://evil.example/data.json" type="application/json">
+              <script src="/assets/entry-client.js" type="module"></script>
+            </head>
+            <body class="shell-next">
+              <main data-facetheory-view><p>Next Page</p></main>
+            </body>
+          </html>`,
+        { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } },
+      );
+    },
+  });
+
+  try {
+    await assert.rejects(
+      controller.navigate('/next'),
+      /FaceTheory SPA hydration data resolved cross-origin/,
+    );
+
+    assert.deepEqual(fetched, ['http://localhost/next']);
+    assert.equal(dom.window.location.href, 'http://localhost/');
+    assert.equal(dom.window.document.title, 'Home');
+    assert.equal(
+      dom.window.document.querySelector(DEFAULT_FACE_VIEW_SELECTOR)?.textContent?.trim(),
+      'Home',
+    );
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
+test('spa helpers: startFaceNavigation fails closed on invalid external hydration data', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    onError: () => {},
+    fetcher: async (input) => {
+      if (String(input).endsWith('/_facetheory/hydration/bad.json')) {
+        return new Response('not-json', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(
+        `<!doctype html>
+          <html lang="en">
+            <head>
+              <title>Next</title>
+              <link rel="facetheory-hydration" href="/_facetheory/hydration/bad.json" type="application/json">
+              <script src="/assets/entry-client.js" type="module"></script>
+            </head>
+            <body class="shell-next">
+              <main data-facetheory-view><p>Next Page</p></main>
+            </body>
+          </html>`,
+        { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } },
+      );
+    },
+  });
+
+  try {
+    await assert.rejects(
+      controller.navigate('/next'),
+      /hydration data response was not valid JSON/,
     );
 
     assert.equal(dom.window.location.href, 'http://localhost/');

--- a/ts/test/unit/vite.test.ts
+++ b/ts/test/unit/vite.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  externalHydrationForEntry,
   viteAssetsForEntry,
   viteDynamicImportPolicy,
   viteHydrationForEntry,
@@ -157,6 +158,86 @@ test('vite: hydration helper sets bootstrap module', () => {
   const hydration = viteHydrationForEntry(manifest, 'src/entry-client.tsx', { ok: true });
   assert.equal(hydration.bootstrapModule, '/assets/entry.aaa.js');
   assert.deepEqual(hydration.data, { ok: true });
+});
+
+test('vite: external hydration helper preserves dataUrl and bootstrap metadata', () => {
+  const manifest = {
+    'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
+  };
+
+  const hydration = externalHydrationForEntry(
+    manifest,
+    'src/entry-client.tsx',
+    { ok: true },
+    {
+      base: '/portal/',
+      dataUrl: '/portal/_facetheory/hydration/page.json',
+    },
+  );
+
+  assert.deepEqual(hydration, {
+    type: 'external',
+    data: { ok: true },
+    dataUrl: '/portal/_facetheory/hydration/page.json',
+    bootstrapModule: '/portal/assets/entry.aaa.js',
+  });
+});
+
+test('vite: external hydration helper accepts same-origin absolute dataUrl', () => {
+  const manifest = {
+    'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
+  };
+
+  const hydration = externalHydrationForEntry(
+    manifest,
+    'src/entry-client.tsx',
+    { ok: true },
+    {
+      base: 'https://app.example/assets-base/',
+      allowedOrigin: 'https://app.example',
+      dataUrl: 'https://app.example/_facetheory/hydration/page.json',
+    },
+  );
+
+  assert.equal(
+    hydration.bootstrapModule,
+    'https://app.example/assets-base/assets/entry.aaa.js',
+  );
+  assert.equal(
+    hydration.dataUrl,
+    'https://app.example/_facetheory/hydration/page.json',
+  );
+});
+
+test('vite: external hydration helper rejects unsafe and cross-origin dataUrl', () => {
+  const manifest = {
+    'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
+  };
+
+  assert.throws(
+    () =>
+      externalHydrationForEntry(manifest, 'src/entry-client.tsx', {}, {
+        dataUrl: 'javascript:alert(1)',
+      }),
+    /dataUrl must be http\(s\) or same-origin/,
+  );
+
+  assert.throws(
+    () =>
+      externalHydrationForEntry(manifest, 'src/entry-client.tsx', {}, {
+        allowedOrigin: 'https://app.example',
+        dataUrl: 'https://evil.example/page.json',
+      }),
+    /dataUrl resolved cross-origin/,
+  );
+
+  assert.throws(
+    () =>
+      externalHydrationForEntry(manifest, 'src/entry-client.tsx', {}, {
+        dataUrl: 'https://app.example/page.json',
+      }),
+    /dataUrl must be same-origin or relative/,
+  );
 });
 
 test('vite: dynamic import policy is ignore', () => {


### PR DESCRIPTION
## Milestone
strict-csp-core-contracts — adapter-neutral strict CSP policy, external hydration contracts, Vite helper, and SPA external hydration loading for THE-1155..THE-1158.

## Linear
Project: https://linear.app/theorycloud/project/facetheory-strict-csp-hydration-and-navigation-efd2d53fc1db
Milestone: strict-csp-core-contracts
Issues: THE-1155, THE-1156, THE-1157, THE-1158

## Render modes and adapters affected
- Render modes: SSR / SSG / ISR / SPA core contracts are affected.
- Adapters: React / Vue / Svelte receive the public core type surface, but no adapter-specific implementation is included in this milestone.

## Determinism impact
New determinism surface: external hydration metadata must identify the same bootstrap module and JSON data used for server render. This PR keeps legacy inline hydration unchanged by default and adds fail-closed same-origin checks for strict head output and SPA external hydration loading before DOM mutation.

## Backward compatibility
Additive. Legacy `{ data, bootstrapModule }` inline hydration remains valid and current default output is preserved when no strict CSP policy/external hydration shape is used.

## Tasks
- [x] THE-1155 — Add strict-CSP policy and hydration type contracts
- [x] THE-1156 — Render external hydration references and validate strict head output
- [x] THE-1157 — Add Vite external hydration helper
- [x] THE-1158 — Load external hydration data in SPA navigation helpers

## Validation
- [x] `scripts/verify-version-alignment.sh` — PASS (`version-alignment: PASS (3.1.2)`)
- [x] `git diff --check origin/staging...HEAD && git diff --check` — PASS
- [x] `cd ts && npm run typecheck` — PASS
- [x] `cd ts && npm run lint` — PASS
- [x] `cd ts && npm test` — PASS (283 passing, 1 skipped)
- [x] `cd ts && npm run build` — PASS
- [x] `cd ts && npm run check` — absent in current `ts/package.json`; equivalent commands above were run explicitly.

Focused coverage added:
- legacy inline compatibility and additive type contracts
- external hydration head metadata without inline JSON
- strict rejection of inline scripts, inline styles, raw head HTML, unsafe head attributes, unsafe/cross-origin bootstrap/data URLs
- Vite base path, manifest lookup, data URL preservation, unsafe/cross-origin data URL rejection, legacy helper compatibility
- SPA external hydration parsing/loading, fail-closed invalid data handling, same-origin enforcement, cross-origin rejection before DOM mutation

## Scope notes
- Includes the three strict-CSP planning docs under `docs/planning/` because the requester clarified that those docs are the project contract being implemented here.
- Does not implement runtime pre-flush enforcement, SSG/ISR sidecars, OAC navigation policy, adapter parity strict-mode enforcement, examples, docs-release, RC/stable release work, or Simulacrum repo edits.
- No version bump and no Release Please state changes.

## Risks / blockers
- No current blocker.
- Runtime-wide strict CSP enforcement is intentionally deferred to the next Factory milestone; this PR only adds the core contracts/helpers and head/SPA fail-closed behavior covered by THE-1155..THE-1158.

## Cross-repo coordination
None for this milestone.