### PR TITLE
feat(csp): enforce strict adapter parity

### DIFF
--- a/ts/src/adapter-csp.ts
+++ b/ts/src/adapter-csp.ts
@@ -1,0 +1,121 @@
+import type { FaceCspPolicy, FaceHeadTag, FaceRenderResult } from './types.js';
+
+export interface AdapterStrictCspValidationOptions {
+  adapterName: string;
+}
+
+export function enforceAdapterStrictCspResult(
+  out: FaceRenderResult,
+  options: AdapterStrictCspValidationOptions,
+): void {
+  const policy = out.csp;
+  if (!policy) return;
+
+  const adapterName = normalizeAdapterName(options.adapterName);
+
+  if (policy.inlineScripts === false) {
+    if (out.hydration && out.hydration.type !== 'external') {
+      throw new Error(
+        `FaceTheory ${adapterName} strict CSP requires external hydration data`,
+      );
+    }
+
+    for (const tag of out.headTags ?? []) {
+      assertNoInlineScriptHeadTag(adapterName, tag);
+    }
+  }
+
+  if (policy.inlineStyles === false) {
+    if ((out.styleTags ?? []).some((tag) => String(tag.cssText ?? '').trim())) {
+      throw new Error(
+        `FaceTheory ${adapterName} strict CSP rejects inline adapter style output`,
+      );
+    }
+
+    for (const tag of out.headTags ?? []) {
+      assertNoInlineStyleHeadTag(adapterName, tag);
+    }
+  }
+
+  if (policy.rawHead === false) {
+    if (out.headTags?.some((tag) => tag.type === 'raw')) {
+      throw new Error(
+        `FaceTheory ${adapterName} strict CSP rejects raw adapter head output`,
+      );
+    }
+  }
+}
+
+export function enforceReactStrictCspStreamingOptions(options: {
+  adapterName: string;
+  policy?: FaceCspPolicy | undefined;
+  styleStrategy: 'all-ready' | 'shell';
+}): void {
+  if (options.policy?.inlineScripts !== false) return;
+  if (options.styleStrategy !== 'shell') return;
+
+  const adapterName = normalizeAdapterName(options.adapterName);
+  throw new Error(
+    `FaceTheory ${adapterName} strict CSP streaming requires styleStrategy "all-ready"`,
+  );
+}
+
+function normalizeAdapterName(adapterName: string): string {
+  return String(adapterName ?? '').trim() || 'adapter';
+}
+
+function assertNoInlineScriptHeadTag(
+  adapterName: string,
+  tag: FaceHeadTag,
+): void {
+  if (tag.type === 'script' && tag.body !== undefined) {
+    throw new Error(
+      `FaceTheory ${adapterName} strict CSP rejects inline adapter script output`,
+    );
+  }
+
+  const attrs = attrsForTag(tag);
+  if (!attrs) return;
+  for (const name of Object.keys(attrs)) {
+    if (/^on[a-z]/i.test(name.trim())) {
+      throw new Error(
+        `FaceTheory ${adapterName} strict CSP rejects inline adapter event handlers`,
+      );
+    }
+  }
+}
+
+function assertNoInlineStyleHeadTag(
+  adapterName: string,
+  tag: FaceHeadTag,
+): void {
+  if (tag.type === 'style' && String(tag.cssText ?? '').trim()) {
+    throw new Error(
+      `FaceTheory ${adapterName} strict CSP rejects inline adapter style output`,
+    );
+  }
+
+  const attrs = attrsForTag(tag);
+  if (!attrs) return;
+  for (const name of Object.keys(attrs)) {
+    if (name.trim().toLowerCase() === 'style') {
+      throw new Error(
+        `FaceTheory ${adapterName} strict CSP rejects inline adapter style attributes`,
+      );
+    }
+  }
+}
+
+function attrsForTag(tag: FaceHeadTag) {
+  switch (tag.type) {
+    case 'meta':
+    case 'link':
+    case 'script':
+      return tag.attrs;
+    case 'style':
+      return tag.attrs;
+    case 'title':
+    case 'raw':
+      return undefined;
+  }
+}

--- a/ts/src/adapter-csp.ts
+++ b/ts/src/adapter-csp.ts
@@ -37,7 +37,11 @@ export function enforceAdapterStrictCspResult(
     }
   }
 
