### PR TITLE
feat(oac): add strict csp navigation policies

### DIFF
--- a/ts/src/oac-form.ts
+++ b/ts/src/oac-form.ts
@@ -1,3 +1,15 @@
+import {
+  applyFaceNavigationSnapshot,
+  DEFAULT_FACE_VIEW_SELECTOR,
+  fetchFaceNavigationSnapshot,
+  loadFaceNavigationHydrationData,
+  loadFaceNavigationModule,
+  parseFaceNavigationSnapshot,
+  validateFaceNavigationSnapshot,
+  type FaceNavigationSnapshot,
+  type FaceNavigationBootstrapModule,
+} from './spa.js';
+
 export const AWS_OAC_CONTENT_SHA256_HEADER = 'x-amz-content-sha256';
 export const AWS_OAC_FORM_MARKER_ATTRIBUTE = 'data-facetheory-oac-form';
 export const AWS_OAC_URL_ENCODED_FORM_ENCODING =
@@ -46,11 +58,22 @@ export interface AwsOacFormTransportResponseContext {
 }
 
 export type AwsOacFormNavigationKind = 'redirect' | 'replace-document';
+export type AwsOacFormNavigationPolicy = 'auto' | 'full-page' | 'spa';
+
+export interface AwsOacFormSpaNavigationOptions {
+  hydrationRequestInit?: RequestInit;
+  importModule?: (specifier: string) => Promise<FaceNavigationBootstrapModule>;
+  parser?: Pick<DOMParser, 'parseFromString'>;
+  reloadOnMissingHook?: boolean;
+  requestInit?: RequestInit;
+  syncHead?: boolean;
+  viewSelector?: string;
+}
 
 export interface AwsOacFormTransportNavigationContext extends AwsOacFormTransportResponseContext {
   finalUrl: URL;
   html: string | null;
-  navigation: AwsOacFormNavigationKind;
+  navigation: AwsOacFormNavigationKind | 'spa';
 }
 
 export interface AwsOacFormTransportErrorContext {
@@ -68,6 +91,7 @@ export interface StartAwsOacFormTransportOptions {
   document?: Document;
   fetcher?: typeof fetch;
   markerAttribute?: string;
+  navigationPolicy?: AwsOacFormNavigationPolicy;
   onError?: (
     error: unknown,
     context: AwsOacFormTransportErrorContext,
@@ -80,6 +104,8 @@ export interface StartAwsOacFormTransportOptions {
     context: AwsOacFormTransportResponseContext,
   ) => void | Promise<void>;
   requestInit?: RequestInit;
+  spaNavigation?: AwsOacFormSpaNavigationOptions;
+  strictCsp?: boolean;
   window?: Window;
 }
 
@@ -388,6 +414,11 @@ async function applyDefaultNavigationPolicy(
       navigation: 'redirect',
     };
     if (await customNavigationHandled(input.options, navigationContext)) return;
+    const policy = resolveNavigationPolicy(input.options);
+    if (policy === 'spa') {
+      await applySpaNavigationPolicy(input, context, finalUrl, null);
+      return;
+    }
     input.window.location.assign(finalUrl.toString());
     return;
   }
@@ -395,16 +426,25 @@ async function applyDefaultNavigationPolicy(
   if (isHtmlResponse(context.response)) {
     const responseHasCsp = hasResponseCsp(context.response);
     const html = await context.response.text();
+    const policy = resolveNavigationPolicy(input.options);
     const navigationContext: AwsOacFormTransportNavigationContext = {
       ...context,
       finalUrl,
       html,
-      navigation: 'replace-document',
+      navigation: policy === 'spa' ? 'spa' : 'replace-document',
     };
     if (await customNavigationHandled(input.options, navigationContext)) return;
+    if (policy === 'full-page') {
+      input.window.location.assign(finalUrl.toString());
+      return;
+    }
+    if (policy === 'spa') {
+      await applySpaNavigationPolicy(input, context, finalUrl, html);
+      return;
+    }
     if (responseHasCsp) {
       throw new Error(
-        'FaceTheory OAC form transport refused to replace the current document with an HTML response protected by Content-Security-Policy because fetch cannot install response CSP headers during document.write navigation; handle the response with onNavigate instead',
+        'FaceTheory OAC form transport refused to replace the current document with an HTML response protected by Content-Security-Policy because fetch cannot install response CSP headers during document.write navigation; use navigationPolicy:"full-page", navigationPolicy:"spa", or handle the response with onNavigate instead',
       );
     }
     replaceDocument(input.form.ownerDocument, input.window, html, finalUrl);
@@ -416,6 +456,116 @@ async function applyDefaultNavigationPolicy(
       `FaceTheory OAC form transport failed (${context.response.status}) for ${input.action.toString()}`,
     );
   }
+}
+
+async function applySpaNavigationPolicy(
+  input: SubmitAwsOacFormInput,
+  context: AwsOacFormTransportResponseContext,
+  finalUrl: URL,
+  html: string | null,
+): Promise<void> {
+  const snapshot = await resolveSpaNavigationSnapshot(
+    input,
+    finalUrl,
+    html,
+  );
+  const options = input.options.spaNavigation ?? {};
+  const viewSelector = options.viewSelector ?? DEFAULT_FACE_VIEW_SELECTOR;
+
+  validateFaceNavigationSnapshot(snapshot, {
+    allowedOrigin: input.allowedOrigin,
+  });
+  const applyOptions = {
+    document: input.form.ownerDocument,
+    viewSelector,
+    ...(options.syncHead !== undefined ? { syncHead: options.syncHead } : {}),
+  };
+  applyFaceNavigationSnapshot(snapshot, applyOptions);
+
+  const loadOptions = {
+    allowedOrigin: input.allowedOrigin,
+    document: input.form.ownerDocument,
+    viewSelector,
+    ...(options.importModule !== undefined
+      ? { importModule: options.importModule }
+      : {}),
+    ...(options.reloadOnMissingHook !== undefined
+      ? { reloadOnMissingHook: options.reloadOnMissingHook }
+      : {}),
+  };
+  await loadFaceNavigationModule(snapshot, loadOptions);
+
+  if (finalUrl.toString() !== input.window.location.href) {
+    input.window.history.replaceState({}, '', finalUrl);
+  }
+
+  void context;
+}
+
+async function resolveSpaNavigationSnapshot(
+  input: SubmitAwsOacFormInput,
+  finalUrl: URL,
+  html: string | null,
+): Promise<FaceNavigationSnapshot> {
+  const options = input.options.spaNavigation ?? {};
+  const hydrationOptions = {
+    allowedOrigin: input.allowedOrigin,
+    fetcher: input.fetcher,
+    ...(options.hydrationRequestInit !== undefined
+      ? { requestInit: options.hydrationRequestInit }
+      : {}),
+  };
+
+  if (html !== null) {
+    const parseOptions = {
+      url: finalUrl,
+      ...spaParserOption(input.window, options),
+      ...(options.viewSelector !== undefined
+        ? { viewSelector: options.viewSelector }
+        : {}),
+    };
+    const snapshot = parseFaceNavigationSnapshot(html, parseOptions);
+    validateFaceNavigationSnapshot(snapshot, {
+      allowedOrigin: input.allowedOrigin,
+    });
+    return loadFaceNavigationHydrationData(snapshot, hydrationOptions);
+  }
+
+  const fetchOptions = {
+    allowedOrigin: input.allowedOrigin,
+    fetcher: input.fetcher,
+    ...spaParserOption(input.window, options),
+    ...(options.hydrationRequestInit !== undefined
+      ? { hydrationRequestInit: options.hydrationRequestInit }
+      : {}),
+    ...(options.requestInit !== undefined
+      ? { requestInit: options.requestInit }
+      : {}),
+    ...(options.viewSelector !== undefined
+      ? { viewSelector: options.viewSelector }
+      : {}),
+  };
+  return fetchFaceNavigationSnapshot(finalUrl, fetchOptions);
+}
+
+function spaParserOption(
+  win: Window,
+  options: AwsOacFormSpaNavigationOptions,
+): { parser?: Pick<DOMParser, 'parseFromString'> } {
+  if (options.parser !== undefined) return { parser: options.parser };
+  const winWithParser = win as Window & { DOMParser?: typeof DOMParser };
+  if (typeof winWithParser.DOMParser === 'function') {
+    return { parser: new winWithParser.DOMParser() };
+  }
+  return {};
+}
+
+function resolveNavigationPolicy(
+  options: StartAwsOacFormTransportOptions,
+): AwsOacFormNavigationPolicy {
+  if (options.navigationPolicy !== undefined) return options.navigationPolicy;
+  if (options.strictCsp === true) return 'full-page';
+  return 'auto';
 }
 
 async function customNavigationHandled(

--- a/ts/src/spa.ts
+++ b/ts/src/spa.ts
@@ -69,6 +69,10 @@ export interface LoadFaceNavigationModuleOptions {
   viewSelector?: string;
 }
 
+export interface ValidateFaceNavigationSnapshotOptions {
+  allowedOrigin?: string | URL;
+}
+
 export interface StartFaceNavigationOptions
   extends Omit<FetchFaceNavigationSnapshotOptions, 'url'>,
     Pick<ApplyFaceNavigationSnapshotOptions, 'syncHead'>,
@@ -341,6 +345,16 @@ export async function loadFaceNavigationModule(
   if (typeof reloaded.hydrateFaceNavigation === 'function') {
     await reloaded.hydrateFaceNavigation(context);
   }
+}
+
+export function validateFaceNavigationSnapshot(
+  snapshot: FaceNavigationSnapshot,
+  options: ValidateFaceNavigationSnapshotOptions = {},
+): void {
+  const allowedOrigin =
+    resolveAllowedNavigationOrigin(options.allowedOrigin) ??
+    resolveNavigationUrl(snapshot.url, 'http://localhost/').origin;
+  assertSameOriginHydrationReferences(snapshot, allowedOrigin);
 }
 
 export function startFaceNavigation(

--- a/ts/test/unit/oac-form.test.ts
+++ b/ts/test/unit/oac-form.test.ts
@@ -1047,6 +1047,274 @@ test('oac form transport: refuses default document replacement when response CSP
   }
 });
 
+test('oac form transport: strict CSP defaults to full same-origin browser navigation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html>
+        <head><title>Edit</title></head>
+        <body>
+          <form action="/save" method="post" data-facetheory-oac-form>
+            <input name="title" value="">
+          </form>
+        </body>
+      </html>`,
+    { url: 'https://example.test/edit' },
+  );
+
+  try {
+    const form = dom.window.document.querySelector('form');
+    assert.ok(form instanceof dom.window.HTMLFormElement);
+
+    let writeCount = 0;
+    dom.window.document.write = () => {
+      writeCount += 1;
+    };
+
+    const assigned: string[] = [];
+    const replaced: string[] = [];
+    startAwsOacFormTransport({
+      document: dom.window.document,
+      fetcher: async () =>
+        responseWithUrl(
+          new Response(
+            '<!doctype html><html><head><title>Invalid</title></head><body><main>Title is required</main></body></html>',
+            {
+              headers: {
+                'content-security-policy': "script-src 'self'",
+                'content-type': 'text/html; charset=utf-8',
+              },
+              status: 422,
+            },
+          ),
+          'https://example.test/save',
+        ),
+      strictCsp: true,
+      window: fakeNavigationWindow(dom, assigned, replaced),
+    });
+
+    const event = new dom.window.SubmitEvent('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+    form.dispatchEvent(event);
+    await flushEventLoop();
+
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(dom.window.document.title, 'Edit');
+    assert.equal(writeCount, 0);
+    assert.deepEqual(assigned, ['https://example.test/save']);
+    assert.deepEqual(replaced, []);
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('oac form transport: SPA navigation policy loads external hydration before mutation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html>
+        <head><title>Edit</title></head>
+        <body>
+          <form action="/save" method="post" data-facetheory-oac-form>
+            <input name="title" value="Draft">
+          </form>
+          <main data-facetheory-view>Editing</main>
+        </body>
+      </html>`,
+    { url: 'https://example.test/edit' },
+  );
+
+  try {
+    const form = dom.window.document.querySelector('form');
+    assert.ok(form instanceof dom.window.HTMLFormElement);
+
+    let writeCount = 0;
+    dom.window.document.write = () => {
+      writeCount += 1;
+    };
+
+    const fetched: string[] = [];
+    const hydrated: Array<{ data: unknown; text: string | null; url: string }> =
+      [];
+    const replaced: string[] = [];
+    const navigated = new Promise<void>((resolve) => {
+      startAwsOacFormTransport({
+        document: dom.window.document,
+        fetcher: async (input) => {
+          fetched.push(String(input));
+          if (String(input).endsWith('/_facetheory/hydration/save.json')) {
+            return new Response(JSON.stringify({ saved: true }), {
+              headers: { 'content-type': 'application/json' },
+              status: 200,
+            });
+          }
+          return responseWithUrl(
+            new Response(
+              `<!doctype html>
+                <html>
+                  <head>
+                    <title>Saved</title>
+                    <link rel="facetheory-hydration" href="/_facetheory/hydration/save.json" type="application/json">
+                    <script src="/assets/entry-client.js" type="module"></script>
+                  </head>
+                  <body>
+                    <main data-facetheory-view>Saved view</main>
+                  </body>
+                </html>`,
+              {
+                headers: {
+                  'content-security-policy': "script-src 'self'",
+                  'content-type': 'text/html; charset=utf-8',
+                },
+                status: 200,
+              },
+            ),
+            'https://example.test/save',
+          );
+        },
+        navigationPolicy: 'spa',
+        onError: (error) => {
+          throw error;
+        },
+        spaNavigation: {
+          importModule: async () => ({
+            hydrateFaceNavigation: (context) => {
+              hydrated.push({
+                data: context.data,
+                text: context.view?.textContent?.trim() ?? null,
+                url: context.url.toString(),
+              });
+              resolve();
+            },
+          }),
+          parser: new dom.window.DOMParser(),
+        },
+        window: fakeNavigationWindow(dom, [], replaced),
+      });
+    });
+
+    const event = new dom.window.SubmitEvent('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+    form.dispatchEvent(event);
+    await navigated;
+    await flushEventLoop();
+
+    assert.equal(event.defaultPrevented, true);
+    assert.deepEqual(fetched, [
+      'https://example.test/save',
+      'https://example.test/_facetheory/hydration/save.json',
+    ]);
+    assert.equal(writeCount, 0);
+    assert.equal(dom.window.document.title, 'Saved');
+    assert.equal(
+      dom.window.document.querySelector('[data-facetheory-view]')?.textContent,
+      'Saved view',
+    );
+    assert.deepEqual(hydrated, [
+      {
+        data: { saved: true },
+        text: 'Saved view',
+        url: 'https://example.test/save',
+      },
+    ]);
+    assert.deepEqual(replaced, ['https://example.test/save']);
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('oac form transport: SPA policy rejects unsafe hydration targets before mutation', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html>
+        <head><title>Edit</title></head>
+        <body>
+          <form action="/save" method="post" data-facetheory-oac-form>
+            <input name="title" value="Draft">
+          </form>
+          <main data-facetheory-view>Editing</main>
+        </body>
+      </html>`,
+    { url: 'https://example.test/edit' },
+  );
+
+  try {
+    const form = dom.window.document.querySelector('form');
+    assert.ok(form instanceof dom.window.HTMLFormElement);
+
+    let writeCount = 0;
+    dom.window.document.write = () => {
+      writeCount += 1;
+    };
+
+    const errors: unknown[] = [];
+    const replaced: string[] = [];
+    const errored = new Promise<void>((resolve) => {
+      startAwsOacFormTransport({
+        document: dom.window.document,
+        fetcher: async () =>
+          responseWithUrl(
+            new Response(
+              `<!doctype html>
+                <html>
+                  <head>
+                    <title>Saved</title>
+                    <link rel="facetheory-hydration" href="https://evil.test/hydration.json" type="application/json">
+                    <script src="/assets/entry-client.js" type="module"></script>
+                  </head>
+                  <body>
+                    <main data-facetheory-view>Unsafe saved view</main>
+                  </body>
+                </html>`,
+              {
+                headers: {
+                  'content-security-policy': "script-src 'self'",
+                  'content-type': 'text/html; charset=utf-8',
+                },
+                status: 200,
+              },
+            ),
+            'https://example.test/save',
+          ),
+        navigationPolicy: 'spa',
+        onError: (error) => {
+          errors.push(error);
+          resolve();
+        },
+        spaNavigation: {
+          parser: new dom.window.DOMParser(),
+        },
+        window: fakeNavigationWindow(dom, [], replaced),
+      });
+    });
+
+    const event = new dom.window.SubmitEvent('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+    form.dispatchEvent(event);
+    await errored;
+
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(dom.window.document.title, 'Edit');
+    assert.equal(
+      dom.window.document.querySelector('[data-facetheory-view]')?.textContent,
+      'Editing',
+    );
+    assert.equal(writeCount, 0);
+    assert.deepEqual(replaced, []);
+    assert.equal(errors.length, 1);
+    assert.match(
+      String(errors[0]),
+      /FaceTheory SPA hydration data resolved cross-origin/,
+    );
+  } finally {
+    dom.window.close();
+  }
+});
+
 test('oac form transport: lets hosts override navigation outcomes', async () => {
   const dom = new JSDOM(
     `<!doctype html>


### PR DESCRIPTION
## Milestone
strict-csp-navigation-oac — add CSP-safe OAC navigation policies for strict no-inline consumers.

## Linear
- THE-1163 — [09] Add CSP-safe OAC navigation policies

## Render modes and adapters affected
- OAC form transport for SSR/SSG/ISR/SPA-rendered forms.
- SPA navigation helpers for adapter-neutral snapshot validation.
- No framework adapter changes.

## Determinism / CSP impact
- Adds explicit OAC navigation policies: `auto` (legacy behavior), `full-page`, and `spa`.
- `strictCsp: true` defaults OAC HTML outcomes to full same-origin browser navigation, avoiding `document.write()` for CSP-protected fetched HTML.
- `navigationPolicy: "spa"` performs a same-origin FaceTheory SPA snapshot handoff, loads external hydration data before DOM mutation, validates hydration data/module references as same-origin, and fails closed before mutation for unsafe targets.
- Existing non-strict OAC behavior and `onNavigate` override behavior remain backward compatible.

## Scope note
Narrow related type/API additions are in `ts/src/oac-form.ts` and `ts/src/spa.ts` only:
- `AwsOacFormNavigationPolicy`
- `AwsOacFormSpaNavigationOptions`
- `validateFaceNavigationSnapshot(...)`

## Tasks
- [x] THE-1163 — Add CSP-safe OAC navigation policies

## Validation
- [x] `git diff --check origin/facetheory/strict-csp-static-isr-sidecars...HEAD`
- [x] `git diff --check`
- [x] `scripts/verify-version-alignment.sh`
- [x] `cd ts && npm ci`
- [x] `cd ts && npm run typecheck`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm test`
- [x] `cd ts && npm run build`
- [x] `cd ts && npm run check` — not present in `ts/package.json`; ran typecheck/lint/test/build explicitly.

## Risks / blockers
- No blockers.
- SPA policy is explicit opt-in because partial DOM navigation can drift from full document CSP semantics; strict mode defaults to full-page navigation.

## Cross-repo coordination
None. No AppTheory/TableTheory schema or runtime changes, no Simulacrum edits, no AWS/deploy/account work.
