### PR TITLE
feat(csp): add strict csp core contracts

### DIFF
--- a/ts/src/head.ts
+++ b/ts/src/head.ts
@@ -1,8 +1,15 @@
 import { escapeHTML, safeJson } from './html.js';
-import type { FaceAttributes, FaceHeadTag, FaceRenderResult } from './types.js';
+import type {
+  FaceAttributes,
+  FaceCspPolicy,
+  FaceHeadTag,
+  FaceHydration,
+  FaceRenderResult,
+} from './types.js';
 
 export interface RenderFaceHeadOptions {
   cspNonce?: string | null;
+  allowedOrigin?: string | URL;
 }
 
 export interface NormalizeHeadTagsOptions {
@@ -28,6 +35,160 @@ function safeHttpUrl(value: string): string | null {
       : null;
   } catch {
     return null;
+  }
+}
+
+function requireSafeHttpUrl(value: string, label: string): string {
+  const safe = safeHttpUrl(value);
+  if (!safe) {
+    throw new Error(`FaceTheory ${label} must be an http(s) or same-origin URL`);
+  }
+  return safe;
+}
+
+function isExternalHydration(
+  hydration: FaceHydration,
+): hydration is Extract<FaceHydration, { type: 'external' }> {
+  return hydration.type === 'external';
+}
+
+function normalizeAllowedOrigin(origin: string | URL | undefined): string | null {
+  if (origin === undefined) return null;
+  return new URL(String(origin)).origin;
+}
+
+function isAbsoluteOrProtocolRelativeUrl(value: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value) || value.startsWith('//');
+}
+
+function assertStrictSameOriginUrl(
+  value: string,
+  label: string,
+  allowedOrigin: string | null,
+): void {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) {
+    throw new Error(`FaceTheory strict CSP ${label} URL must not be empty`);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed, 'https://facetheory.invalid');
+  } catch {
+    throw new Error(`FaceTheory strict CSP ${label} URL is invalid: ${trimmed}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `FaceTheory strict CSP ${label} URL must be http(s) or same-origin: ${trimmed}`,
+    );
+  }
+
+  if (!isAbsoluteOrProtocolRelativeUrl(trimmed)) return;
+
+  if (!allowedOrigin) {
+    throw new Error(
+      `FaceTheory strict CSP ${label} URL must be same-origin or relative: ${trimmed}`,
+    );
+  }
+
+  if (parsed.origin !== allowedOrigin) {
+    throw new Error(
+      `FaceTheory strict CSP ${label} URL resolved cross-origin: expected ${allowedOrigin}, received ${parsed.origin}`,
+    );
+  }
+}
+
+function isCspDisabled(
+  policy: FaceCspPolicy | undefined,
+  key: keyof FaceCspPolicy,
+): boolean {
+  return policy?.[key] === false;
+}
+
+function validateStrictAttributes(
+  tag: FaceHeadTag,
+  attrs: FaceAttributes | undefined,
+  policy: FaceCspPolicy | undefined,
+  allowedOrigin: string | null,
+): void {
+  if (!attrs) return;
+
+  for (const [name, rawValue] of Object.entries(attrs)) {
+    if (rawValue === undefined || rawValue === null || rawValue === false) continue;
+    const lowerName = name.trim().toLowerCase();
+
+    if (isCspDisabled(policy, 'inlineScripts') && /^on[a-z]/.test(lowerName)) {
+      throw new Error(
+        `FaceTheory strict CSP rejects inline event handler attribute "${name}" in head`,
+      );
+    }
+
+    if (isCspDisabled(policy, 'inlineStyles') && lowerName === 'style') {
+      throw new Error('FaceTheory strict CSP rejects inline style attributes in head');
+    }
+
+    if (
+      isCspDisabled(policy, 'inlineScripts') &&
+      tag.type === 'script' &&
+      lowerName === 'src'
+    ) {
+      assertStrictSameOriginUrl(String(rawValue), 'script src', allowedOrigin);
+    }
+
+    if (
+      (isCspDisabled(policy, 'inlineScripts') ||
+        isCspDisabled(policy, 'inlineStyles')) &&
+      tag.type === 'link' &&
+      lowerName === 'href'
+    ) {
+      assertStrictSameOriginUrl(String(rawValue), 'link href', allowedOrigin);
+    }
+  }
+}
+
+function validateStrictHeadTags(
+  tags: FaceHeadTag[],
+  policy: FaceCspPolicy | undefined,
+  options: {
+    allowedOrigin?: string | URL;
+    allowedEscapedRawHtml?: string | null;
+  } = {},
+): void {
+  if (!policy) return;
+
+  const allowedOrigin = normalizeAllowedOrigin(options.allowedOrigin);
+  const allowedEscapedRawHtml = options.allowedEscapedRawHtml ?? null;
+
+  for (const tag of tags) {
+    switch (tag.type) {
+      case 'raw':
+        if (
+          isCspDisabled(policy, 'rawHead') &&
+          tag.html !== allowedEscapedRawHtml
+        ) {
+          throw new Error('FaceTheory strict CSP rejects raw head HTML');
+        }
+        break;
+      case 'script':
+        if (isCspDisabled(policy, 'inlineScripts') && tag.body !== undefined) {
+          throw new Error('FaceTheory strict CSP rejects inline script tags');
+        }
+        validateStrictAttributes(tag, tag.attrs, policy, allowedOrigin);
+        break;
+      case 'style':
+        if (isCspDisabled(policy, 'inlineStyles')) {
+          throw new Error('FaceTheory strict CSP rejects inline style tags');
+        }
+        validateStrictAttributes(tag, tag.attrs, policy, allowedOrigin);
+        break;
+      case 'meta':
+      case 'link':
+        validateStrictAttributes(tag, tag.attrs, policy, allowedOrigin);
+        break;
+      case 'title':
+        break;
+    }
   }
 }
 
@@ -197,6 +358,9 @@ export function renderFaceHead(
   options: RenderFaceHeadOptions = {},
 ): string {
   const tags: FaceHeadTag[] = [];
+  const escapedLegacyHeadHtml = out.head?.html
+    ? escapeHTML(out.head.html)
+    : null;
 
   if (out.headTags) tags.push(...out.headTags);
 
@@ -213,24 +377,54 @@ export function renderFaceHead(
   if (out.head?.title) {
     tags.push({ type: 'title', text: out.head.title });
   }
-  if (out.head?.html) {
-    tags.push({ type: 'raw', html: escapeHTML(out.head.html) });
+  if (escapedLegacyHeadHtml) {
+    tags.push({ type: 'raw', html: escapedLegacyHeadHtml });
   }
 
   if (out.hydration) {
-    tags.push({
-      type: 'script',
-      attrs: { id: '__FACETHEORY_DATA__', type: 'application/json' },
-      body: safeJson(out.hydration.data),
-    });
-    const bootstrapModule = safeHttpUrl(out.hydration.bootstrapModule);
-    if (bootstrapModule) {
+    if (isExternalHydration(out.hydration)) {
+      const dataUrl = requireSafeHttpUrl(out.hydration.dataUrl, 'external hydration dataUrl');
+      const bootstrapModule = requireSafeHttpUrl(
+        out.hydration.bootstrapModule,
+        'external hydration bootstrapModule',
+      );
+      tags.push({
+        type: 'link',
+        attrs: {
+          id: '__FACETHEORY_DATA_URL__',
+          rel: 'facetheory-hydration',
+          href: dataUrl,
+          type: 'application/json',
+        },
+      });
       tags.push({
         type: 'script',
         attrs: { type: 'module', src: bootstrapModule },
       });
+    } else {
+      tags.push({
+        type: 'script',
+        attrs: { id: '__FACETHEORY_DATA__', type: 'application/json' },
+        body: safeJson(out.hydration.data),
+      });
+      const bootstrapModule = safeHttpUrl(out.hydration.bootstrapModule);
+      if (bootstrapModule) {
+        tags.push({
+          type: 'script',
+          attrs: { type: 'module', src: bootstrapModule },
+        });
+      }
     }
   }
+
+  const validationOptions: {
+    allowedOrigin?: string | URL;
+    allowedEscapedRawHtml?: string | null;
+  } = { allowedEscapedRawHtml: escapedLegacyHeadHtml };
+  if (options.allowedOrigin !== undefined) {
+    validationOptions.allowedOrigin = options.allowedOrigin;
+  }
+  validateStrictHeadTags(tags, out.csp, validationOptions);
 
   return normalizeHeadTags(tags, { cspNonce: options.cspNonce ?? null })
     .map(renderHeadTag)

--- a/ts/src/spa.ts
+++ b/ts/src/spa.ts
@@ -384,6 +384,12 @@ export function startFaceNavigation(
     };
     if (options.fetcher !== undefined) fetchOptions.fetcher = options.fetcher;
     if (options.requestInit !== undefined) fetchOptions.requestInit = options.requestInit;
+    if (options.hydrationRequestInit !== undefined) {
+      fetchOptions.hydrationRequestInit = options.hydrationRequestInit;
+    }
+    if (options.loadExternalHydration !== undefined) {
+      fetchOptions.loadExternalHydration = options.loadExternalHydration;
+    }
     if (options.parser !== undefined) {
       fetchOptions.parser = options.parser;
     } else if (typeof winWithParser.DOMParser === 'function') {

--- a/ts/src/spa.ts
+++ b/ts/src/spa.ts
@@ -3,6 +3,8 @@ import type { FaceAttributes, FaceHydration } from './types.js';
 export const DEFAULT_FACE_VIEW_SELECTOR = '[data-facetheory-view]';
 
 const HYDRATION_DATA_SCRIPT_ID = '__FACETHEORY_DATA__';
+const HYDRATION_DATA_LINK_ID = '__FACETHEORY_DATA_URL__';
+const HYDRATION_DATA_LINK_REL = 'facetheory-hydration';
 const NAVIGATION_CACHE_BUST_PARAM = 'facetheory-nav';
 
 export interface FaceNavigationSnapshot {
@@ -26,6 +28,14 @@ export interface ParseFaceNavigationSnapshotOptions extends SnapshotFaceDocument
 }
 
 export interface FetchFaceNavigationSnapshotOptions extends ParseFaceNavigationSnapshotOptions {
+  allowedOrigin?: string | URL;
+  fetcher?: typeof fetch;
+  hydrationRequestInit?: RequestInit;
+  loadExternalHydration?: boolean;
+  requestInit?: RequestInit;
+}
+
+export interface LoadFaceNavigationHydrationDataOptions {
   allowedOrigin?: string | URL;
   fetcher?: typeof fetch;
   requestInit?: RequestInit;
@@ -96,14 +106,38 @@ export function readFaceHydrationData<T = unknown>(doc: Document = document): T 
   }
 }
 
+export function readFaceHydrationDataUrl(doc: Document = document): string | null {
+  const byId = doc.getElementById(HYDRATION_DATA_LINK_ID);
+  if (byId?.tagName.toLowerCase() === 'link') {
+    const href = byId.getAttribute('href');
+    if (href) return href;
+  }
+
+  const byRel = doc.querySelector(`link[rel="${HYDRATION_DATA_LINK_REL}"]`);
+  if (!byRel) return null;
+  const href = byRel.getAttribute('href');
+  return href || null;
+}
+
 export function snapshotFaceDocument(
   doc: Document,
   options: SnapshotFaceDocumentOptions = {},
 ): FaceNavigationSnapshot {
   const viewSelector = options.viewSelector ?? DEFAULT_FACE_VIEW_SELECTOR;
   const bootstrapModule = readHydrationBootstrapModule(doc);
+  const dataUrl = readFaceHydrationDataUrl(doc);
   const data = readFaceHydrationData(doc);
   const view = doc.querySelector(viewSelector);
+  const hydration: FaceHydration | null = dataUrl
+    ? {
+        type: 'external',
+        data: undefined,
+        dataUrl,
+        bootstrapModule: bootstrapModule ?? '',
+      }
+    : bootstrapModule
+      ? { bootstrapModule, data }
+      : null;
 
   return {
     url: resolveSnapshotUrl(doc, options.url),
@@ -113,7 +147,7 @@ export function snapshotFaceDocument(
     headHtml: doc.head.innerHTML,
     bodyHtml: doc.body.innerHTML,
     viewHtml: view ? view.innerHTML : null,
-    hydration: bootstrapModule ? { bootstrapModule, data } : null,
+    hydration,
   };
 }
 
@@ -173,7 +207,76 @@ export async function fetchFaceNavigationSnapshot(
     parseOptions.parser = options.parser;
   }
 
-  return parseFaceNavigationSnapshot(await response.text(), parseOptions);
+  const snapshot = parseFaceNavigationSnapshot(await response.text(), parseOptions);
+  if (options.loadExternalHydration === false) return snapshot;
+
+  const hydrationOptions: LoadFaceNavigationHydrationDataOptions = {};
+  if (allowedOrigin) hydrationOptions.allowedOrigin = allowedOrigin;
+  if (options.fetcher !== undefined) hydrationOptions.fetcher = options.fetcher;
+  if (options.hydrationRequestInit !== undefined) {
+    hydrationOptions.requestInit = options.hydrationRequestInit;
+  }
+  return loadFaceNavigationHydrationData(snapshot, hydrationOptions);
+}
+
+export async function loadFaceNavigationHydrationData(
+  snapshot: FaceNavigationSnapshot,
+  options: LoadFaceNavigationHydrationDataOptions = {},
+): Promise<FaceNavigationSnapshot> {
+  if (!isExternalHydration(snapshot.hydration)) return snapshot;
+
+  const fetcher = options.fetcher ?? globalThis.fetch;
+  if (typeof fetcher !== 'function') {
+    throw new Error('FaceTheory SPA helpers require fetch in the current environment');
+  }
+
+  const allowedOrigin =
+    resolveAllowedNavigationOrigin(options.allowedOrigin) ??
+    resolveNavigationUrl(snapshot.url, 'http://localhost/').origin;
+  const dataUrl = assertSameOriginNavigationUrl(
+    snapshot.hydration.dataUrl,
+    allowedOrigin,
+    snapshot.url,
+    'FaceTheory SPA hydration data resolved cross-origin',
+  );
+
+  const response = await fetcher(dataUrl.toString(), {
+    ...options.requestInit,
+    headers: {
+      accept: 'application/json',
+      ...(options.requestInit?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `FaceTheory hydration data fetch failed (${response.status}) for ${dataUrl.toString()}`,
+    );
+  }
+
+  assertSameOriginNavigationUrl(
+    response.url || dataUrl,
+    allowedOrigin,
+    snapshot.url,
+    'FaceTheory SPA hydration data fetch resolved cross-origin',
+  );
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new Error('FaceTheory hydration data response was not valid JSON', {
+      cause: error,
+    });
+  }
+
+  return {
+    ...snapshot,
+    hydration: {
+      ...snapshot.hydration,
+      data,
+    },
+  };
 }
 
 export function applyFaceNavigationSnapshot(
@@ -205,14 +308,20 @@ export async function loadFaceNavigationModule(
   snapshot: FaceNavigationSnapshot,
   options: LoadFaceNavigationModuleOptions = {},
 ): Promise<void> {
-  if (!snapshot.hydration?.bootstrapModule) return;
+  if (!snapshot.hydration) return;
+  if (isExternalHydration(snapshot.hydration) && snapshot.hydration.data === undefined) {
+    throw new Error(
+      'FaceTheory SPA external hydration data must be loaded before hydration',
+    );
+  }
+  if (!snapshot.hydration.bootstrapModule) return;
 
   const doc = options.document ?? document;
   const allowedOrigin =
     resolveAllowedNavigationOrigin(options.allowedOrigin) ??
     doc.defaultView?.location.origin ??
     resolveNavigationUrl(snapshot.url, 'http://localhost/').origin;
-  assertSameOriginHydrationModule(snapshot, allowedOrigin);
+  assertSameOriginHydrationReferences(snapshot, allowedOrigin);
   const importModule = options.importModule ?? importFaceNavigationModule;
   const context = createBootstrapContext(
     snapshot,
@@ -282,7 +391,7 @@ export function startFaceNavigation(
     }
 
     const snapshot = await fetchFaceNavigationSnapshot(url, fetchOptions);
-    assertSameOriginHydrationModule(snapshot, win.location.origin);
+    assertSameOriginHydrationReferences(snapshot, win.location.origin);
 
     if (options.render) {
       await options.render(
@@ -446,10 +555,13 @@ function syncAttributes(element: Element, nextAttrs: FaceAttributes): void {
 }
 
 function readHydrationBootstrapModule(doc: Document): string | null {
-  const dataScript = doc.getElementById(HYDRATION_DATA_SCRIPT_ID);
-  if (!dataScript) return null;
+  const marker =
+    doc.getElementById(HYDRATION_DATA_SCRIPT_ID) ??
+    doc.getElementById(HYDRATION_DATA_LINK_ID) ??
+    doc.querySelector(`link[rel="${HYDRATION_DATA_LINK_REL}"]`);
+  if (!marker) return null;
 
-  let current = dataScript.nextElementSibling;
+  let current = marker.nextElementSibling;
   while (current) {
     if (
       current.tagName.toLowerCase() === 'script' &&
@@ -521,19 +633,34 @@ function createBootstrapContext(
   };
 }
 
-function assertSameOriginHydrationModule(
+function isExternalHydration(
+  hydration: FaceHydration | null,
+): hydration is Extract<FaceHydration, { type: 'external' }> {
+  return hydration?.type === 'external';
+}
+
+function assertSameOriginHydrationReferences(
   snapshot: FaceNavigationSnapshot,
   allowedOrigin: string,
 ): void {
   const specifier = snapshot.hydration?.bootstrapModule;
-  if (!specifier) return;
+  if (specifier) {
+    assertSameOriginNavigationUrl(
+      specifier,
+      allowedOrigin,
+      snapshot.url,
+      'FaceTheory SPA hydration module resolved cross-origin',
+    );
+  }
 
-  assertSameOriginNavigationUrl(
-    specifier,
-    allowedOrigin,
-    snapshot.url,
-    'FaceTheory SPA hydration module resolved cross-origin',
-  );
+  if (isExternalHydration(snapshot.hydration)) {
+    assertSameOriginNavigationUrl(
+      snapshot.hydration.dataUrl,
+      allowedOrigin,
+      snapshot.url,
+      'FaceTheory SPA hydration data resolved cross-origin',
+    );
+  }
 }
 
 async function importFaceNavigationModule(

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -29,6 +29,49 @@ export interface FaceStyleTag {
   attrs?: FaceAttributes;
 }
 
+export interface FaceCspPolicy {
+  /**
+   * Whether FaceTheory-owned `<script>` tags may contain inline body text.
+   * Set this to `false` for strict no-inline CSP routes.
+   */
+  inlineScripts?: boolean;
+  /**
+   * Whether FaceTheory-owned `<style>` tags may contain inline CSS text or
+   * structured head attributes may contain inline style declarations.
+   * Set this to `false` for strict no-inline CSP routes.
+   */
+  inlineStyles?: boolean;
+  /**
+   * Whether raw, caller-owned head HTML may be emitted through
+   * `headTags: [{ type: "raw", html }]`.
+   */
+  rawHead?: boolean;
+}
+
+export interface FaceInlineHydration {
+  /**
+   * Optional for backward compatibility: the legacy hydration object shape is
+   * still `{ data, bootstrapModule }`, and is treated as inline hydration.
+   */
+  type?: 'inline';
+  data: unknown;
+  bootstrapModule: string;
+}
+
+export interface FaceExternalHydration {
+  type: 'external';
+  /**
+   * The exact data used for the server render. Strict renderers do not inline
+   * this value, but SSG/ISR/SSR sidecar helpers can persist it at `dataUrl`.
+   */
+  data: unknown;
+  /**
+   * Same-origin JSON URL from which the client loads `data` before hydration.
+   */
+  dataUrl: string;
+  bootstrapModule: string;
+}
+
 export interface FaceRequest {
   method: string;
   path: string;
@@ -69,10 +112,7 @@ export interface FaceHead {
   html?: string;
 }
 
-export interface FaceHydration {
-  data: unknown;
-  bootstrapModule: string;
-}
+export type FaceHydration = FaceInlineHydration | FaceExternalHydration;
 
 export interface FaceRenderResult {
   status?: number;
@@ -84,6 +124,7 @@ export interface FaceRenderResult {
   head?: FaceHead;
   headTags?: FaceHeadTag[];
   styleTags?: FaceStyleTag[];
+  csp?: FaceCspPolicy;
   html: string | AsyncIterable<Uint8Array>;
   hydration?: FaceHydration;
 }

--- a/ts/src/vite.ts
+++ b/ts/src/vite.ts
@@ -1,4 +1,4 @@
-import type { FaceHeadTag, FaceHydration } from './types.js';
+import type { FaceExternalHydration, FaceHeadTag, FaceHydration } from './types.js';
 
 export interface ViteManifestChunk {
   file: string;
@@ -17,6 +17,11 @@ export interface ViteAssetsOptions {
   crossorigin?: boolean;
   includeAssets?: boolean;
   dynamicImports?: DynamicImportPolicy;
+}
+
+export interface ViteExternalHydrationOptions extends ViteAssetsOptions {
+  dataUrl: string;
+  allowedOrigin?: string | URL;
 }
 
 export type DynamicImportPolicy = 'ignore';
@@ -117,6 +122,58 @@ function requireEntryChunk(manifest: ViteManifest, entry: string): ViteManifestC
     throw new Error(`vite manifest entry missing file: ${entry}`);
   }
   return chunk;
+}
+
+function isAbsoluteOrProtocolRelativeUrl(value: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value) || value.startsWith('//');
+}
+
+function originFromAbsoluteHttpUrl(value: string | URL | undefined): string | null {
+  if (value === undefined) return null;
+  const normalized = String(value);
+  if (!isAbsoluteOrProtocolRelativeUrl(normalized)) return null;
+  const parsed = new URL(normalized, 'https://facetheory.invalid');
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  return parsed.origin;
+}
+
+function assertSameOriginDataUrl(
+  dataUrl: string,
+  allowedOrigin: string | null,
+): string {
+  const trimmed = String(dataUrl ?? '').trim();
+  if (!trimmed) {
+    throw new Error('external hydration dataUrl must not be empty');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed, 'https://facetheory.invalid');
+  } catch {
+    throw new Error(`external hydration dataUrl is invalid: ${trimmed}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `external hydration dataUrl must be http(s) or same-origin: ${trimmed}`,
+    );
+  }
+
+  if (!isAbsoluteOrProtocolRelativeUrl(trimmed)) return trimmed;
+
+  if (!allowedOrigin) {
+    throw new Error(
+      `external hydration dataUrl must be same-origin or relative: ${trimmed}`,
+    );
+  }
+
+  if (parsed.origin !== allowedOrigin) {
+    throw new Error(
+      `external hydration dataUrl resolved cross-origin: expected ${allowedOrigin}, received ${parsed.origin}`,
+    );
+  }
+
+  return trimmed;
 }
 
 function stripSearchAndHash(path: string): string {
@@ -255,4 +312,23 @@ export function viteHydrationForEntry(
 ): FaceHydration {
   const { bootstrapModule } = viteAssetsForEntry(manifest, entry, options);
   return { data, bootstrapModule };
+}
+
+export function externalHydrationForEntry(
+  manifest: ViteManifest,
+  entry: string,
+  data: unknown,
+  options: ViteExternalHydrationOptions,
+): FaceExternalHydration {
+  const { bootstrapModule } = viteAssetsForEntry(manifest, entry, options);
+  const allowedOrigin =
+    options.allowedOrigin !== undefined
+      ? new URL(String(options.allowedOrigin)).origin
+      : originFromAbsoluteHttpUrl(options.base);
+  return {
+    type: 'external',
+    data,
+    dataUrl: assertSameOriginDataUrl(options.dataUrl, allowedOrigin),
+    bootstrapModule,
+  };
 }

--- a/ts/test/unit/head.test.ts
+++ b/ts/test/unit/head.test.ts
@@ -89,6 +89,159 @@ test('head: applies CSP nonce to inline styles and hydration scripts', () => {
   );
 });
 
