### PR TITLE
feat(csp): enforce strict csp runtime

### DIFF
--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -15,6 +15,10 @@ import {
   type IsrRuntime,
 } from './isr.js';
 import { logLevelForStatus, type FaceObservabilityHooks } from './ops.js';
+import {
+  requiresStrictCspDocumentValidation,
+  validateStrictCspDocument,
+} from './security.js';
 import { Router } from './router.js';
 import type {
   FaceContext,
@@ -339,17 +343,36 @@ async function toHTTPResponse(
   const documentParts = withDocumentShell(out);
 
   if (typeof out.html === 'string') {
+    const documentHtml = renderHTMLDocument({
+      ...documentParts,
+      head,
+      body: out.html,
+    });
+    validateStrictCspDocument(documentHtml, { policy: out.csp });
+
     return {
       status,
       headers,
       cookies,
-      body: utf8(
-        renderHTMLDocument({
-          ...documentParts,
-          head,
-          body: out.html,
-        }),
-      ),
+      body: utf8(documentHtml),
+      isBase64: false,
+    };
+  }
+
+  if (requiresStrictCspDocumentValidation(out.csp)) {
+    const strictBody = await collectStreamAsUtf8Text(out.html);
+    const documentHtml = renderHTMLDocument({
+      ...documentParts,
+      head,
+      body: strictBody,
+    });
+    validateStrictCspDocument(documentHtml, { policy: out.csp });
+
+    return {
+      status,
+      headers,
+      cookies,
+      body: utf8(documentHtml),
       isBase64: false,
     };
   }
@@ -361,6 +384,20 @@ async function toHTTPResponse(
   });
 
   return { status, headers, cookies, body, isBase64: false };
+}
+
+async function collectStreamAsUtf8Text(
+  input: AsyncIterable<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  let out = '';
+
+  for await (const chunk of input) {
+    out += decoder.decode(chunk, { stream: true });
+  }
+
+  out += decoder.decode();
+  return out;
 }
 
 function withDocumentShell(

--- a/ts/src/security.ts
+++ b/ts/src/security.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from 'node:crypto';
 
+import type { FaceCspPolicy } from './types.js';
+
 /**
  * Generates a CSP nonce suitable for `script-src 'nonce-...'` and `style-src 'nonce-...'`.
  *
@@ -12,3 +14,168 @@ export function createCspNonce(bytes = 16): string {
   return randomBytes(size).toString('base64');
 }
 
+export interface StrictCspHeaderOptions {
+  /**
+   * Optional nonce for callers that intentionally allow FaceTheory-owned
+   * nonced inline tags. The strict default omits this so the header remains a
+   * no-inline baseline for external hydration contracts.
+   */
+  cspNonce?: string | null;
+}
+
+export interface StrictCspDocumentValidationOptions {
+  policy?: FaceCspPolicy | undefined;
+}
+
+const STRICT_CSP_DIRECTIVES: Array<[name: string, values: string[]]> = [
+  ['default-src', ["'self'"]],
+  ['base-uri', ["'self'"]],
+  ['object-src', ["'none'"]],
+  ['frame-ancestors', ["'none'"]],
+  ['script-src', ["'self'"]],
+  ['style-src', ["'self'"]],
+  ['img-src', ["'self'", 'data:']],
+  ['font-src', ["'self'"]],
+  ['connect-src', ["'self'"]],
+  ['form-action', ["'self'"]],
+];
+
+const START_TAG_RE = /<([a-zA-Z][a-zA-Z0-9:-]*)(\s[^<>]*?)?>/g;
+const SCRIPT_PAIR_RE = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
+
+/**
+ * Builds FaceTheory's canonical strict CSP header value.
+ *
+ * The default is same-origin and no-inline: it never emits
+ * `'unsafe-inline'` or `'unsafe-eval'`. Header attachment stays explicit so
+ * hosts can decide which Face responses should receive the policy.
+ */
+export function buildStrictCspHeader(
+  options: StrictCspHeaderOptions = {},
+): string {
+  const nonce = normalizeCspNonce(options.cspNonce ?? null);
+
+  return STRICT_CSP_DIRECTIVES.map(([name, baseValues]) => {
+    const values = [...baseValues];
+    if ((name === 'script-src' || name === 'style-src') && nonce) {
+      values.push(`'nonce-${nonce}'`);
+    }
+    return `${name} ${values.join(' ')}`;
+  }).join('; ');
+}
+
+/**
+ * Returns whether a policy requires whole-document validation beyond the
+ * structured head validation path.
+ */
+export function requiresStrictCspDocumentValidation(
+  policy: FaceCspPolicy | undefined,
+): boolean {
+  return policy?.inlineScripts === false || policy?.inlineStyles === false;
+}
+
+/**
+ * Validates a rendered HTML document against FaceTheory's strict no-inline
+ * CSP policy surface. This is deliberately deterministic and fail-closed; it
+ * catches raw body output that the structured head primitive cannot see.
+ */
+export function validateStrictCspDocument(
+  html: string,
+  options: StrictCspDocumentValidationOptions = {},
+): void {
+  const policy = options.policy;
+  if (!requiresStrictCspDocumentValidation(policy)) return;
+
+  const documentHtml = String(html ?? '');
+
+  if (policy?.inlineScripts === false) {
+    validateNoInlineScriptElements(documentHtml);
+  }
+  if (policy?.inlineStyles === false) {
+    validateNoInlineStyleElements(documentHtml);
+  }
+
+  validateNoUnsafeAttributes(documentHtml, policy);
+}
+
+function normalizeCspNonce(nonce: string | null): string | null {
+  if (nonce === null) return null;
+  const trimmed = String(nonce).trim();
+  if (!trimmed) return null;
+  if (/[\s;'\r\n]/.test(trimmed)) {
+    throw new Error('FaceTheory strict CSP nonce contains unsafe characters');
+  }
+  return trimmed;
+}
+
+function validateNoInlineScriptElements(html: string): void {
+  START_TAG_RE.lastIndex = 0;
+  let startMatch: RegExpExecArray | null;
+  while ((startMatch = START_TAG_RE.exec(html)) !== null) {
+    const tagName = String(startMatch[1] ?? '').toLowerCase();
+    if (tagName !== 'script') continue;
+
+    const attrs = String(startMatch[2] ?? '');
+    if (!hasHtmlAttribute(attrs, 'src')) {
+      throw new Error('FaceTheory strict CSP rejects inline script tags in document');
+    }
+  }
+
+  SCRIPT_PAIR_RE.lastIndex = 0;
+  let pairMatch: RegExpExecArray | null;
+  while ((pairMatch = SCRIPT_PAIR_RE.exec(html)) !== null) {
+    const body = String(pairMatch[2] ?? '');
+    if (body.trim().length > 0) {
+      throw new Error('FaceTheory strict CSP rejects inline script tags in document');
+    }
+  }
+}
+
+function validateNoInlineStyleElements(html: string): void {
+  START_TAG_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = START_TAG_RE.exec(html)) !== null) {
+    const tagName = String(match[1] ?? '').toLowerCase();
+    if (tagName === 'style') {
+      throw new Error('FaceTheory strict CSP rejects inline style tags in document');
+    }
+  }
+}
+
+function validateNoUnsafeAttributes(
+  html: string,
+  policy: FaceCspPolicy | undefined,
+): void {
+  START_TAG_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = START_TAG_RE.exec(html)) !== null) {
+    const attrs = String(match[2] ?? '');
+    if (!attrs) continue;
+
+    if (policy?.inlineScripts === false) {
+      const eventName = findInlineEventAttribute(attrs);
+      if (eventName) {
+        throw new Error(
+          `FaceTheory strict CSP rejects inline event handler attribute "${eventName}" in document`,
+        );
+      }
+    }
+
+    if (policy?.inlineStyles === false && hasHtmlAttribute(attrs, 'style')) {
+      throw new Error('FaceTheory strict CSP rejects inline style attributes in document');
+    }
+  }
+}
+
+function hasHtmlAttribute(attrs: string, name: string): boolean {
+  return new RegExp(`(?:^|\\s)${escapeRegExp(name)}(?:\\s*=|\\s|$)`, 'i').test(attrs);
+}
+
+function findInlineEventAttribute(attrs: string): string | null {
+  const match = /(?:^|\s)(on[a-z][\w:-]*)(?:\s*=|\s|$)/i.exec(attrs);
+  return match?.[1] ?? null;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/ts/test/unit/app.test.ts
+++ b/ts/test/unit/app.test.ts
@@ -217,6 +217,63 @@ test('FaceApp: emits document shell attrs through the public render contract', a
   );
 });
 
