### PR TITLE
feat(csp): emit strict static and isr sidecars

### DIFF
--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -12,6 +12,7 @@ import {
   InMemoryHtmlStore,
   InMemoryIsrMetaStore,
   type FaceIsrOptions,
+  type IsrRenderFreshOptions,
   type IsrRuntime,
 } from './isr.js';
 import { logLevelForStatus, type FaceObservabilityHooks } from './ops.js';
@@ -22,6 +23,8 @@ import {
 import { Router } from './router.js';
 import type {
   FaceContext,
+  FaceExternalHydration,
+  FaceHydration,
   FaceMode,
   FaceModule,
   FaceRenderResult,
@@ -140,11 +143,16 @@ export class FaceApp {
     };
 
     try {
-      const renderFresh = async (): Promise<FaceResponse> => {
+      const renderFresh = async (
+        isrOptions?: IsrRenderFreshOptions,
+      ): Promise<FaceResponse> => {
         const renderStartedAt = now();
         const data = face.load ? await face.load(ctx) : null;
         try {
-          const out = await face.render(ctx, data);
+          const out = prepareRenderResultForIsr(
+            await face.render(ctx, data),
+            isrOptions,
+          );
           return await toHTTPResponse(out, normalizedReq);
         } finally {
           renderMs = Math.max(0, now() - renderStartedAt);
@@ -325,6 +333,43 @@ function toHeaders(input: FaceRenderResult['headers'], cookies: string[] | undef
     sortedHeaders[key] = headers[key] ?? [];
   }
   return sortedHeaders;
+}
+
+function prepareRenderResultForIsr(
+  out: FaceRenderResult,
+  options: IsrRenderFreshOptions | undefined,
+): FaceRenderResult {
+  const dataUrl = options?.strictExternalHydrationDataUrl;
+  if (
+    dataUrl === undefined ||
+    out.csp?.inlineScripts !== false ||
+    out.hydration === undefined
+  ) {
+    return out;
+  }
+
+  const hydration = externalizeHydrationForIsr(out.hydration, dataUrl);
+  options?.onHydrationSidecar?.({
+    data: hydration.data,
+    dataUrl: hydration.dataUrl,
+  });
+
+  return {
+    ...out,
+    hydration,
+  };
+}
+
+function externalizeHydrationForIsr(
+  hydration: FaceHydration,
+  dataUrl: string,
+): FaceExternalHydration {
+  return {
+    type: 'external',
+    data: hydration.data,
+    dataUrl,
+    bootstrapModule: hydration.bootstrapModule,
+  };
 }
 
 async function toHTTPResponse(

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -1,5 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 
+import { utf8 } from './bytes.js';
+import { safeJson } from './html.js';
 import type {
   CookieMap,
   FaceContext,
@@ -30,6 +32,9 @@ const DEFAULT_TENANT_BOUNDARY_HEADERS = [
   'x-tenant-id',
   'x-facetheory-tenant',
 ] as const;
+const ISR_HYDRATION_QUERY_PARAM = '__facetheory_isr_hydration';
+const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
+const HYDRATION_SIDECAR_CACHE_CONTROL = 'no-store';
 
 export type IsrFailurePolicy = 'serve-stale' | 'error';
 export type IsrLockContentionPolicy = 'wait' | 'serve-stale';
@@ -136,7 +141,17 @@ export interface HandleIsrFaceInput {
   face: FaceModule;
   ctx: FaceContext;
   routePattern: string;
-  renderFresh: () => Promise<FaceResponse>;
+  renderFresh: (options?: IsrRenderFreshOptions) => Promise<FaceResponse>;
+}
+
+export interface IsrHydrationSidecar {
+  data: unknown;
+  dataUrl: string;
+}
+
+export interface IsrRenderFreshOptions {
+  strictExternalHydrationDataUrl?: string;
+  onHydrationSidecar?: (sidecar: IsrHydrationSidecar) => void;
 }
 
 export interface IsrRuntime {
@@ -394,6 +409,20 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
         input.face.revalidateSeconds,
       );
       assertPartitionedTenantBoundary(runtimeOptions, input.ctx);
+
+      const hydrationSidecarPointer = hydrationSidecarPointerFromRequest(
+        input.ctx.request.query,
+        runtimeOptions.htmlPointerPrefix,
+      );
+      if (hydrationSidecarPointer.present) {
+        return hydrationSidecarPointer.pointer
+          ? cachedHydrationSidecarResponse(
+              runtimeOptions,
+              hydrationSidecarPointer.pointer,
+            )
+          : hydrationSidecarNotFoundResponse();
+      }
+
       const tenant = resolveTenant(runtimeOptions, input.ctx);
       const cacheKey = runtimeOptions.cacheKey({
         tenant,
@@ -617,17 +646,44 @@ async function regenerateAndCommit(
   staleRecord: IsrMetaRecord,
 ): Promise<FaceResponse> {
   const generatedAt = runtimeOptions.now();
+  const htmlPointer = buildHtmlPointer(
+    cacheKey,
+    generatedAt,
+    runtimeOptions.htmlPointerPrefix,
+  );
+  const hydrationSidecarPointer =
+    buildHydrationSidecarPointerFromHtmlPointer(htmlPointer);
+  const hydrationDataUrl = buildHydrationSidecarDataUrl(
+    input.ctx.request.path,
+    hydrationSidecarPointer,
+  );
+  const hydrationSidecarRef: { current: IsrHydrationSidecar | null } = {
+    current: null,
+  };
+
   try {
-    const prepared = await prepareFreshResponse(await input.renderFresh());
+    const prepared = await prepareFreshResponse(
+      await input.renderFresh({
+        strictExternalHydrationDataUrl: hydrationDataUrl,
+        onHydrationSidecar: (sidecar) => {
+          hydrationSidecarRef.current = sidecar;
+        },
+      }),
+    );
     if (prepared.status >= 500) {
       throw new Error(`ISR regeneration produced status ${prepared.status}`);
     }
 
-    const htmlPointer = buildHtmlPointer(
-      cacheKey,
-      generatedAt,
-      runtimeOptions.htmlPointerPrefix,
-    );
+    const hydrationSidecar = hydrationSidecarRef.current;
+    if (hydrationSidecar !== null) {
+      await runtimeOptions.htmlStore.write({
+        key: hydrationSidecarPointer,
+        body: utf8(`${safeJson(hydrationSidecar.data)}\n`),
+        contentType: JSON_CONTENT_TYPE,
+        cacheControl: HYDRATION_SIDECAR_CACHE_CONTROL,
+      });
+    }
+
     const write = await runtimeOptions.htmlStore.write({
       key: htmlPointer,
       body: prepared.body,
@@ -855,6 +911,115 @@ function buildHtmlPointer(
     .digest('hex')
     .slice(0, 24);
   return `${prefix}${digest}/${generatedAt}-${randomUUID()}.html`;
+}
+
+function buildHydrationSidecarPointerFromHtmlPointer(
+  htmlPointer: string,
+): string {
+  return htmlPointer.endsWith('.html')
+    ? `${htmlPointer.slice(0, -'.html'.length)}.hydration.json`
+    : `${htmlPointer}.hydration.json`;
+}
+
+function buildHydrationSidecarDataUrl(
+  routePath: string,
+  sidecarPointer: string,
+): string {
+  const token = Buffer.from(sidecarPointer, 'utf8').toString('base64url');
+  return `${normalizePath(routePath)}?${ISR_HYDRATION_QUERY_PARAM}=${encodeURIComponent(token)}`;
+}
+
+function hydrationSidecarPointerFromRequest(
+  query: Query,
+  htmlPointerPrefix: string,
+): { present: false } | { present: true; pointer: string | null } {
+  const values = query[ISR_HYDRATION_QUERY_PARAM] ?? [];
+  if (values.length === 0) return { present: false };
+  if (values.length !== 1) return { present: true, pointer: null };
+
+  const token = String(values[0] ?? '').trim();
+  if (!token) return { present: true, pointer: null };
+
+  let pointer: string;
+  try {
+    pointer = Buffer.from(token, 'base64url').toString('utf8');
+  } catch {
+    return { present: true, pointer: null };
+  }
+
+  if (!isValidHydrationSidecarPointer(pointer, htmlPointerPrefix)) {
+    return { present: true, pointer: null };
+  }
+
+  return { present: true, pointer };
+}
+
+function isValidHydrationSidecarPointer(
+  pointer: string,
+  htmlPointerPrefix: string,
+): boolean {
+  const normalized = String(pointer ?? '').trim();
+  if (!normalized) return false;
+  if (normalized.startsWith('/') || normalized.includes('\\')) return false;
+  if (!normalized.endsWith('.hydration.json')) return false;
+  if (htmlPointerPrefix && !normalized.startsWith(htmlPointerPrefix)) {
+    return false;
+  }
+
+  const relative = htmlPointerPrefix
+    ? normalized.slice(htmlPointerPrefix.length)
+    : normalized;
+  const parts = relative.split('/');
+  if (
+    parts.length !== 2 ||
+    !/^[a-f0-9]{24}$/i.test(parts[0] ?? '') ||
+    !/^\d+-[a-f0-9-]{36}\.hydration\.json$/i.test(parts[1] ?? '')
+  ) {
+    return false;
+  }
+
+  for (const part of normalized.split('/')) {
+    if (!part || part === '.' || part === '..') return false;
+  }
+
+  return true;
+}
+
+async function cachedHydrationSidecarResponse(
+  runtimeOptions: CreateIsrRuntimeOptions,
+  pointer: string,
+): Promise<FaceResponse> {
+  const sidecar = await runtimeOptions.htmlStore.read(pointer);
+  if (!sidecar) return hydrationSidecarNotFoundResponse();
+
+  const headers: Headers = {
+    'cache-control': [HYDRATION_SIDECAR_CACHE_CONTROL],
+    'content-type': [JSON_CONTENT_TYPE],
+  };
+  if (sidecar.etag) {
+    headers.etag = [sidecar.etag];
+  }
+
+  return {
+    status: 200,
+    headers: sortHeaders(headers),
+    cookies: [],
+    body: Uint8Array.from(sidecar.body),
+    isBase64: false,
+  };
+}
+
+function hydrationSidecarNotFoundResponse(): FaceResponse {
+  return {
+    status: 404,
+    headers: {
+      'cache-control': ['no-store'],
+      'content-type': ['text/plain; charset=utf-8'],
+    },
+    cookies: [],
+    body: utf8('Not Found'),
+    isBase64: false,
+  };
 }
 
 function createDefaultMetaRecord(

--- a/ts/src/ssg.ts
+++ b/ts/src/ssg.ts
@@ -2,8 +2,14 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { createFaceApp } from './app.js';
-import { renderHTMLDocument } from './html.js';
-import type { FaceBody, FaceModule, Headers } from './types.js';
+import { renderHTMLDocument, safeJson } from './html.js';
+import type {
+  FaceBody,
+  FaceHydration,
+  FaceModule,
+  FaceRenderResult,
+  Headers,
+} from './types.js';
 import {
   normalizePath,
   trimLeadingSlashes,
@@ -63,6 +69,10 @@ interface PlannedPage {
   path: string;
 }
 
+interface SsgHydrationSidecar {
+  data: unknown;
+}
+
 const DEFAULT_ASSET_MANIFEST_PATH = '.vite/manifest.json';
 const DEFAULT_404_HTML = renderHTMLDocument({
   head: '<title>Not Found</title>',
@@ -87,7 +97,13 @@ export async function buildSsgSite(
   }
   await mkdir(outDir, { recursive: true });
 
-  const app = createFaceApp({ faces: options.faces });
+  const strictHydrationSidecars = new Map<string, SsgHydrationSidecar>();
+  const app = createFaceApp({
+    faces: withSsgStrictHydrationSidecars(
+      options.faces,
+      strictHydrationSidecars,
+    ),
+  });
   const plannedPages = await planSsgPages(options.faces);
 
   const builtPages: SsgPageEntry[] = [];
@@ -125,8 +141,16 @@ export async function buildSsgSite(
 
         await writeOutFile(outDir, file, html);
 
+        const strictHydrationSidecar = strictHydrationSidecars.get(page.path);
         let hydrationDataFile: string | undefined;
-        if (emitHydrationData) {
+        if (strictHydrationSidecar !== undefined) {
+          hydrationDataFile = ssgHydrationDataFilePathForRoute(page.path);
+          await writeOutFile(
+            outDir,
+            hydrationDataFile,
+            `${safeJson(strictHydrationSidecar.data)}\n`,
+          );
+        } else if (emitHydrationData) {
           const hydrationJson = extractHydrationDataJson(html);
           if (hydrationJson !== null) {
             hydrationDataFile = ssgHydrationDataFilePathForRoute(page.path);
@@ -251,6 +275,53 @@ export async function planSsgPages(
   }
 
   return planned;
+}
+
+function withSsgStrictHydrationSidecars(
+  faces: FaceModule[],
+  sidecars: Map<string, SsgHydrationSidecar>,
+): FaceModule[] {
+  return faces.map((face) => {
+    if (face.mode !== 'ssg') return face;
+
+    return {
+      ...face,
+      render: async (ctx, data) => {
+        const out = await face.render(ctx, data);
+        if (!requiresSsgStrictHydrationSidecar(out)) return out;
+
+        const routePath = normalizePath(ctx.request.path);
+        const hydrationDataFile = ssgHydrationDataFilePathForRoute(routePath);
+        sidecars.set(routePath, { data: out.hydration.data });
+
+        return {
+          ...out,
+          hydration: externalizeSsgHydration(
+            out.hydration,
+            `/${hydrationDataFile}`,
+          ),
+        };
+      },
+    };
+  });
+}
+
+function requiresSsgStrictHydrationSidecar(
+  out: FaceRenderResult,
+): out is FaceRenderResult & { hydration: FaceHydration } {
+  return out.csp?.inlineScripts === false && out.hydration !== undefined;
+}
+
+function externalizeSsgHydration(
+  hydration: FaceHydration,
+  dataUrl: string,
+): FaceHydration {
+  return {
+    type: 'external',
+    data: hydration.data,
+    dataUrl,
+    bootstrapModule: hydration.bootstrapModule,
+  };
 }
 
 export function ssgFilePathForRoute(

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -7,6 +7,8 @@ import {
   createIsrRuntime,
   defaultIsrCacheKey,
   type FaceIsrOptions,
+  type HtmlStoreWriteInput,
+  type HtmlStoreWriteResult,
   InMemoryHtmlStore,
   InMemoryIsrMetaStore,
   type IsrMetaRecord,
@@ -19,6 +21,14 @@ import {
 
 function decodeBody(body: Uint8Array): string {
   return new TextDecoder().decode(body);
+}
+
+function externalHydrationHref(html: string): string {
+  const tag = /<link\b[^>]*__FACETHEORY_DATA_URL__[^>]*>/i.exec(html)?.[0];
+  assert.ok(tag, 'expected external hydration link tag');
+  const href = /\bhref="([^"]+)"/i.exec(tag)?.[1];
+  assert.ok(href, 'expected external hydration href');
+  return href;
 }
 
 function delay(ms: number): Promise<void> {
@@ -682,4 +692,212 @@ test('isr: metadata commits never include HTML body text', async () => {
         typeof commit.htmlPointer === 'string' && commit.htmlPointer.length > 0,
     ),
   );
+});
+
+test('isr: strict CSP hydration writes and serves pointer-derived sidecars', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  const secret = 'HYDRATION_SECRET_PAYLOAD';
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/posts/{slug}',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: (ctx) => {
+          const seq = ++renderCount;
+          return {
+            csp: {
+              inlineScripts: false,
+              inlineStyles: false,
+              rawHead: false,
+            },
+            html: `<main>${ctx.params.slug}-${seq}</main>`,
+            hydration: {
+              data: {
+                slug: ctx.params.slug,
+                seq,
+                secret,
+                terminator: '</script>',
+              },
+              bootstrapModule: '/assets/client-entry.js',
+            },
+          };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => 1_000,
+    },
+  });
+
+  const miss = await app.handle({ method: 'GET', path: '/posts/a' });
+  const missHtml = decodeBody(miss.body as Uint8Array);
+  const sidecarHref = externalHydrationHref(missHtml);
+
+  assert.equal(miss.headers['x-facetheory-isr']?.[0], 'miss');
+  assert.ok(missHtml.includes('<main>a-1</main>'));
+  assert.ok(missHtml.includes('src="/assets/client-entry.js"'));
+  assert.equal(missHtml.includes('id="__FACETHEORY_DATA__"'), false);
+  assert.equal(missHtml.includes(secret), false);
+  assert.match(sidecarHref, /^\/posts\/a\?__facetheory_isr_hydration=/);
+
+  const sidecar = await app.handle({ method: 'GET', path: sidecarHref });
+  assert.equal(sidecar.status, 200);
+  assert.equal(sidecar.headers['content-type']?.[0], 'application/json; charset=utf-8');
+  assert.equal(renderCount, 1);
+
+  const sidecarJson = decodeBody(sidecar.body as Uint8Array);
+  assert.equal(sidecarJson.includes('<'), false);
+  assert.deepEqual(JSON.parse(sidecarJson), {
+    slug: 'a',
+    seq: 1,
+    secret,
+    terminator: '</script>',
+  });
+
+  const hit = await app.handle({ method: 'GET', path: '/posts/a' });
+  const hitHtml = decodeBody(hit.body as Uint8Array);
+  assert.equal(hit.headers['x-facetheory-isr']?.[0], 'hit');
+  assert.equal(externalHydrationHref(hitHtml), sidecarHref);
+  assert.equal(renderCount, 1);
+
+  const serializedMeta = JSON.stringify(metaStore.debugSnapshot());
+  assert.equal(serializedMeta.includes(secret), false);
+  assert.equal(serializedMeta.includes('terminator'), false);
+});
+
+class FailingSidecarHtmlStore extends InMemoryHtmlStore {
+  failSidecarWrites = false;
+
+  override async write(
+    input: HtmlStoreWriteInput,
+  ): Promise<HtmlStoreWriteResult> {
+    if (this.failSidecarWrites && input.key.endsWith('.hydration.json')) {
+      throw new Error('sidecar write failed');
+    }
+    return await super.write(input);
+  }
+}
+
+test('isr: failed strict sidecar writes fail closed to stale HTML/data pairs', async () => {
+  const htmlStore = new FailingSidecarHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+
+  let nowMs = 10_000;
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/strict',
+        mode: 'isr',
+        revalidateSeconds: 1,
+        render: () => {
+          const seq = ++renderCount;
+          return {
+            csp: {
+              inlineScripts: false,
+              inlineStyles: false,
+              rawHead: false,
+            },
+            html: `<main>v${seq}</main>`,
+            hydration: {
+              data: { seq },
+              bootstrapModule: '/assets/client-entry.js',
+            },
+          };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => nowMs,
+    },
+  });
+
+  const warm = await app.handle({ method: 'GET', path: '/strict' });
+  const warmHtml = decodeBody(warm.body as Uint8Array);
+  const warmHref = externalHydrationHref(warmHtml);
+  assert.ok(warmHtml.includes('<main>v1</main>'));
+
+  const cacheKey = defaultIsrCacheKey({
+    tenant: 'default',
+    routePattern: '/strict',
+    params: {},
+    query: {},
+    headers: {},
+    cookies: {},
+  });
+  const beforeFailure = await metaStore.get(cacheKey);
+  assert.ok(beforeFailure?.htmlPointer);
+
+  nowMs = 11_000;
+  htmlStore.failSidecarWrites = true;
+  const stale = await app.handle({ method: 'GET', path: '/strict' });
+  const staleHtml = decodeBody(stale.body as Uint8Array);
+  assert.ok(staleHtml.includes('<main>v1</main>'));
+  assert.equal(externalHydrationHref(staleHtml), warmHref);
+  assert.equal(renderCount, 2);
+
+  const afterFailure = await metaStore.get(cacheKey);
+  assert.equal(afterFailure?.htmlPointer, beforeFailure?.htmlPointer);
+
+  const warmSidecar = await app.handle({ method: 'GET', path: warmHref });
+  assert.deepEqual(JSON.parse(decodeBody(warmSidecar.body as Uint8Array)), {
+    seq: 1,
+  });
+
+  htmlStore.failSidecarWrites = false;
+  nowMs = 11_001;
+  const recovered = await app.handle({ method: 'GET', path: '/strict' });
+  const recoveredHtml = decodeBody(recovered.body as Uint8Array);
+  const recoveredHref = externalHydrationHref(recoveredHtml);
+  assert.ok(recoveredHtml.includes('<main>v3</main>'));
+  assert.notEqual(recoveredHref, warmHref);
+
+  const recoveredSidecar = await app.handle({
+    method: 'GET',
+    path: recoveredHref,
+  });
+  assert.deepEqual(
+    JSON.parse(decodeBody(recoveredSidecar.body as Uint8Array)),
+    { seq: 3 },
+  );
+});
+
+test('isr: invalid strict sidecar tokens fail closed without rendering', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/',
+        mode: 'isr',
+        render: () => {
+          renderCount += 1;
+          return { html: '<main>should-not-render</main>' };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+    },
+  });
+
+  const response = await app.handle({
+    method: 'GET',
+    path: '/?__facetheory_isr_hydration=not-a-valid-token',
+  });
+
+  assert.equal(response.status, 404);
+  assert.equal(renderCount, 0);
 });

--- a/ts/test/unit/ssg.test.ts
+++ b/ts/test/unit/ssg.test.ts
@@ -237,3 +237,126 @@ test('ssg: allows explicit fetch mock', async () => {
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+test('ssg: strict CSP hydration emits canonical sidecar without inline data', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-strict-'));
+  const outDir = path.resolve(tempRoot, 'out');
+
+  const faces: FaceModule[] = [
+    {
+      route: '/',
+      mode: 'ssg',
+      render: () => ({
+        csp: {
+          inlineScripts: false,
+          inlineStyles: false,
+          rawHead: false,
+        },
+        head: { title: 'Strict Home' },
+        html: '<main>strict</main>',
+        hydration: {
+          data: {
+            message: '</script><script>alert("xss")</script>',
+            count: 1,
+          },
+          bootstrapModule: '/assets/client-entry.js',
+        },
+      }),
+    },
+  ];
+
+  try {
+    const result = await buildSsgSite({ faces, outDir });
+
+    assert.equal(result.pages.length, 1);
+    assert.equal(
+      result.pages[0]?.hydrationDataFile,
+      '_facetheory/data/index.json',
+    );
+
+    const html = await readFile(path.resolve(outDir, 'index.html'), 'utf8');
+    assert.ok(html.includes('id="__FACETHEORY_DATA_URL__"'));
+    assert.ok(html.includes('href="/_facetheory/data/index.json"'));
+    assert.ok(html.includes('src="/assets/client-entry.js"'));
+    assert.equal(html.includes('id="__FACETHEORY_DATA__"'), false);
+    assert.equal(html.includes('</script><script>alert'), false);
+
+    const hydrationJson = await readFile(
+      path.resolve(outDir, '_facetheory/data/index.json'),
+      'utf8',
+    );
+    assert.equal(
+      hydrationJson,
+      '{"message":"\\u003c/script\\u003e\\u003cscript\\u003ealert(\\"xss\\")\\u003c/script\\u003e","count":1}\n',
+    );
+
+    const manifestRaw = await readFile(
+      path.resolve(outDir, '.facetheory/ssg-manifest.json'),
+      'utf8',
+    );
+    const manifest = JSON.parse(manifestRaw) as {
+      pages: Array<{ path: string; hydrationDataFile?: string }>;
+    };
+    assert.deepEqual(
+      manifest.pages.map((page) => `${page.path} -> ${page.hydrationDataFile}`),
+      ['/ -> _facetheory/data/index.json'],
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('ssg: non-strict hydration sidecars remain opt-in compatibility output', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-compat-'));
+  const outDir = path.resolve(tempRoot, 'out');
+
+  const faces: FaceModule[] = [
+    {
+      route: '/',
+      mode: 'ssg',
+      render: () => ({
+        html: '<main>legacy</main>',
+        hydration: {
+          data: { message: 'legacy' },
+          bootstrapModule: '/assets/client-entry.js',
+        },
+      }),
+    },
+  ];
+
+  try {
+    const withoutCompatibilitySidecar = await buildSsgSite({
+      faces,
+      outDir,
+    });
+
+    assert.equal(
+      withoutCompatibilitySidecar.pages[0]?.hydrationDataFile,
+      undefined,
+    );
+    let html = await readFile(path.resolve(outDir, 'index.html'), 'utf8');
+    assert.ok(html.includes('id="__FACETHEORY_DATA__"'));
+
+    const withCompatibilitySidecar = await buildSsgSite({
+      faces,
+      outDir,
+      emitHydrationData: true,
+    });
+
+    assert.equal(
+      withCompatibilitySidecar.pages[0]?.hydrationDataFile,
+      '_facetheory/data/index.json',
+    );
+    html = await readFile(path.resolve(outDir, 'index.html'), 'utf8');
+    assert.ok(html.includes('id="__FACETHEORY_DATA__"'));
+    assert.ok(html.includes('{"message":"legacy"}'));
+
+    const hydrationJson = await readFile(
+      path.resolve(outDir, '_facetheory/data/index.json'),
+      'utf8',
+    );
+    assert.equal(hydrationJson, '{"message":"legacy"}\n');
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Milestone
strict-csp-static-isr-sidecars — emit/cache strict external hydration sidecars without adding a render mode or TableTheory schema fields.

## Linear
- THE-1161 — [07] Emit strict external hydration sidecars during SSG
- THE-1162 — [08] Cache ISR hydration sidecars with pointer-derived keys

## Render modes and adapters affected
- SSG: strict `inlineScripts:false` hydration is converted to deterministic `_facetheory/data/...json` sidecars and recorded in the SSG manifest.
- ISR: strict hydration sidecars are written beside cached HTML using keys derived from the generated HTML pointer, and served via a same-route opaque sidecar token.
- Adapters: none directly; behavior stays in core delivery-mode plumbing.

## Determinism impact
Preserves the exact server-rendered hydration data pair:
- SSG writes the same `safeJson()` payload used by the legacy inline hydration path, but references it externally for strict no-inline output.
- ISR derives the sidecar object key from the cached HTML pointer, rewrites strict hydration to that same-origin URL before strict validation, writes the sidecar before committing HTML metadata, and falls back to the stale HTML/data pair if sidecar writes fail.
- ISR metadata remains body/data-free; no TableTheory schema change.

## Scope note
ISR needed a small `FaceApp` renderFresh hook so the runtime can preserve `FaceRenderResult.hydration.data` before conversion to `FaceResponse`; after conversion, the exact data is no longer available to `isr.ts`, and reconstructing it from HTML would not satisfy the pair-consistency contract.

## Tasks
- [x] THE-1161 — Emit strict external hydration sidecars during SSG
- [x] THE-1162 — Cache ISR hydration sidecars with pointer-derived keys

## Validation
- [x] `git diff --check origin/facetheory/strict-csp-runtime-enforcement...HEAD`
- [x] `git diff --check`
- [x] `scripts/verify-version-alignment.sh`
- [x] `cd ts && npm ci`
- [x] `cd ts && npm run typecheck`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm test`
- [x] `cd ts && npm run build`
- [x] `cd ts && npm run example:ssg:build`
- [x] `cd ts && npm run check` — not present in `ts/package.json`; ran typecheck/lint/test/build explicitly.

## Cross-repo coordination
None. ISR remains on existing TableTheory metadata and lease contracts.