+test('head: external hydration emits metadata without inline JSON', () => {
+  const head = renderFaceHead({
+    html: '<div>ok</div>',
+    hydration: {
+      type: 'external',
+      data: { a: '<script>&</script>' },
+      dataUrl: '/_facetheory/hydration/page.json',
+      bootstrapModule: '/assets/entry.js',
+    },
+  });
+
+  assert.ok(
+    head.includes(
+      '<link href="/_facetheory/hydration/page.json" id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration" type="application/json">',
+    ),
+  );
+  assert.ok(head.includes('<script src="/assets/entry.js" type="module"></script>'));
+  assert.equal(head.includes('__FACETHEORY_DATA__'), false);
+  assert.equal(head.includes('\\u003cscript'), false);
+});
+
+test('head: strict CSP rejects inline script, style, raw head, and unsafe attributes', () => {
+  const csp = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } as const;
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        hydration: { data: { page: 'inline' }, bootstrapModule: '/assets/entry.js' },
+      }),
+    /strict CSP rejects inline script tags/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        styleTags: [{ cssText: 'body{color:red}' }],
+      }),
+    /strict CSP rejects inline style tags/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        headTags: [{ type: 'raw', html: '<meta name="unsafe" content="1">' }],
+      }),
+    /strict CSP rejects raw head HTML/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        headTags: [{ type: 'meta', attrs: { onclick: 'alert(1)' } }],
+      }),
+    /inline event handler attribute/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        headTags: [{ type: 'meta', attrs: { style: 'color:red' } }],
+      }),
+    /inline style attributes/,
+  );
+});
+
+test('head: strict CSP allows external hydration with same-origin URLs', () => {
+  const head = renderFaceHead(
+    {
+      html: '<div>ok</div>',
+      csp: {
+        inlineScripts: false,
+        inlineStyles: false,
+        rawHead: false,
+      },
+      head: {
+        title: 'Strict',
+        html: '<meta name="escaped">',
+      },
+      headTags: [{ type: 'link', attrs: { rel: 'stylesheet', href: '/assets/app.css' } }],
+      hydration: {
+        type: 'external',
+        data: { page: 'strict' },
+        dataUrl: '/_facetheory/hydration/strict.json',
+        bootstrapModule: '/assets/entry.js',
+      },
+    },
+    { allowedOrigin: 'https://app.example' },
+  );
+
+  assert.ok(head.includes('<title>Strict</title>'));
+  assert.ok(head.includes('&lt;meta name=&quot;escaped&quot;&gt;'));
+  assert.ok(head.includes('href="/_facetheory/hydration/strict.json"'));
+  assert.equal(head.includes('__FACETHEORY_DATA__'), false);
+});
+
+test('head: strict CSP rejects cross-origin bootstrap and data URLs', () => {
+  const csp = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } as const;
+
+  assert.throws(
+    () =>
+      renderFaceHead(
+        {
+          html: '<div>ok</div>',
+          csp,
+          hydration: {
+            type: 'external',
+            data: { page: 'strict' },
+            dataUrl: '/_facetheory/hydration/strict.json',
+            bootstrapModule: 'https://evil.example/entry.js',
+          },
+        },
+        { allowedOrigin: 'https://app.example' },
+      ),
+    /script src URL resolved cross-origin/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead(
+        {
+          html: '<div>ok</div>',
+          csp,
+          hydration: {
+            type: 'external',
+            data: { page: 'strict' },
+            dataUrl: 'https://evil.example/data.json',
+            bootstrapModule: '/assets/entry.js',
+          },
+        },
+        { allowedOrigin: 'https://app.example' },
+      ),
+    /link href URL resolved cross-origin/,
+  );
+});
+
 test('head: escapes legacy head fields and blocks unsafe hydration module URLs', () => {
   const head = renderFaceHead({
     html: '<div>ok</div>',

--- a/ts/test/unit/head.test.ts
+++ b/ts/test/unit/head.test.ts
@@ -2,6 +2,43 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { renderFaceHead } from '../../src/head.js';
+import type { FaceCspPolicy, FaceHydration, FaceRenderResult } from '../../src/types.js';
+
+test('head contracts: strict CSP policy and hydration shapes are additive', () => {
+  const strictPolicy = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } satisfies FaceCspPolicy;
+
+  const legacyHydration = {
+    data: { page: 'legacy' },
+    bootstrapModule: '/assets/legacy.js',
+  } satisfies FaceHydration;
+
+  const explicitInlineHydration = {
+    type: 'inline',
+    data: { page: 'inline' },
+    bootstrapModule: '/assets/inline.js',
+  } satisfies FaceHydration;
+
+  const externalHydration = {
+    type: 'external',
+    data: { page: 'external' },
+    dataUrl: '/_facetheory/hydration/external.json',
+    bootstrapModule: '/assets/external.js',
+  } satisfies FaceHydration;
+
+  const renderResult = {
+    html: '<main>ok</main>',
+    csp: strictPolicy,
+    hydration: externalHydration,
+  } satisfies FaceRenderResult;
+
+  assert.equal(legacyHydration.bootstrapModule, '/assets/legacy.js');
+  assert.equal(explicitInlineHydration.type, 'inline');
+  assert.equal(renderResult.csp.inlineScripts, false);
+});
 
 test('head: charset meta then title, with dedupe (last wins)', () => {
   const head = renderFaceHead({

--- a/ts/test/unit/spa.test.ts
+++ b/ts/test/unit/spa.test.ts
@@ -6,9 +6,11 @@ import { JSDOM } from 'jsdom';
 import {
   applyFaceNavigationSnapshot,
   DEFAULT_FACE_VIEW_SELECTOR,
+  loadFaceNavigationHydrationData,
   loadFaceNavigationModule,
   parseFaceNavigationSnapshot,
   readFaceHydrationData,
+  readFaceHydrationDataUrl,
   startFaceNavigation,
 } from '../../src/spa.js';
 
@@ -51,6 +53,99 @@ test('spa helpers: parse FaceTheory documents into navigation snapshots', () => 
     assert.deepEqual(snapshot.hydration, {
       bootstrapModule: '/assets/entry-client.js',
       data: { page: 'next' },
+    });
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('spa helpers: parse external hydration metadata without inline data', () => {
+  const html = `<!doctype html>
+    <html lang="en">
+      <head>
+        <title>External</title>
+        <link id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration" href="/_facetheory/hydration/next.json" type="application/json">
+        <script src="/assets/entry-client.js" type="module"></script>
+      </head>
+      <body>
+        <main data-facetheory-view><h1>External Page</h1></main>
+      </body>
+    </html>`;
+
+  const dom = new JSDOM(html, { url: 'http://localhost/next' });
+
+  try {
+    assert.equal(readFaceHydrationData(dom.window.document), null);
+    assert.equal(
+      readFaceHydrationDataUrl(dom.window.document),
+      '/_facetheory/hydration/next.json',
+    );
+
+    const snapshot = parseFaceNavigationSnapshot(html, {
+      parser: new dom.window.DOMParser(),
+      url: 'http://localhost/next',
+      viewSelector: DEFAULT_FACE_VIEW_SELECTOR,
+    });
+
+    assert.deepEqual(snapshot.hydration, {
+      type: 'external',
+      data: undefined,
+      dataUrl: '/_facetheory/hydration/next.json',
+      bootstrapModule: '/assets/entry-client.js',
+    });
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('spa helpers: load external hydration data before module hydration', async () => {
+  const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>', {
+    url: 'http://localhost/',
+  });
+
+  try {
+    const snapshot = parseFaceNavigationSnapshot(
+      `<!doctype html>
+        <html lang="en">
+          <head>
+            <title>External</title>
+            <link rel="facetheory-hydration" href="/_facetheory/hydration/next.json" type="application/json">
+            <script src="/assets/entry-client.js" type="module"></script>
+          </head>
+          <body>
+            <main data-facetheory-view><h1>External Page</h1></main>
+          </body>
+        </html>`,
+      {
+        parser: new dom.window.DOMParser(),
+        url: 'http://localhost/next',
+        viewSelector: DEFAULT_FACE_VIEW_SELECTOR,
+      },
+    );
+
+    await assert.rejects(
+      loadFaceNavigationModule(snapshot, { document: dom.window.document }),
+      /external hydration data must be loaded/,
+    );
+
+    const fetched: string[] = [];
+    const loaded = await loadFaceNavigationHydrationData(snapshot, {
+      allowedOrigin: 'http://localhost',
+      fetcher: async (input) => {
+        fetched.push(String(input));
+        return new Response(JSON.stringify({ page: 'external' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    });
+
+    assert.deepEqual(fetched, ['http://localhost/_facetheory/hydration/next.json']);
+    assert.deepEqual(loaded.hydration, {
+      type: 'external',
+      data: { page: 'external' },
+      dataUrl: '/_facetheory/hydration/next.json',
+      bootstrapModule: '/assets/entry-client.js',
     });
   } finally {
     dom.window.close();
@@ -204,6 +299,95 @@ test('spa helpers: startFaceNavigation intercepts links and invokes hydration ho
   }
 });
 
+test('spa helpers: startFaceNavigation loads external hydration before DOM mutation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <nav><a href="/next" id="next-link">Next</a></nav>
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+  dom.window.scrollTo = (() => {}) as typeof dom.window.scrollTo;
+
+  const fetched: string[] = [];
+  const hydrated: Array<{ data: unknown; text: string | null; url: string }> = [];
+
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    viewSelector: DEFAULT_FACE_VIEW_SELECTOR,
+    fetcher: async (input) => {
+      fetched.push(String(input));
+      if (String(input).endsWith('/_facetheory/hydration/next.json')) {
+        return new Response(JSON.stringify({ page: 'external-next' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(
+        `<!doctype html>
+          <html data-theme="night" lang="en">
+            <head>
+              <title>Next</title>
+              <link rel="facetheory-hydration" href="/_facetheory/hydration/next.json" type="application/json">
+              <script src="/assets/entry-client.js" type="module"></script>
+            </head>
+            <body class="shell-next">
+              <nav><a href="/next" id="next-link">Next</a></nav>
+              <main data-facetheory-view><p>Next Page</p></main>
+            </body>
+          </html>`,
+        { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } },
+      );
+    },
+    importModule: async () => ({
+      hydrateFaceNavigation: async (context) => {
+        hydrated.push({
+          data: context.data,
+          text: context.view?.textContent?.trim() ?? null,
+          url: context.url.toString(),
+        });
+      },
+    }),
+  });
+
+  try {
+    const link = dom.window.document.getElementById('next-link');
+    assert.ok(link instanceof dom.window.HTMLAnchorElement);
+
+    link.dispatchEvent(
+      new dom.window.MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      }),
+    );
+
+    await flushEventLoop();
+
+    assert.deepEqual(fetched, [
+      'http://localhost/next',
+      'http://localhost/_facetheory/hydration/next.json',
+    ]);
+    assert.equal(dom.window.location.pathname, '/next');
+    assert.equal(dom.window.document.title, 'Next');
+    assert.deepEqual(hydrated, [
+      {
+        data: { page: 'external-next' },
+        text: 'Next Page',
+        url: 'http://localhost/next',
+      },
+    ]);
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
 test('spa helpers: startFaceNavigation rejects cross-origin programmatic navigation', async () => {
   const dom = new JSDOM(
     `<!doctype html>
@@ -331,6 +515,119 @@ test('spa helpers: startFaceNavigation rejects remote hydration modules before D
     await assert.rejects(
       controller.navigate('/next'),
       /FaceTheory SPA hydration module resolved cross-origin/,
+    );
+
+    assert.equal(dom.window.location.href, 'http://localhost/');
+    assert.equal(dom.window.document.title, 'Home');
+    assert.equal(
+      dom.window.document.querySelector(DEFAULT_FACE_VIEW_SELECTOR)?.textContent?.trim(),
+      'Home',
+    );
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
+test('spa helpers: startFaceNavigation rejects cross-origin hydration data before DOM mutation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+
+  const fetched: string[] = [];
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    onError: () => {},
+    fetcher: async (input) => {
+      fetched.push(String(input));
+      return new Response(
+        `<!doctype html>
+          <html lang="en">
+            <head>
+              <title>Next</title>
+              <link rel="facetheory-hydration" href="https://evil.example/data.json" type="application/json">
+              <script src="/assets/entry-client.js" type="module"></script>
+            </head>
+            <body class="shell-next">
+              <main data-facetheory-view><p>Next Page</p></main>
+            </body>
+          </html>`,
+        { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } },
+      );
+    },
+  });
+
+  try {
+    await assert.rejects(
+      controller.navigate('/next'),
+      /FaceTheory SPA hydration data resolved cross-origin/,
+    );
+
+    assert.deepEqual(fetched, ['http://localhost/next']);
+    assert.equal(dom.window.location.href, 'http://localhost/');
+    assert.equal(dom.window.document.title, 'Home');
+    assert.equal(
+      dom.window.document.querySelector(DEFAULT_FACE_VIEW_SELECTOR)?.textContent?.trim(),
+      'Home',
+    );
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
+test('spa helpers: startFaceNavigation fails closed on invalid external hydration data', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    onError: () => {},
+    fetcher: async (input) => {
+      if (String(input).endsWith('/_facetheory/hydration/bad.json')) {
+        return new Response('not-json', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(
+        `<!doctype html>
+          <html lang="en">
+            <head>
+              <title>Next</title>
+              <link rel="facetheory-hydration" href="/_facetheory/hydration/bad.json" type="application/json">
+              <script src="/assets/entry-client.js" type="module"></script>
+            </head>
+            <body class="shell-next">
+              <main data-facetheory-view><p>Next Page</p></main>
+            </body>
+          </html>`,
+        { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } },
+      );
+    },
+  });
+
+  try {
+    await assert.rejects(
+      controller.navigate('/next'),
+      /hydration data response was not valid JSON/,
     );
 
     assert.equal(dom.window.location.href, 'http://localhost/');

--- a/ts/test/unit/spa.test.ts
+++ b/ts/test/unit/spa.test.ts
@@ -313,15 +313,19 @@ test('spa helpers: startFaceNavigation loads external hydration before DOM mutat
   );
   dom.window.scrollTo = (() => {}) as typeof dom.window.scrollTo;
 
-  const fetched: string[] = [];
+  const fetched: Array<{ init: RequestInit | undefined; input: string }> = [];
   const hydrated: Array<{ data: unknown; text: string | null; url: string }> = [];
 
   const controller = startFaceNavigation({
     document: dom.window.document,
     window: dom.window as unknown as Window,
     viewSelector: DEFAULT_FACE_VIEW_SELECTOR,
-    fetcher: async (input) => {
-      fetched.push(String(input));
+    hydrationRequestInit: {
+      credentials: 'include',
+      headers: { 'x-hydration': 'custom' },
+    },
+    fetcher: async (input, init) => {
+      fetched.push({ input: String(input), init });
       if (String(input).endsWith('/_facetheory/hydration/next.json')) {
         return new Response(JSON.stringify({ page: 'external-next' }), {
           status: 200,
@@ -369,10 +373,23 @@ test('spa helpers: startFaceNavigation loads external hydration before DOM mutat
 
     await flushEventLoop();
 
-    assert.deepEqual(fetched, [
-      'http://localhost/next',
-      'http://localhost/_facetheory/hydration/next.json',
-    ]);
+    assert.deepEqual(
+      fetched.map((entry) => entry.input),
+      ['http://localhost/next', 'http://localhost/_facetheory/hydration/next.json'],
+    );
+    assert.equal(
+      (fetched[0]?.init?.headers as Record<string, string> | undefined)?.accept,
+      'text/html,application/xhtml+xml',
+    );
+    assert.equal(fetched[1]?.init?.credentials, 'include');
+    assert.equal(
+      (fetched[1]?.init?.headers as Record<string, string> | undefined)?.accept,
+      'application/json',
+    );
+    assert.equal(
+      (fetched[1]?.init?.headers as Record<string, string> | undefined)?.['x-hydration'],
+      'custom',
+    );
     assert.equal(dom.window.location.pathname, '/next');
     assert.equal(dom.window.document.title, 'Next');
     assert.deepEqual(hydrated, [
@@ -382,6 +399,72 @@ test('spa helpers: startFaceNavigation loads external hydration before DOM mutat
         url: 'http://localhost/next',
       },
     ]);
+  } finally {
+    controller.stop();
+    dom.window.close();
+  }
+});
+
+test('spa helpers: startFaceNavigation can opt out of external hydration loading', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html lang="en">
+        <head><title>Home</title></head>
+        <body class="shell">
+          <main data-facetheory-view><p>Home</p></main>
+        </body>
+      </html>`,
+    { url: 'http://localhost/' },
+  );
+  dom.window.scrollTo = (() => {}) as typeof dom.window.scrollTo;
+
+  const fetched: string[] = [];
+  const rendered: Array<{ data: unknown; hydrationData: unknown }> = [];
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    loadExternalHydration: false,
+    fetcher: async (input) => {
+      fetched.push(String(input));
+      return new Response(
+        `<!doctype html>
+          <html lang="en">
+            <head>
+              <title>Next</title>
+              <link rel="facetheory-hydration" href="/_facetheory/hydration/next.json" type="application/json">
+              <script src="/assets/entry-client.js" type="module"></script>
+            </head>
+            <body class="shell-next">
+              <main data-facetheory-view><p>Next Page</p></main>
+            </body>
+          </html>`,
+        { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } },
+      );
+    },
+    render: (snapshot, context) => {
+      rendered.push({
+        data: context.data,
+        hydrationData: snapshot.hydration?.data,
+      });
+    },
+  });
+
+  try {
+    await controller.navigate('/next');
+
+    assert.deepEqual(fetched, ['http://localhost/next']);
+    assert.deepEqual(rendered, [
+      {
+        data: null,
+        hydrationData: undefined,
+      },
+    ]);
+    assert.equal(dom.window.location.pathname, '/next');
+    assert.equal(dom.window.document.title, 'Home');
+    assert.equal(
+      dom.window.document.querySelector(DEFAULT_FACE_VIEW_SELECTOR)?.textContent?.trim(),
+      'Home',
+    );
   } finally {
     controller.stop();
     dom.window.close();

--- a/ts/test/unit/vite.test.ts
+++ b/ts/test/unit/vite.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  externalHydrationForEntry,
   viteAssetsForEntry,
   viteDynamicImportPolicy,
   viteHydrationForEntry,
@@ -157,6 +158,86 @@ test('vite: hydration helper sets bootstrap module', () => {
   const hydration = viteHydrationForEntry(manifest, 'src/entry-client.tsx', { ok: true });
   assert.equal(hydration.bootstrapModule, '/assets/entry.aaa.js');
   assert.deepEqual(hydration.data, { ok: true });
+});
+
+test('vite: external hydration helper preserves dataUrl and bootstrap metadata', () => {
+  const manifest = {
+    'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
+  };
+
+  const hydration = externalHydrationForEntry(
+    manifest,
+    'src/entry-client.tsx',
+    { ok: true },
+    {
+      base: '/portal/',
+      dataUrl: '/portal/_facetheory/hydration/page.json',
+    },
+  );
+
+  assert.deepEqual(hydration, {
+    type: 'external',
+    data: { ok: true },
+    dataUrl: '/portal/_facetheory/hydration/page.json',
+    bootstrapModule: '/portal/assets/entry.aaa.js',
+  });
+});
+
+test('vite: external hydration helper accepts same-origin absolute dataUrl', () => {
+  const manifest = {
+    'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
+  };
+
+  const hydration = externalHydrationForEntry(
+    manifest,
+    'src/entry-client.tsx',
+    { ok: true },
+    {
+      base: 'https://app.example/assets-base/',
+      allowedOrigin: 'https://app.example',
+      dataUrl: 'https://app.example/_facetheory/hydration/page.json',
+    },
+  );
+
+  assert.equal(
+    hydration.bootstrapModule,
+    'https://app.example/assets-base/assets/entry.aaa.js',
+  );
+  assert.equal(
+    hydration.dataUrl,
+    'https://app.example/_facetheory/hydration/page.json',
+  );
+});
+
+test('vite: external hydration helper rejects unsafe and cross-origin dataUrl', () => {
+  const manifest = {
+    'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
+  };
+
+  assert.throws(
+    () =>
+      externalHydrationForEntry(manifest, 'src/entry-client.tsx', {}, {
+        dataUrl: 'javascript:alert(1)',
+      }),
+    /dataUrl must be http\(s\) or same-origin/,
+  );
+
+  assert.throws(
+    () =>
+      externalHydrationForEntry(manifest, 'src/entry-client.tsx', {}, {
+        allowedOrigin: 'https://app.example',
+        dataUrl: 'https://evil.example/page.json',
+      }),
+    /dataUrl resolved cross-origin/,
+  );
+
+  assert.throws(
+    () =>
+      externalHydrationForEntry(manifest, 'src/entry-client.tsx', {}, {
+        dataUrl: 'https://app.example/page.json',
+      }),
+    /dataUrl must be same-origin or relative/,
+  );
 });
 
 test('vite: dynamic import policy is ignore', () => {


### PR DESCRIPTION
## Milestone
strict-csp-core-contracts — adapter-neutral strict CSP policy, external hydration contracts, Vite helper, and SPA external hydration loading for THE-1155..THE-1158.

## Linear
Project: https://linear.app/theorycloud/project/facetheory-strict-csp-hydration-and-navigation-efd2d53fc1db
Milestone: strict-csp-core-contracts
Issues: THE-1155, THE-1156, THE-1157, THE-1158

## Render modes and adapters affected
- Render modes: SSR / SSG / ISR / SPA core contracts are affected.
- Adapters: React / Vue / Svelte receive the public core type surface, but no adapter-specific implementation is included in this milestone.

## Determinism impact
New determinism surface: external hydration metadata must identify the same bootstrap module and JSON data used for server render. This PR keeps legacy inline hydration unchanged by default and adds fail-closed same-origin checks for strict head output and SPA external hydration loading before DOM mutation.

## Backward compatibility
Additive. Legacy `{ data, bootstrapModule }` inline hydration remains valid and current default output is preserved when no strict CSP policy/external hydration shape is used.

## Tasks
- [x] THE-1155 — Add strict-CSP policy and hydration type contracts
- [x] THE-1156 — Render external hydration references and validate strict head output
- [x] THE-1157 — Add Vite external hydration helper
- [x] THE-1158 — Load external hydration data in SPA navigation helpers

## Validation
- [x] Fresh full clone from `origin/staging` used for this PR branch; no planning docs included in the diff.
- [x] `npm ci` in `ts/` — PASS
- [x] `scripts/verify-version-alignment.sh` — PASS (`version-alignment: PASS (3.1.2)`)
- [x] `git diff --check origin/staging...HEAD && git diff --check` — PASS
- [x] `cd ts && npm run typecheck` — PASS
- [x] `cd ts && npm run lint` — PASS
- [x] `cd ts && npm test` — PASS (283 passing, 1 skipped)
- [x] `cd ts && npm run build` — PASS
- [x] `cd ts && npm run check` — absent in current `ts/package.json`; equivalent commands above were run explicitly.

Focused coverage added:
- legacy inline compatibility and additive type contracts
- external hydration head metadata without inline JSON
- strict rejection of inline scripts, inline styles, raw head HTML, unsafe head attributes, unsafe/cross-origin bootstrap/data URLs
- Vite base path, manifest lookup, data URL preservation, unsafe/cross-origin data URL rejection, legacy helper compatibility
- SPA external hydration parsing/loading, fail-closed invalid data handling, same-origin enforcement, cross-origin rejection before DOM mutation

## Scope notes
- This supersedes PR #182, which was opened before Factory’s option-3 clarification and included planning docs.
- This clean PR includes only the allowed issue paths for THE-1155..THE-1158:
  - `ts/src/types.ts`
  - `ts/src/head.ts`
  - `ts/src/vite.ts`
  - `ts/src/spa.ts`
  - `ts/test/unit/head.test.ts`
  - `ts/test/unit/vite.test.ts`
  - `ts/test/unit/spa.test.ts`
- Does not implement runtime pre-flush enforcement, SSG/ISR sidecars, OAC navigation policy, adapter parity strict-mode enforcement, examples, docs-release, RC/stable release work, or Simulacrum repo edits.
- No version bump and no Release Please state changes.

## Risks / blockers
- No current blocker.
- Runtime-wide strict CSP enforcement remains intentionally deferred to the next Factory milestone; this PR only adds the core contracts/helpers and head/SPA fail-closed behavior covered by THE-1155..THE-1158.

## Cross-repo coordination
None for this milestone.