-  if (policy.rawHead === false) {
+  if (
+    policy.rawHead === false ||
+    policy.inlineScripts === false ||
+    policy.inlineStyles === false
+  ) {
     if (out.headTags?.some((tag) => tag.type === 'raw')) {
       throw new Error(
         `FaceTheory ${adapterName} strict CSP rejects raw adapter head output`,

--- a/ts/src/adapters/react.ts
+++ b/ts/src/adapters/react.ts
@@ -3,9 +3,14 @@ import { PassThrough } from 'node:stream';
 import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 
+import {
+  enforceAdapterStrictCspResult,
+  enforceReactStrictCspStreamingOptions,
+} from '../adapter-csp.js';
 import { prepareUIIntegrations } from '../types.js';
 import type {
   FaceContext,
+  FaceCspPolicy,
   FaceHead,
   FaceHeadTag,
   FaceHydration,
@@ -24,6 +29,7 @@ export interface RenderReactOptions {
   headTags?: FaceHeadTag[];
   styleTags?: FaceStyleTag[];
   hydration?: FaceHydration;
+  csp?: FaceCspPolicy;
   integrations?: Array<UIIntegration<React.ReactElement>>;
 }
 
@@ -70,7 +76,11 @@ export async function renderReact(
     UIIntegration<React.ReactElement>
   >(options.integrations ?? [], ctx);
 
-  let tree: React.ReactElement = React.createElement(React.Fragment, null, node);
+  let tree: React.ReactElement = React.createElement(
+    React.Fragment,
+    null,
+    node,
+  );
 
   for (const { integration, state } of integrations) {
     if (integration.wrapTree) {
@@ -84,8 +94,10 @@ export async function renderReact(
   for (const { integration, state } of integrations) {
     if (!integration.contribute) continue;
     const contribution = await integration.contribute(ctx, state);
-    if (contribution.headTags) integrationHeadTags.push(...contribution.headTags);
-    if (contribution.styleTags) integrationStyleTags.push(...contribution.styleTags);
+    if (contribution.headTags)
+      integrationHeadTags.push(...contribution.headTags);
+    if (contribution.styleTags)
+      integrationStyleTags.push(...contribution.styleTags);
   }
 
   const html = ReactDOMServer.renderToString(tree);
@@ -100,12 +112,15 @@ export async function renderReact(
   if (headTags.length) out.headTags = headTags;
   if (styleTags.length) out.styleTags = styleTags;
   if (options.hydration !== undefined) out.hydration = options.hydration;
+  if (options.csp !== undefined) out.csp = options.csp;
 
   for (const { integration, state } of integrations) {
     if (integration.finalize) {
       out = await integration.finalize(out, ctx, state);
     }
   }
+
+  enforceAdapterStrictCspResult(out, { adapterName: 'React adapter' });
 
   return out;
 }
@@ -120,7 +135,11 @@ export async function renderReactStream(
     UIIntegration<React.ReactElement>
   >(options.integrations ?? [], ctx);
 
-  let tree: React.ReactElement = React.createElement(React.Fragment, null, node);
+  let tree: React.ReactElement = React.createElement(
+    React.Fragment,
+    null,
+    node,
+  );
 
   for (const { integration, state } of integrations) {
     if (integration.wrapTree) {
@@ -134,8 +153,10 @@ export async function renderReactStream(
   for (const { integration, state } of integrations) {
     if (!integration.contribute) continue;
     const contribution = await integration.contribute(ctx, state);
-    if (contribution.headTags) integrationHeadTags.push(...contribution.headTags);
-    if (contribution.styleTags) integrationStyleTags.push(...contribution.styleTags);
+    if (contribution.headTags)
+      integrationHeadTags.push(...contribution.headTags);
+    if (contribution.styleTags)
+      integrationStyleTags.push(...contribution.styleTags);
   }
 
   const headTags = [...integrationHeadTags, ...(options.headTags ?? [])];
@@ -144,8 +165,14 @@ export async function renderReactStream(
   const stream = new PassThrough();
   const abortDelayMs = options.abortDelayMs ?? 5000;
   const styleStrategy = options.styleStrategy ?? 'all-ready';
+  enforceReactStrictCspStreamingOptions({
+    adapterName: 'React adapter',
+    policy: options.csp,
+    styleStrategy,
+  });
   const startedAt = Date.now();
-  const requestId = String(ctx.request.headers['x-request-id']?.[0] ?? '').trim() || null;
+  const requestId =
+    String(ctx.request.headers['x-request-id']?.[0] ?? '').trim() || null;
 
   let didPipe = false;
   let shellSettled = false;
@@ -250,7 +277,9 @@ export async function renderReactStream(
     await shellReady;
   }
 
-  let out: FaceRenderResult = { html: stream as unknown as AsyncIterable<Uint8Array> };
+  let out: FaceRenderResult = {
+    html: stream as unknown as AsyncIterable<Uint8Array>,
+  };
   if (options.status !== undefined) out.status = options.status;
   if (options.headers !== undefined) out.headers = options.headers;
   if (options.cookies !== undefined) out.cookies = options.cookies;
@@ -258,12 +287,15 @@ export async function renderReactStream(
   if (headTags.length) out.headTags = headTags;
   if (styleTags.length) out.styleTags = styleTags;
   if (options.hydration !== undefined) out.hydration = options.hydration;
+  if (options.csp !== undefined) out.csp = options.csp;
 
   for (const { integration, state } of integrations) {
     if (integration.finalize) {
       out = await integration.finalize(out, ctx, state);
     }
   }
+
+  enforceAdapterStrictCspResult(out, { adapterName: 'React adapter' });
 
   return out;
 }
@@ -272,10 +304,16 @@ export interface ReactFaceOptions<Data = unknown> {
   route: string;
   mode: FaceMode;
   load?: (ctx: FaceContext) => Promise<Data>;
-  render: (ctx: FaceContext, data: Data) => React.ReactNode | Promise<React.ReactNode>;
+  render: (
+    ctx: FaceContext,
+    data: Data,
+  ) => React.ReactNode | Promise<React.ReactNode>;
   renderOptions?:
     | RenderReactOptions
-    | ((ctx: FaceContext, data: Data) => RenderReactOptions | Promise<RenderReactOptions>);
+    | ((
+        ctx: FaceContext,
+        data: Data,
+      ) => RenderReactOptions | Promise<RenderReactOptions>);
 }
 
 export function createReactFace<Data = unknown>(
@@ -295,7 +333,9 @@ export function createReactFace<Data = unknown>(
   };
 
   if (options.load) {
-    mod.load = options.load as unknown as (ctx: FaceContext) => Promise<unknown>;
+    mod.load = options.load as unknown as (
+      ctx: FaceContext,
+    ) => Promise<unknown>;
   }
 
   return mod;
@@ -305,7 +345,10 @@ export interface ReactStreamFaceOptions<Data = unknown> {
   route: string;
   mode: FaceMode;
   load?: (ctx: FaceContext) => Promise<Data>;
-  render: (ctx: FaceContext, data: Data) => React.ReactNode | Promise<React.ReactNode>;
+  render: (
+    ctx: FaceContext,
+    data: Data,
+  ) => React.ReactNode | Promise<React.ReactNode>;
   renderOptions?:
     | RenderReactStreamOptions
     | ((
@@ -331,7 +374,9 @@ export function createReactStreamFace<Data = unknown>(
   };
 
   if (options.load) {
-    mod.load = options.load as unknown as (ctx: FaceContext) => Promise<unknown>;
+    mod.load = options.load as unknown as (
+      ctx: FaceContext,
+    ) => Promise<unknown>;
   }
 
   return mod;

--- a/ts/src/svelte/index.ts
+++ b/ts/src/svelte/index.ts
@@ -1,6 +1,8 @@
+import { enforceAdapterStrictCspResult } from '../adapter-csp.js';
 import { prepareUIIntegrations } from '../types.js';
 import type {
   FaceContext,
+  FaceCspPolicy,
   FaceHead,
   FaceHeadTag,
   FaceHydration,
@@ -29,6 +31,7 @@ export interface RenderSvelteOptions {
   headTags?: FaceHeadTag[];
   styleTags?: FaceStyleTag[];
   hydration?: FaceHydration;
+  csp?: FaceCspPolicy;
   integrations?: Array<SvelteUIIntegration>;
 }
 
@@ -67,26 +70,42 @@ export async function renderSvelte<Props extends Record<string, unknown>>(
   for (const { integration, state } of integrations) {
     if (!integration.contribute) continue;
     const contribution = await integration.contribute(ctx, state);
-    if (contribution.headTags) integrationHeadTags.push(...contribution.headTags);
-    if (contribution.styleTags) integrationStyleTags.push(...contribution.styleTags);
+    if (contribution.headTags)
+      integrationHeadTags.push(...contribution.headTags);
+    if (contribution.styleTags)
+      integrationStyleTags.push(...contribution.styleTags);
   }
 
   let rendered: SvelteSSRRenderResult;
 
-  const maybeLegacy = currentInput.component as Partial<SvelteLegacySSRComponent<Props>>;
+  const maybeLegacy = currentInput.component as Partial<
+    SvelteLegacySSRComponent<Props>
+  >;
   if (typeof maybeLegacy.render === 'function') {
     try {
       rendered = maybeLegacy.render(currentInput.props);
     } catch (err) {
       if (!isSvelte5DeprecatedRenderError(err)) throw err;
-      rendered = await renderWithSvelteServer(currentInput.component, currentInput.props);
+      rendered = await renderWithSvelteServer(
+        currentInput.component,
+        currentInput.props,
+      );
     }
   } else {
-    rendered = await renderWithSvelteServer(currentInput.component, currentInput.props);
+    rendered = await renderWithSvelteServer(
+      currentInput.component,
+      currentInput.props,
+    );
   }
 
-  const headTags: FaceHeadTag[] = [...integrationHeadTags, ...(options.headTags ?? [])];
-  const styleTags: FaceStyleTag[] = [...integrationStyleTags, ...(options.styleTags ?? [])];
+  const headTags: FaceHeadTag[] = [
+    ...integrationHeadTags,
+    ...(options.headTags ?? []),
+  ];
+  const styleTags: FaceStyleTag[] = [
+    ...integrationStyleTags,
+    ...(options.styleTags ?? []),
+  ];
 
   if (rendered.head) {
     headTags.push({ type: 'raw', html: rendered.head });
@@ -107,18 +126,23 @@ export async function renderSvelte<Props extends Record<string, unknown>>(
   if (headTags.length) out.headTags = headTags;
   if (styleTags.length) out.styleTags = styleTags;
   if (options.hydration !== undefined) out.hydration = options.hydration;
+  if (options.csp !== undefined) out.csp = options.csp;
 
   for (const { integration, state } of integrations) {
     if (!integration.finalize) continue;
     out = await integration.finalize(out, ctx, state);
   }
 
+  enforceAdapterStrictCspResult(out, { adapterName: 'Svelte adapter' });
+
   return out;
 }
 
 function isSvelte5DeprecatedRenderError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  return err.message.includes('Component.render(...) is no longer valid in Svelte 5');
+  return err.message.includes(
+    'Component.render(...) is no longer valid in Svelte 5',
+  );
 }
 
 async function renderWithSvelteServer<Props extends Record<string, unknown>>(
@@ -158,10 +182,16 @@ export interface SvelteFaceOptions<
   route: string;
   mode: FaceMode;
   load?: (ctx: FaceContext) => Promise<Data>;
-  render: (ctx: FaceContext, data: Data) => SvelteRenderInput<Props> | Promise<SvelteRenderInput<Props>>;
+  render: (
+    ctx: FaceContext,
+    data: Data,
+  ) => SvelteRenderInput<Props> | Promise<SvelteRenderInput<Props>>;
   renderOptions?:
     | RenderSvelteOptions
-    | ((ctx: FaceContext, data: Data) => RenderSvelteOptions | Promise<RenderSvelteOptions>);
+    | ((
+        ctx: FaceContext,
+        data: Data,
+      ) => RenderSvelteOptions | Promise<RenderSvelteOptions>);
 }
 
 export function createSvelteFace<
@@ -182,7 +212,9 @@ export function createSvelteFace<
   };
 
   if (options.load) {
-    mod.load = options.load as unknown as (ctx: FaceContext) => Promise<unknown>;
+    mod.load = options.load as unknown as (
+      ctx: FaceContext,
+    ) => Promise<unknown>;
   }
 
   return mod;

--- a/ts/src/vue/index.ts
+++ b/ts/src/vue/index.ts
@@ -1,9 +1,11 @@
 import { createSSRApp, h, type App, type VNode } from 'vue';
 import { renderToString } from '@vue/server-renderer';
 
+import { enforceAdapterStrictCspResult } from '../adapter-csp.js';
 import { prepareUIIntegrations } from '../types.js';
 import type {
   FaceContext,
+  FaceCspPolicy,
   FaceHead,
   FaceHeadTag,
   FaceHydration,
@@ -14,8 +16,10 @@ import type {
   UIIntegration,
 } from '../types.js';
 
-export interface VueUIIntegration<TState = unknown>
-  extends UIIntegration<VNode, TState> {
+export interface VueUIIntegration<TState = unknown> extends UIIntegration<
+  VNode,
+  TState
+> {
   wrapApp?: (app: App, ctx: FaceContext, state: TState) => void | Promise<void>;
 }
 
@@ -27,6 +31,7 @@ export interface RenderVueOptions {
   headTags?: FaceHeadTag[];
   styleTags?: FaceStyleTag[];
   hydration?: FaceHydration;
+  csp?: FaceCspPolicy;
   integrations?: Array<VueUIIntegration>;
 }
 
@@ -57,8 +62,10 @@ export async function renderVue(
   for (const { integration, state } of integrations) {
     if (!integration.contribute) continue;
     const contribution = await integration.contribute(ctx, state);
-    if (contribution.headTags) integrationHeadTags.push(...contribution.headTags);
-    if (contribution.styleTags) integrationStyleTags.push(...contribution.styleTags);
+    if (contribution.headTags)
+      integrationHeadTags.push(...contribution.headTags);
+    if (contribution.styleTags)
+      integrationStyleTags.push(...contribution.styleTags);
   }
 
   const html = await renderToString(app);
@@ -74,11 +81,14 @@ export async function renderVue(
   if (headTags.length) out.headTags = headTags;
   if (styleTags.length) out.styleTags = styleTags;
   if (options.hydration !== undefined) out.hydration = options.hydration;
+  if (options.csp !== undefined) out.csp = options.csp;
 
   for (const { integration, state } of integrations) {
     if (!integration.finalize) continue;
     out = await integration.finalize(out, ctx, state);
   }
+
+  enforceAdapterStrictCspResult(out, { adapterName: 'Vue adapter' });
 
   return out;
 }
@@ -90,10 +100,15 @@ export interface VueFaceOptions<Data = unknown> {
   render: (ctx: FaceContext, data: Data) => VNode | Promise<VNode>;
   renderOptions?:
     | RenderVueOptions
-    | ((ctx: FaceContext, data: Data) => RenderVueOptions | Promise<RenderVueOptions>);
+    | ((
+        ctx: FaceContext,
+        data: Data,
+      ) => RenderVueOptions | Promise<RenderVueOptions>);
 }
 
-export function createVueFace<Data = unknown>(options: VueFaceOptions<Data>): FaceModule {
+export function createVueFace<Data = unknown>(
+  options: VueFaceOptions<Data>,
+): FaceModule {
   const mod: FaceModule = {
     route: options.route,
     mode: options.mode,
@@ -108,7 +123,9 @@ export function createVueFace<Data = unknown>(options: VueFaceOptions<Data>): Fa
   };
 
   if (options.load) {
-    mod.load = options.load as unknown as (ctx: FaceContext) => Promise<unknown>;
+    mod.load = options.load as unknown as (
+      ctx: FaceContext,
+    ) => Promise<unknown>;
   }
 
   return mod;

--- a/ts/test/unit/antd.test.ts
+++ b/ts/test/unit/antd.test.ts
@@ -5,8 +5,24 @@ import { Button, Menu, theme as antdTheme, Typography } from 'antd';
 import * as React from 'react';
 
 import { createFaceApp } from '../../src/app.js';
-import { createReactFace } from '../../src/adapters/react.js';
+import { createReactFace, renderReact } from '../../src/adapters/react.js';
+import type { FaceContext } from '../../src/types.js';
 import { createAntdIntegration } from '../../src/react/antd.js';
+
+const baseCtx: FaceContext = {
+  request: {
+    method: 'GET',
+    path: '/',
+    query: {},
+    headers: { 'x-request-id': ['test-antd'] },
+    cookies: {},
+    body: new Uint8Array(),
+    isBase64: false,
+    cspNonce: null,
+  },
+  params: {},
+  proxy: null,
+};
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -89,7 +105,11 @@ test('antd integration: shared instances stay isolated across overlapping render
           if (kind === 'menu') {
             return React.createElement(MenuFixture);
           }
-          return React.createElement(Button, { type: 'primary' }, 'Primary request');
+          return React.createElement(
+            Button,
+            { type: 'primary' },
+            'Primary request',
+          );
         },
         renderOptions: {
           integrations: [
@@ -132,3 +152,18 @@ function MenuFixture() {
     ],
   });
 }
+
+test('antd integration: strict CSP rejects inline style extraction', async () => {
+  await assert.rejects(
+    () =>
+      renderReact(
+        baseCtx,
+        React.createElement(Button, { type: 'primary' }, 'Strict Button'),
+        {
+          csp: { inlineStyles: false },
+          integrations: [createAntdIntegration({ hashed: false })],
+        },
+      ),
+    /React adapter strict CSP rejects inline adapter style output/,
+  );
+});

--- a/ts/test/unit/emotion.test.ts
+++ b/ts/test/unit/emotion.test.ts
@@ -6,10 +6,26 @@ import { Typography } from 'antd';
 import * as React from 'react';
 
 import { createFaceApp } from '../../src/app.js';
-import { createReactFace } from '../../src/adapters/react.js';
+import { createReactFace, renderReact } from '../../src/adapters/react.js';
+import type { FaceContext } from '../../src/types.js';
 import { createAntdEmotionTokenIntegration } from '../../src/react/antd-emotion.js';
 import { createAntdIntegration } from '../../src/react/antd.js';
 import { createEmotionIntegration } from '../../src/react/emotion.js';
+
+const baseCtx: FaceContext = {
+  request: {
+    method: 'GET',
+    path: '/',
+    query: {},
+    headers: { 'x-request-id': ['test-emotion'] },
+    cookies: {},
+    body: new Uint8Array(),
+    isBase64: false,
+    cspNonce: null,
+  },
+  params: {},
+  proxy: null,
+};
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -17,7 +33,15 @@ function delay(ms: number): Promise<void> {
 
 function ThemedBox() {
   const theme = useTheme() as { color: string };
-  return jsx('div', { css: css`color: ${theme.color};` }, 'Hello');
+  return jsx(
+    'div',
+    {
+      css: css`
+        color: ${theme.color};
+      `,
+    },
+    'Hello',
+  );
 }
 
 test('emotion integration: extracts SSR styles and preserves theme values', async () => {
@@ -28,13 +52,19 @@ test('emotion integration: extracts SSR styles and preserves theme values', asyn
         mode: 'ssr',
         render: () => jsx(ThemedBox, {}),
         renderOptions: {
-          integrations: [createEmotionIntegration({ theme: { color: 'rgb(1, 2, 3)' } })],
+          integrations: [
+            createEmotionIntegration({ theme: { color: 'rgb(1, 2, 3)' } }),
+          ],
         },
       }),
     ],
   });
 
-  const resp = await app.handle({ method: 'GET', path: '/', cspNonce: 'nonce-xyz' });
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/',
+    cspNonce: 'nonce-xyz',
+  });
   const body = new TextDecoder().decode(resp.body as Uint8Array);
 
   assert.ok(body.includes('Hello'));
@@ -48,7 +78,11 @@ test('emotion integration: can consume Ant Design tokens (portal pattern)', asyn
     const theme = useTheme() as { colorPrimary: string };
     return jsx(
       'div',
-      { css: css`color: ${theme.colorPrimary};` },
+      {
+        css: css`
+          color: ${theme.colorPrimary};
+        `,
+      },
       theme.colorPrimary,
     );
   }
@@ -79,7 +113,11 @@ test('emotion integration: can consume Ant Design tokens (portal pattern)', asyn
     ],
   });
 
-  const resp = await app.handle({ method: 'GET', path: '/', cspNonce: 'nonce-bridge' });
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/',
+    cspNonce: 'nonce-bridge',
+  });
   const body = new TextDecoder().decode(resp.body as Uint8Array);
 
   assert.ok(body.includes('AntD'));
@@ -101,7 +139,11 @@ test('emotion integration: shared instances stay isolated across overlapping ren
           const color = String(ctx.request.query.color?.[0] ?? 'rgb(0, 0, 0)');
           return jsx(
             'div',
-            { css: css`color: ${color};` },
+            {
+              css: css`
+                color: ${color};
+              `,
+            },
             color,
           );
         },
@@ -136,4 +178,17 @@ test('emotion integration: shared instances stay isolated across overlapping ren
   assert.ok(!bodyA.includes(colorB));
   assert.ok(bodyB.includes(colorB));
   assert.ok(!bodyB.includes(colorA));
+});
+
+test('emotion integration: strict CSP rejects inline style extraction', async () => {
+  await assert.rejects(
+    () =>
+      renderReact(baseCtx, jsx(ThemedBox, {}), {
+        csp: { inlineStyles: false },
+        integrations: [
+          createEmotionIntegration({ theme: { color: 'rgb(7, 8, 9)' } }),
+        ],
+      }),
+    /React adapter strict CSP rejects inline adapter style output/,
+  );
 });

--- a/ts/test/unit/react-stream.test.ts
+++ b/ts/test/unit/react-stream.test.ts
@@ -4,14 +4,33 @@ import test from 'node:test';
 import * as React from 'react';
 
 import { createFaceApp } from '../../src/app.js';
-import { createReactStreamFace } from '../../src/adapters/react.js';
-import type { FaceBody } from '../../src/types.js';
+import {
+  createReactStreamFace,
+  renderReactStream,
+} from '../../src/adapters/react.js';
+import type { FaceBody, FaceContext } from '../../src/types.js';
+
+const baseCtx: FaceContext = {
+  request: {
+    method: 'GET',
+    path: '/',
+    query: {},
+    headers: { 'x-request-id': ['test-react-stream'] },
+    cookies: {},
+    body: new Uint8Array(),
+    isBase64: false,
+    cspNonce: null,
+  },
+  params: {},
+  proxy: null,
+};
 
 async function collect(body: FaceBody): Promise<string> {
   const dec = new TextDecoder();
   if (body instanceof Uint8Array) return dec.decode(body);
   const parts: string[] = [];
-  for await (const chunk of body) parts.push(dec.decode(chunk, { stream: true }));
+  for await (const chunk of body)
+    parts.push(dec.decode(chunk, { stream: true }));
   parts.push(dec.decode());
   return parts.join('');
 }
@@ -49,13 +68,18 @@ test('react adapter: readiness callback fires for shell and all-ready', async ()
         mode: 'ssr',
         render: () => React.createElement('main', null, 'Hello'),
         renderOptions: {
-          onReadiness: (evt) => readiness.push({ phase: evt.phase, requestId: evt.requestId }),
+          onReadiness: (evt) =>
+            readiness.push({ phase: evt.phase, requestId: evt.requestId }),
         },
       }),
     ],
   });
 
-  const resp = await app.handle({ method: 'GET', path: '/', headers: { 'x-request-id': ['req-1'] } });
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/',
+    headers: { 'x-request-id': ['req-1'] },
+  });
   assert.ok(!(resp.body instanceof Uint8Array));
 
   // Yield to allow callbacks to flush (especially `onAllReady`).
@@ -64,4 +88,48 @@ test('react adapter: readiness callback fires for shell and all-ready', async ()
   assert.ok(readiness.some((e) => e.phase === 'shell'));
   assert.ok(readiness.some((e) => e.phase === 'all-ready'));
   assert.ok(readiness.every((e) => e.requestId === 'req-1'));
+});
+
+test('react adapter: strict CSP streaming buffers safe all-ready output', async () => {
+  const app = createFaceApp({
+    faces: [
+      createReactStreamFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => React.createElement('main', null, 'Strict stream'),
+        renderOptions: {
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          hydration: {
+            type: 'external',
+            data: { stream: true },
+            dataUrl: '/_facetheory/data/react-stream.json',
+            bootstrapModule: '/assets/react-stream-entry.js',
+          },
+        },
+      }),
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.ok(resp.body instanceof Uint8Array);
+
+  const html = await collect(resp.body);
+  assert.ok(html.includes('Strict stream'));
+  assert.ok(html.includes('id="__FACETHEORY_DATA_URL__"'));
+  assert.ok(!html.includes('id="__FACETHEORY_DATA__"'));
+});
+
+test('react adapter: strict CSP rejects shell streaming strategy', async () => {
+  await assert.rejects(
+    () =>
+      renderReactStream(
+        baseCtx,
+        React.createElement('main', null, 'Unsafe shell'),
+        {
+          csp: { inlineScripts: false },
+          styleStrategy: 'shell',
+        },
+      ),
+    /React adapter strict CSP streaming requires styleStrategy "all-ready"/,
+  );
 });

--- a/ts/test/unit/react.test.ts
+++ b/ts/test/unit/react.test.ts
@@ -4,7 +4,23 @@ import test from 'node:test';
 import * as React from 'react';
 
 import { createFaceApp } from '../../src/app.js';
-import { createReactFace } from '../../src/adapters/react.js';
+import { createReactFace, renderReact } from '../../src/adapters/react.js';
+import type { FaceContext } from '../../src/types.js';
+
+const baseCtx: FaceContext = {
+  request: {
+    method: 'GET',
+    path: '/',
+    query: {},
+    headers: { 'x-request-id': ['test-react'] },
+    cookies: {},
+    body: new Uint8Array(),
+    isBase64: false,
+    cspNonce: null,
+  },
+  params: {},
+  proxy: null,
+};
 
 test('react adapter: renders ReactNode + head tags + hydration', async () => {
   const app = createFaceApp({
@@ -42,7 +58,9 @@ test('react adapter: renders ReactNode + head tags + hydration', async () => {
   assert.ok(m?.[1]);
   assert.deepEqual(JSON.parse(m![1]), { message: '<hi>&</hi>' });
 
-  assert.ok(body.includes('<script src="/assets/entry.js" type="module"></script>'));
+  assert.ok(
+    body.includes('<script src="/assets/entry.js" type="module"></script>'),
+  );
 });
 
 test('react adapter: renders non-element ReactNode', async () => {
@@ -59,4 +77,58 @@ test('react adapter: renders non-element ReactNode', async () => {
   const resp = await app.handle({ method: 'GET', path: '/' });
   const body = new TextDecoder().decode(resp.body as Uint8Array);
   assert.ok(body.includes('<body>ok</body>'));
+});
+
+test('react adapter: strict CSP emits external hydration without inline data', async () => {
+  const app = createFaceApp({
+    faces: [
+      createReactFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => React.createElement('main', null, 'Strict React'),
+        renderOptions: {
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          hydration: {
+            type: 'external',
+            data: { message: '<strict-react>' },
+            dataUrl: '/_facetheory/data/react.json',
+            bootstrapModule: '/assets/react-entry.js',
+          },
+        },
+      }),
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 200);
+
+  const body = new TextDecoder().decode(resp.body as Uint8Array);
+  assert.ok(body.includes('Strict React'));
+  assert.ok(body.includes('id="__FACETHEORY_DATA_URL__"'));
+  assert.ok(body.includes('href="/_facetheory/data/react.json"'));
+  assert.ok(
+    body.includes(
+      '<script src="/assets/react-entry.js" type="module"></script>',
+    ),
+  );
+  assert.ok(!body.includes('id="__FACETHEORY_DATA__"'));
+  assert.ok(!body.includes('<strict-react>'));
+});
+
+test('react adapter: strict CSP rejects inline hydration before head emission', async () => {
+  await assert.rejects(
+    () =>
+      renderReact(
+        baseCtx,
+        React.createElement('main', null, 'Inline hydration'),
+        {
+          csp: { inlineScripts: false },
+          hydration: {
+            data: { unsafe: true },
+            bootstrapModule: '/assets/react-entry.js',
+          },
+        },
+      ),
+    /React adapter strict CSP requires external hydration data/,
+  );
 });

--- a/ts/test/unit/svelte.test.ts
+++ b/ts/test/unit/svelte.test.ts
@@ -9,7 +9,23 @@ import { pathToFileURL } from 'node:url';
 import { assertDocumentTagNonces } from '../helpers/csp.js';
 
 import { createFaceApp } from '../../src/app.js';
-import { createSvelteFace } from '../../src/svelte/index.js';
+import { createSvelteFace, renderSvelte } from '../../src/svelte/index.js';
+import type { FaceContext } from '../../src/types.js';
+
+const baseCtx: FaceContext = {
+  request: {
+    method: 'GET',
+    path: '/',
+    query: {},
+    headers: { 'x-request-id': ['test-svelte'] },
+    cookies: {},
+    body: new Uint8Array(),
+    isBase64: false,
+    cspNonce: null,
+  },
+  params: {},
+  proxy: null,
+};
 
 test('svelte adapter: renders component + extracts css', async () => {
   const source = `
@@ -155,7 +171,9 @@ test('svelte adapter: integration hooks provide deterministic head/style orderin
                   styleTags: [
                     {
                       cssText: `.from-int{letter-spacing:1px;} .from-int-state-${String((state as { id: number }).id)}{display:block;}`,
-                      attrs: { id: `style-int-${String((state as { id: number }).id)}` },
+                      attrs: {
+                        id: `style-int-${String((state as { id: number }).id)}`,
+                      },
                     },
                   ],
                 }),
@@ -215,4 +233,80 @@ test('svelte adapter: integration hooks provide deterministic head/style orderin
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test('svelte adapter: strict CSP emits external hydration without inline data', async () => {
+  const Component = {
+    render: () => ({ html: '<main>Strict Svelte</main>' }),
+  };
+
+  const app = createFaceApp({
+    faces: [
+      createSvelteFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => ({ component: Component }),
+        renderOptions: {
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          hydration: {
+            type: 'external',
+            data: { message: '<strict-svelte>' },
+            dataUrl: '/_facetheory/data/svelte.json',
+            bootstrapModule: '/assets/svelte-entry.js',
+          },
+        },
+      }),
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 200);
+
+  const body = new TextDecoder().decode(resp.body as Uint8Array);
+  assert.ok(body.includes('Strict Svelte'));
+  assert.ok(body.includes('id="__FACETHEORY_DATA_URL__"'));
+  assert.ok(body.includes('href="/_facetheory/data/svelte.json"'));
+  assert.ok(
+    body.includes(
+      '<script src="/assets/svelte-entry.js" type="module"></script>',
+    ),
+  );
+  assert.ok(!body.includes('id="__FACETHEORY_DATA__"'));
+  assert.ok(!body.includes('<strict-svelte>'));
+});
+
+test('svelte adapter: strict CSP rejects raw SSR head and CSS fallback', async () => {
+  await assert.rejects(
+    () =>
+      renderSvelte(
+        baseCtx,
+        {
+          component: {
+            render: () => ({
+              html: '<main>Unsafe head</main>',
+              head: '<meta name="svelte-raw" content="yes">',
+            }),
+          },
+        },
+        { csp: { inlineScripts: false } },
+      ),
+    /Svelte adapter strict CSP rejects raw adapter head output/,
+  );
+
+  await assert.rejects(
+    () =>
+      renderSvelte(
+        baseCtx,
+        {
+          component: {
+            render: () => ({
+              html: '<main>Unsafe CSS</main>',
+              css: { code: 'main{color:red;}' },
+            }),
+          },
+        },
+        { csp: { inlineStyles: false } },
+      ),
+    /Svelte adapter strict CSP rejects inline adapter style output/,
+  );
 });

--- a/ts/test/unit/vue.test.ts
+++ b/ts/test/unit/vue.test.ts
@@ -4,7 +4,23 @@ import test from 'node:test';
 import { assertDocumentTagNonces } from '../helpers/csp.js';
 
 import { createFaceApp } from '../../src/app.js';
-import { createVueFace, h } from '../../src/vue/index.js';
+import { createVueFace, h, renderVue } from '../../src/vue/index.js';
+import type { FaceContext } from '../../src/types.js';
+
+const baseCtx: FaceContext = {
+  request: {
+    method: 'GET',
+    path: '/',
+    query: {},
+    headers: { 'x-request-id': ['test-vue'] },
+    cookies: {},
+    body: new Uint8Array(),
+    isBase64: false,
+    cspNonce: null,
+  },
+  params: {},
+  proxy: null,
+};
 
 test('vue adapter: renders VNode + head tags', async () => {
   const app = createFaceApp({
@@ -65,7 +81,13 @@ test('vue adapter: integration hooks provide deterministic head/style ordering a
               name: 'vue-wrap-contrib-finalize',
               createState: () => ({ id: ++nextStateId }),
               wrapTree: (tree, _ctx, state) =>
-                h('section', { class: `wrapped wrapped-${String((state as { id: number }).id)}` }, [tree]),
+                h(
+                  'section',
+                  {
+                    class: `wrapped wrapped-${String((state as { id: number }).id)}`,
+                  },
+                  [tree],
+                ),
               contribute: (_ctx, state) => ({
                 headTags: [
                   {
@@ -79,7 +101,9 @@ test('vue adapter: integration hooks provide deterministic head/style ordering a
                 styleTags: [
                   {
                     cssText: `.from-int{color:rgb(1,2,3);} .from-int-state-${String((state as { id: number }).id)}{display:block;}`,
-                    attrs: { id: `style-int-${String((state as { id: number }).id)}` },
+                    attrs: {
+                      id: `style-int-${String((state as { id: number }).id)}`,
+                    },
                   },
                 ],
               }),
@@ -132,4 +156,61 @@ test('vue adapter: integration hooks provide deterministic head/style ordering a
   assert.ok(secondBody.includes('/integration-a-2.css'));
   assert.ok(secondBody.includes('/integration-b-2.css'));
   assert.ok(secondBody.includes('id="style-int-2"'));
+});
+
+test('vue adapter: strict CSP emits external hydration without inline data', async () => {
+  const app = createFaceApp({
+    faces: [
+      createVueFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => h('main', null, 'Strict Vue'),
+        renderOptions: {
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          hydration: {
+            type: 'external',
+            data: { message: '<strict-vue>' },
+            dataUrl: '/_facetheory/data/vue.json',
+            bootstrapModule: '/assets/vue-entry.js',
+          },
+        },
+      }),
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 200);
+
+  const body = new TextDecoder().decode(resp.body as Uint8Array);
+  assert.ok(body.includes('Strict Vue'));
+  assert.ok(body.includes('id="__FACETHEORY_DATA_URL__"'));
+  assert.ok(body.includes('href="/_facetheory/data/vue.json"'));
+  assert.ok(
+    body.includes('<script src="/assets/vue-entry.js" type="module"></script>'),
+  );
+  assert.ok(!body.includes('id="__FACETHEORY_DATA__"'));
+  assert.ok(!body.includes('<strict-vue>'));
+});
+
+test('vue adapter: strict CSP rejects inline hydration and styles', async () => {
+  await assert.rejects(
+    () =>
+      renderVue(baseCtx, h('main', null, 'Unsafe Vue hydration'), {
+        csp: { inlineScripts: false },
+        hydration: {
+          data: { unsafe: true },
+          bootstrapModule: '/assets/vue-entry.js',
+        },
+      }),
+    /Vue adapter strict CSP requires external hydration data/,
+  );
+
+  await assert.rejects(
+    () =>
+      renderVue(baseCtx, h('main', null, 'Unsafe Vue style'), {
+        csp: { inlineStyles: false },
+        styleTags: [{ cssText: '.unsafe-vue{color:red;}' }],
+      }),
+    /Vue adapter strict CSP rejects inline adapter style output/,
+  );
 });


### PR DESCRIPTION
## Milestone
strict-csp-adapter-parity — wire strict-CSP/no-inline behavior across React, Vue, and Svelte adapters.

## Linear
- THE-1164 — [10] Wire React strict-CSP adapter behavior
- THE-1165 — [11] Wire Vue strict-CSP parity behavior
- THE-1166 — [12] Wire Svelte strict-CSP parity behavior

## Render modes and adapters affected
- SSR / SPA shell adapter output
- React buffered SSR and streaming SSR
- React Emotion and AntD integrations
- Vue SSR adapter
- Svelte SSR adapter

## Determinism impact
Preserves determinism by failing closed before FaceApp head/body emission when strict-CSP adapter output would require inline scripts, inline styles, raw head HTML, inline hydration data, or unsafe shell streaming.

## Backward compatibility
Additive. Non-strict routes retain existing inline hydration/style/head behavior. Strict routes must use external hydration/assets or fail closed.

## Implementation
- Adds a shared adapter strict-CSP validation helper for adapter-returned head/style/hydration output.
- React render options now carry `csp`; strict routes reject inline hydration, inline style output from Emotion/AntD extraction, raw adapter head output, and shell streaming when inline scripts are disabled.
- Vue render options now carry `csp`; strict routes reject inline hydration/styles/raw adapter head output while allowing external hydration.
- Svelte render options now carry `csp`; strict routes reject raw SSR head output and CSS fallback/inline style output while allowing external hydration.

## Tasks
- [x] THE-1164 — [10] Wire React strict-CSP adapter behavior
- [x] THE-1165 — [11] Wire Vue strict-CSP parity behavior
- [x] THE-1166 — [12] Wire Svelte strict-CSP parity behavior

## Validation
- [x] `git diff --check origin/facetheory/strict-csp-navigation-oac...HEAD`
- [x] `git diff --check`
- [x] `scripts/verify-version-alignment.sh` — PASS (3.1.2)
- [x] `cd ts && npm ci` — PASS (450 packages, 0 vulnerabilities)
- [x] `cd ts && npm run typecheck` — PASS
- [x] `cd ts && npm run lint` — PASS
- [x] `cd ts && npm test` — PASS (310 pass / 1 skipped)
- [x] `cd ts && npm run build` — PASS
- [x] `cd ts && npm run check` — not present in `ts/package.json`
- [x] `cd ts && npm run example:vite:vue:build` — PASS
- [x] `cd ts && npm run example:vite:svelte:build` — PASS (existing Svelte compiler/a11y warnings only)
- [x] `cd ts && npm run example:vite:svelte:library:build` — PASS
- [x] `cd ts && npm run example:streaming:serve` smoke path — PASS (`curl` returned FaceTheory React streaming SSR HTML)

## Cross-repo coordination
None. No release/version bumps, Release Please changes, Simulacrum edits, AWS/deploy/account/secret/live-receipt work, or sibling/parent/framework repo edits.