+
+
+test('FaceApp: strict CSP validates body HTML before returning a response', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/',
+        mode: 'ssr',
+        render: () => ({
+          csp: {
+            inlineScripts: false,
+            inlineStyles: false,
+            rawHead: false,
+          },
+          hydration: {
+            type: 'external',
+            data: { page: 'strict' },
+            dataUrl: '/_facetheory/hydration/home.json',
+            bootstrapModule: '/assets/entry.js',
+          },
+          html: '<main><button onclick="bad()">Unsafe</button></main>',
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 500);
+  assert.ok(resp.body instanceof Uint8Array);
+
+  const body = decodeBody(resp.body as Uint8Array);
+  assert.ok(body.includes('<h1>Internal Server Error</h1>'));
+  assert.equal(body.includes('onclick'), false);
+  assert.equal(body.includes('Unsafe'), false);
+});
+
+test('FaceApp: non-strict routes preserve legacy inline body output', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/',
+        mode: 'ssr',
+        render: () => ({
+          html: '<main><button onclick="legacy()" style="color:red">Legacy</button></main>',
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 200);
+
+  const body = decodeBody(resp.body as Uint8Array);
+  assert.ok(body.includes('onclick="legacy()"'));
+  assert.ok(body.includes('style="color:red"'));
+});
+
 test('parseCookiesFromHeaders: supports mixed case cookie header names', () => {
   const parsed = parseCookiesFromHeaders({
     Cookie: ['token=xyz'],

--- a/ts/test/unit/html.test.ts
+++ b/ts/test/unit/html.test.ts
@@ -2,6 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { escapeHTML, renderHTMLDocument, safeJson } from '../../src/html.js';
+import {
+  buildStrictCspHeader,
+  validateStrictCspDocument,
+} from '../../src/security.js';
 
 test('escapeHTML escapes basic characters', () => {
   assert.equal(escapeHTML(`a&b<c>d"e'f`), 'a&amp;b&lt;c&gt;d&quot;e&#39;f');
@@ -41,5 +45,84 @@ test('renderHTMLDocument merges document shell attrs deterministically', () => {
   assert.ok(
     html.includes('<body class="page" data-label="&lt;unsafe&gt;" hidden>ok</body>'),
     html,
+  );
+});
+
+
+test('security: strict CSP header uses deterministic same-origin no-inline defaults', () => {
+  const header = buildStrictCspHeader();
+
+  assert.equal(
+    header,
+    "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; form-action 'self'",
+  );
+  assert.equal(header.includes("'unsafe-inline'"), false);
+  assert.equal(header.includes("'unsafe-eval'"), false);
+});
+
+test('security: strict CSP header can include a deterministic nonce', () => {
+  const header = buildStrictCspHeader({ cspNonce: 'abc123' });
+
+  assert.ok(header.includes("script-src 'self' 'nonce-abc123'"));
+  assert.ok(header.includes("style-src 'self' 'nonce-abc123'"));
+  assert.equal(header.includes("'unsafe-inline'"), false);
+  assert.throws(
+    () => buildStrictCspHeader({ cspNonce: "bad; nonce" }),
+    /nonce contains unsafe characters/,
+  );
+});
+
+test('security: strict CSP document validator rejects inline document scripts and styles', () => {
+  const policy = { inlineScripts: false, inlineStyles: false, rawHead: false } as const;
+
+  assert.throws(
+    () =>
+      validateStrictCspDocument('<!doctype html><html><body><script>bad()</script></body></html>', {
+        policy,
+      }),
+    /inline script tags in document/,
+  );
+  assert.throws(
+    () =>
+      validateStrictCspDocument('<!doctype html><html><body><script type="application/json">{}</script></body></html>', {
+        policy,
+      }),
+    /inline script tags in document/,
+  );
+  assert.throws(
+    () =>
+      validateStrictCspDocument('<!doctype html><html><body><style>body{color:red}</style></body></html>', {
+        policy,
+      }),
+    /inline style tags in document/,
+  );
+  assert.doesNotThrow(() =>
+    validateStrictCspDocument('<!doctype html><html><body><script src="/assets/app.js"></script></body></html>', {
+      policy,
+    }),
+  );
+});
+
+test('security: strict CSP document validator rejects inline body attributes', () => {
+  const policy = { inlineScripts: false, inlineStyles: false, rawHead: false } as const;
+
+  assert.throws(
+    () =>
+      validateStrictCspDocument('<!doctype html><html><body><button onclick="bad()">x</button></body></html>', {
+        policy,
+      }),
+    /inline event handler attribute "onclick" in document/,
+  );
+  assert.throws(
+    () =>
+      validateStrictCspDocument('<!doctype html><html><body><main style="color:red">x</main></body></html>', {
+        policy,
+      }),
+    /inline style attributes in document/,
+  );
+  assert.doesNotThrow(() =>
+    validateStrictCspDocument('<!doctype html><html><body><main class="safe">x</main></body></html>', {
+      policy,
+    }),
   );
 });

--- a/ts/test/unit/streaming.test.ts
+++ b/ts/test/unit/streaming.test.ts
@@ -154,6 +154,79 @@ test('FaceApp: streaming emits document shell attrs before the body stream', asy
   assert.ok(!first.includes('streamed'));
 });
 
+
+
+test('FaceApp: strict CSP streaming responses are coerced to validated buffered HTML', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/',
+        mode: 'ssr',
+        render: () => ({
+          csp: {
+            inlineScripts: false,
+            inlineStyles: false,
+            rawHead: false,
+          },
+          hydration: {
+            type: 'external',
+            data: { page: 'strict-stream' },
+            dataUrl: '/_facetheory/hydration/strict-stream.json',
+            bootstrapModule: '/assets/entry.js',
+          },
+          html: streamFromString('<main>strict streamed</main>'),
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 200);
+  assert.ok(resp.body instanceof Uint8Array);
+
+  const full = new TextDecoder().decode(resp.body);
+  assert.ok(full.includes('<main>strict streamed</main>'));
+  assert.ok(full.includes('rel="facetheory-hydration"'));
+  assert.equal(full.includes('__FACETHEORY_DATA__'), false);
+});
+
+test('FaceApp: strict CSP streaming violations fail before bytes flush', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/',
+        mode: 'ssr',
+        render: () => ({
+          csp: {
+            inlineScripts: false,
+            inlineStyles: false,
+            rawHead: false,
+          },
+          hydration: {
+            type: 'external',
+            data: { page: 'strict-stream' },
+            dataUrl: '/_facetheory/hydration/strict-stream.json',
+            bootstrapModule: '/assets/entry.js',
+          },
+          html: (async function* () {
+            yield utf8('<main>first chunk</main>');
+            yield utf8('<button onclick="bad()">unsafe</button>');
+          })(),
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 500);
+  assert.ok(resp.body instanceof Uint8Array);
+
+  const full = new TextDecoder().decode(resp.body);
+  assert.ok(full.includes('<h1>Internal Server Error</h1>'));
+  assert.equal(full.includes('first chunk'), false);
+  assert.equal(full.includes('onclick'), false);
+});
+
 test('react adapter: streaming includes AntD + Emotion styles in head before body', async () => {
   function EmotionBox() {
     return jsx(


### PR DESCRIPTION
## Milestone
`strict-csp-runtime-enforcement` — enforce strict CSP before FaceApp emits HTML bytes and expose deterministic strict CSP helpers.

## Linear
Project: FaceTheory Strict CSP Hydration and Navigation
Milestone: `strict-csp-runtime-enforcement`
- THE-1159 — [05] Enforce strict CSP before FaceApp flushes bytes
- THE-1160 — [06] Add strict CSP header builder and optional document validator

## Stack / base
Stacked on PR #183 (`facetheory/strict-csp-core-contracts-clean`) at approved head `33a7768d141355055d2293363749534053839888`.

This PR targets `facetheory/strict-csp-core-contracts-clean` so review can focus on only the THE-1159/THE-1160 delta. After PR #183 lands to `staging`, this branch can be retargeted/rebased as directed by Factory.

## Render modes and adapters affected
- Core runtime: SSR and streaming SSR response construction.
- SPA shell is affected only through shared FaceApp HTML response validation.
- No React/Vue/Svelte adapter-specific changes in this milestone.

## Determinism impact
Strict CSP routes now validate the full rendered document deterministically before a response body can be returned to Lambda/AppTheory writers. Strict streaming responses that need whole-document validation are coerced to a buffered response so unsafe body output cannot flush before validation completes.

## Backward compatibility
Additive for non-strict/default behavior. Routes without `csp.inlineScripts === false` or `csp.inlineStyles === false` retain existing string and streaming behavior.

## Scope summary
- Added `buildStrictCspHeader()` for canonical same-origin no-inline CSP header values.
- Added `validateStrictCspDocument()` and `requiresStrictCspDocumentValidation()` to fail closed on inline document scripts/styles and inline `style=` / event-handler attributes.
- Integrated strict document validation into `FaceApp` before buffered response emission.
- Coerced strict streaming responses into validated buffered HTML so validation completes before any bytes can flush.
- Added focused unit coverage for helper behavior, buffered strict success, strict body violations, strict streaming preflush failures, and legacy non-strict behavior.

## Tasks
- [x] THE-1160 — Add strict CSP header builder and optional document validator
- [x] THE-1159 — Enforce strict CSP before FaceApp flushes bytes

## Validation
- `git diff --check origin/facetheory/strict-csp-core-contracts-clean...HEAD` — PASS
- `git diff --check` — PASS
- `scripts/verify-version-alignment.sh` — PASS (3.1.2)
- `cd ts && npm ci` — PASS
- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run lint` — PASS
- `cd ts && npm test` — PASS (292 pass / 1 skipped)
- `cd ts && npm run build` — PASS
- `cd ts && npm run check` — not present in this checkout; explicit gates above were run.

## Risks / notes
- Strict streaming responses that disable inline scripts or styles are intentionally buffered for this milestone. That preserves the pre-flush guarantee at the cost of streaming TTFB for strict routes until later adapter/sidecar milestones can certify narrower streaming paths.
- Header attachment remains explicit; this PR exposes the builder but does not automatically add a CSP header to every response.

## Explicit exclusions
No SSG/ISR sidecars, OAC navigation policies, adapter parity wiring, examples, docs-release, RC/stable publication, release-please/version bumps, Simulacrum edits, AWS/deploy/account/secret/live-receipt work, or sibling/parent repo edits.
