### PR TITLE
feat(csp): add strict example validation

### DIFF
--- a/ts/examples/vite-strict-csp-svelte/README.md
+++ b/ts/examples/vite-strict-csp-svelte/README.md
@@ -1,0 +1,33 @@
+# Strict CSP Vite SSR Example (Svelte)
+
+Canonical strict-CSP Svelte/Vite FaceTheory example.
+
+It demonstrates:
+
+- external Vite CSS and asset injection via manifest head tags;
+- same-origin module bootstrap;
+- external FaceTheory hydration JSON via `<link rel="facetheory-hydration">`;
+- strict no-inline CSP render validation (`inlineScripts:false`, `inlineStyles:false`, `rawHead:false`);
+- deterministic server/client hydration data equivalence.
+
+## Build
+
+From `ts/`:
+
+```bash
+npm run example:vite:svelte:strict-csp:build
+```
+
+Outputs:
+
+- `ts/examples/vite-strict-csp-svelte/dist/client/.vite/manifest.json`
+- `ts/examples/vite-strict-csp-svelte/dist/client/assets/*`
+- `ts/examples/vite-strict-csp-svelte/dist/server/entry-server.js`
+
+## Run
+
+```bash
+npm run example:vite:svelte:strict-csp:serve
+```
+
+Then open `http://localhost:4178/`.

--- a/ts/examples/vite-strict-csp-svelte/node-server.ts
+++ b/ts/examples/vite-strict-csp-svelte/node-server.ts
@@ -1,0 +1,138 @@
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { ViteManifest } from '../../src/vite.js';
+
+async function loadManifest(): Promise<ViteManifest> {
+  const manifestPath = path.resolve(
+    'examples/vite-strict-csp-svelte/dist/client/.vite/manifest.json',
+  );
+  const raw = await readFile(manifestPath, 'utf8');
+  return JSON.parse(raw) as ViteManifest;
+}
+
+function contentTypeForPath(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.js':
+      return 'text/javascript; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function decodeUrlPath(urlPath: string): string | null {
+  try {
+    return decodeURIComponent(urlPath);
+  } catch {
+    return null;
+  }
+}
+
+async function readStaticFile(
+  root: string,
+  urlPath: string,
+): Promise<{ body: Uint8Array; type: string } | null> {
+  const decoded = decodeUrlPath(urlPath);
+  if (!decoded?.startsWith('/')) return null;
+  if (decoded.includes('\0')) return null;
+
+  const safePath = decoded.replaceAll('\\', '/');
+  if (safePath.includes('..')) return null;
+
+  const filePath = path.resolve(root, `.${safePath}`);
+  const rootPrefix = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  if (!filePath.startsWith(rootPrefix)) return null;
+
+  try {
+    const body = await readFile(filePath);
+    return { body, type: contentTypeForPath(filePath) };
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const manifest = await loadManifest();
+  const serverEntryPath = path.resolve(
+    'examples/vite-strict-csp-svelte/dist/server/entry-server.js',
+  );
+  const serverMod = await import(pathToFileURL(serverEntryPath).href);
+
+  const app = serverMod.createViteStrictCspSvelteExampleApp(manifest);
+
+  const server = http.createServer(async (req, res) => {
+    if (!req.url) {
+      res.writeHead(400);
+      res.end('Bad Request');
+      return;
+    }
+
+    const requestPath = new URL(req.url, 'http://localhost').pathname;
+    if (requestPath.startsWith('/_facetheory/data/')) {
+      const pathname = requestPath.endsWith('next.json') ? '/next' : '/';
+      res.writeHead(200, {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+      });
+      res.end(serverMod.strictCspSvelteHydrationJsonForPath(pathname));
+      return;
+    }
+
+    const clientRoot = path.resolve(
+      'examples/vite-strict-csp-svelte/dist/client',
+    );
+    if (
+      requestPath.startsWith('/assets/') ||
+      requestPath.startsWith('/.vite/')
+    ) {
+      const staticFile = await readStaticFile(clientRoot, requestPath);
+      if (!staticFile) {
+        res.writeHead(404);
+        res.end('Not Found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': staticFile.type });
+      res.end(staticFile.body);
+      return;
+    }
+
+    const resp = await app.handle({
+      method: req.method ?? 'GET',
+      path: req.url,
+    });
+    res.writeHead(
+      resp.status,
+      Object.fromEntries(
+        Object.entries(resp.headers).map(([k, v]) => [k, v.join(', ')]),
+      ),
+    );
+
+    if (resp.body instanceof Uint8Array) {
+      res.end(resp.body);
+      return;
+    }
+
+    for await (const chunk of resp.body) {
+      res.write(chunk);
+    }
+    res.end();
+  });
+
+  const port = Number(process.env.PORT ?? 4178);
+  server.listen(port);
+  console.log(`listening on http://localhost:${port}/`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ts/examples/vite-strict-csp-svelte/src/App.svelte
+++ b/ts/examples/vite-strict-csp-svelte/src/App.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  export let page: string;
+  export let message: string;
+  export let detail: string;
+  export let logoUrl: string;
+
+  const navItems = [
+    { href: '/', label: 'Home', page: 'home' },
+    { href: '/next', label: 'Next', page: 'next' },
+  ];
+</script>
+
+<main class="strict-csp-shell" data-facetheory-view data-page={page}>
+  <section class="strict-csp-card" aria-labelledby="strict-csp-title">
+    <img class="strict-csp-logo" src={logoUrl} alt="FaceTheory strict CSP" />
+    <p class="strict-csp-eyebrow">FaceTheory strict CSP</p>
+    <h1 id="strict-csp-title" class="strict-csp-title">Svelte + Vite without inline output</h1>
+    <p class="strict-csp-copy">Hello {message}</p>
+    <p class="strict-csp-copy">{detail}</p>
+    <nav class="strict-csp-nav" aria-label="Strict CSP example pages">
+      {#each navItems as item}
+        <a
+          class="strict-csp-link"
+          href={item.href}
+          aria-current={item.page === page ? 'page' : undefined}
+        >{item.label}</a>
+      {/each}
+    </nav>
+  </section>
+</main>

--- a/ts/examples/vite-strict-csp-svelte/src/entry-client.ts
+++ b/ts/examples/vite-strict-csp-svelte/src/entry-client.ts
@@ -1,0 +1,120 @@
+import { hydrate } from 'svelte';
+
+import type { FaceNavigationBootstrapContext } from '../../../src/spa.js';
+
+import App from './App.svelte';
+import logoUrl from './logo.svg';
+import './styles.css';
+
+interface StrictCspSvelteExampleData {
+  page?: string;
+  message?: string;
+  detail?: string;
+}
+
+declare global {
+  interface Window {
+    __FACETHEORY_STRICT_CSP_SVELTE_DATA__?: StrictCspSvelteExampleData;
+    __FACETHEORY_STRICT_CSP_SVELTE_HYDRATED__?: number;
+    __FACETHEORY_STRICT_CSP_SVELTE_NAVIGATED__?: number;
+  }
+}
+
+function dataUrlFromDocument(doc: Document): string {
+  const marker = doc.getElementById('__FACETHEORY_DATA_URL__');
+  if (marker?.tagName.toLowerCase() === 'link') {
+    const href = marker.getAttribute('href');
+    if (href) return href;
+  }
+
+  const relMarker = doc.querySelector('link[rel="facetheory-hydration"]');
+  const href = relMarker?.getAttribute('href');
+  if (href) return href;
+
+  throw new Error('missing FaceTheory strict CSP hydration data link');
+}
+
+async function loadExternalHydrationData(
+  doc: Document,
+  fetcher: typeof fetch,
+): Promise<StrictCspSvelteExampleData> {
+  const win = doc.defaultView ?? window;
+  const dataUrl = new URL(dataUrlFromDocument(doc), win.location.href);
+  if (dataUrl.origin !== win.location.origin) {
+    throw new Error('strict CSP hydration data must be same-origin');
+  }
+
+  const response = await fetcher(dataUrl.toString(), {
+    headers: { accept: 'application/json' },
+  });
+  const responseUrl = response.url
+    ? new URL(response.url, win.location.href)
+    : dataUrl;
+  if (responseUrl.origin !== win.location.origin) {
+    throw new Error('strict CSP hydration data response must stay same-origin');
+  }
+  if (!response.ok) {
+    throw new Error(`strict CSP hydration data failed (${response.status})`);
+  }
+
+  return (await response.json()) as StrictCspSvelteExampleData;
+}
+
+function propsFromData(data: StrictCspSvelteExampleData) {
+  return {
+    page: data.page ?? 'home',
+    message: data.message ?? 'from client fallback',
+    detail: data.detail ?? 'External hydration data was unavailable.',
+    logoUrl,
+  };
+}
+
+function recordHydration(
+  doc: Document,
+  data: StrictCspSvelteExampleData,
+  navigation: boolean,
+): void {
+  const win = doc.defaultView ?? window;
+  win.__FACETHEORY_STRICT_CSP_SVELTE_DATA__ = data;
+  win.__FACETHEORY_STRICT_CSP_SVELTE_HYDRATED__ =
+    (win.__FACETHEORY_STRICT_CSP_SVELTE_HYDRATED__ ?? 0) + 1;
+  if (navigation) {
+    win.__FACETHEORY_STRICT_CSP_SVELTE_NAVIGATED__ =
+      (win.__FACETHEORY_STRICT_CSP_SVELTE_NAVIGATED__ ?? 0) + 1;
+  }
+}
+
+export async function hydrateStrictCspSvelteExample(
+  options: {
+    document?: Document;
+    fetcher?: typeof fetch;
+    navigation?: boolean;
+    target?: Element;
+  } = {},
+): Promise<StrictCspSvelteExampleData> {
+  const doc = options.document ?? document;
+  const fetcher = options.fetcher ?? fetch.bind(globalThis);
+  const data = await loadExternalHydrationData(doc, fetcher);
+  const target = options.target ?? doc.body;
+
+  recordHydration(doc, data, options.navigation === true);
+  hydrate(App, {
+    target,
+    props: propsFromData(data),
+  });
+  return data;
+}
+
+export async function hydrateFaceNavigation(
+  context: FaceNavigationBootstrapContext,
+): Promise<void> {
+  const doc = context.document;
+  const data = (context.data ?? {}) as StrictCspSvelteExampleData;
+  recordHydration(doc, data, true);
+}
+
+if (typeof document !== 'undefined') {
+  void hydrateStrictCspSvelteExample().catch((error) => {
+    console.error('FaceTheory strict CSP Svelte hydration failed', error);
+  });
+}

--- a/ts/examples/vite-strict-csp-svelte/src/entry-server.ts
+++ b/ts/examples/vite-strict-csp-svelte/src/entry-server.ts
@@ -1,0 +1,113 @@
+import { createFaceApp } from '../../../src/app.js';
+import { buildStrictCspHeader } from '../../../src/security.js';
+import { createSvelteFace } from '../../../src/svelte/index.js';
+import type { ViteManifest } from '../../../src/vite.js';
+import {
+  externalHydrationForEntry,
+  viteAssetsForEntry,
+} from '../../../src/vite.js';
+
+import App from './App.svelte';
+import logoUrl from './logo.svg';
+
+export interface StrictCspSvelteExampleData {
+  page: 'home' | 'next';
+  message: string;
+  detail: string;
+}
+
+export interface StrictCspSvelteExampleRenderData extends StrictCspSvelteExampleData {
+  logoUrl: string;
+}
+
+const ENTRY = 'src/entry-client.ts';
+const STRICT_CSP = {
+  inlineScripts: false,
+  inlineStyles: false,
+  rawHead: false,
+} as const;
+
+export function strictCspSvelteDataForPath(
+  pathname: string,
+): StrictCspSvelteExampleData {
+  if (pathname === '/next') {
+    return {
+      page: 'next',
+      message: 'from strict external hydration next',
+      detail:
+        'The next page is hydrated from same-origin JSON before the navigation hook runs.',
+    };
+  }
+
+  return {
+    page: 'home',
+    message: 'from strict external hydration home',
+    detail:
+      'The home page uses external CSS, a same-origin module, and a JSON sidecar.',
+  };
+}
+
+export function strictCspSvelteHydrationDataUrl(pathname: string): string {
+  return pathname === '/next'
+    ? '/_facetheory/data/strict-csp-svelte-next.json'
+    : '/_facetheory/data/strict-csp-svelte-home.json';
+}
+
+export function strictCspSvelteHydrationJsonForPath(pathname: string): string {
+  return JSON.stringify(strictCspSvelteDataForPath(pathname));
+}
+
+export function createViteStrictCspSvelteExampleApp(manifest: ViteManifest) {
+  return createFaceApp({
+    faces: [
+      createSvelteFace({
+        route: '/',
+        mode: 'ssr',
+        load: async () => strictCspSvelteDataForPath('/'),
+        render: (_ctx, data) => ({
+          component: App,
+          props: { ...(data as StrictCspSvelteExampleData), logoUrl },
+        }),
+        renderOptions: strictRenderOptions(manifest, '/'),
+      }),
+      createSvelteFace({
+        route: '/next',
+        mode: 'ssr',
+        load: async () => strictCspSvelteDataForPath('/next'),
+        render: (_ctx, data) => ({
+          component: App,
+          props: { ...(data as StrictCspSvelteExampleData), logoUrl },
+        }),
+        renderOptions: strictRenderOptions(manifest, '/next'),
+      }),
+    ],
+  });
+}
+
+function strictRenderOptions(manifest: ViteManifest, pathname: string) {
+  return async (_ctx: unknown, data: unknown) => {
+    const exampleData = data as StrictCspSvelteExampleData;
+    const { headTags } = viteAssetsForEntry(manifest, ENTRY, {
+      includeAssets: true,
+    });
+    const hydration = externalHydrationForEntry(manifest, ENTRY, exampleData, {
+      dataUrl: strictCspSvelteHydrationDataUrl(pathname),
+    });
+
+    return {
+      csp: STRICT_CSP,
+      headers: {
+        'content-security-policy': buildStrictCspHeader(),
+      },
+      headTags: [
+        ...headTags,
+        {
+          type: 'meta' as const,
+          attrs: { name: 'example', content: 'strict-csp-svelte' },
+        },
+        { type: 'title' as const, text: 'FaceTheory Strict CSP Svelte' },
+      ],
+      hydration,
+    };
+  };
+}

--- a/ts/examples/vite-strict-csp-svelte/src/logo.svg
+++ b/ts/examples/vite-strict-csp-svelte/src/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="FaceTheory strict CSP mark">
+  <rect width="64" height="64" rx="14" fill="#143642"/>
+  <path d="M18 34 28 44 48 20" fill="none" stroke="#f7f3e3" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ts/examples/vite-strict-csp-svelte/src/styles.css
+++ b/ts/examples/vite-strict-csp-svelte/src/styles.css
@@ -1,0 +1,79 @@
+:root {
+  color: #143642;
+  background: #f7f3e3;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.strict-csp-shell {
+  display: grid;
+  gap: 1rem;
+  margin: 0 auto;
+  max-width: 52rem;
+  padding: 4rem 1.5rem;
+}
+
+.strict-csp-card {
+  background: #ffffff;
+  border: 1px solid rgba(20, 54, 66, 0.18);
+  border-radius: 24px;
+  box-shadow: 0 18px 40px rgba(20, 54, 66, 0.12);
+  display: grid;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.strict-csp-logo {
+  height: 48px;
+  width: 48px;
+}
+
+.strict-csp-eyebrow {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.strict-csp-title {
+  font-size: clamp(2rem, 6vw, 4rem);
+  line-height: 0.95;
+  margin: 0;
+}
+
+.strict-csp-copy {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.strict-csp-nav {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.strict-csp-link {
+  border: 1px solid rgba(20, 54, 66, 0.3);
+  border-radius: 999px;
+  color: #143642;
+  font-weight: 700;
+  padding: 0.65rem 0.95rem;
+  text-decoration: none;
+}
+
+.strict-csp-link[aria-current='page'] {
+  background: #143642;
+  color: #f7f3e3;
+}

--- a/ts/examples/vite-strict-csp-svelte/vite.config.ts
+++ b/ts/examples/vite-strict-csp-svelte/vite.config.ts
@@ -1,0 +1,34 @@
+import path from 'node:path';
+
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ isSsrBuild }) => {
+  const root = path.resolve(__dirname);
+  const ssr = Boolean(isSsrBuild);
+
+  return {
+    root,
+    appType: 'custom',
+    plugins: [svelte()],
+    build: {
+      outDir: ssr ? 'dist/server' : 'dist/client',
+      emptyOutDir: false,
+      assetsInlineLimit: 0,
+      manifest: !ssr,
+      ssr: ssr ? path.resolve(root, 'src/entry-server.ts') : undefined,
+      rollupOptions: {
+        input: ssr
+          ? path.resolve(root, 'src/entry-server.ts')
+          : path.resolve(root, 'src/entry-client.ts'),
+        output: ssr
+          ? {
+              entryFileNames: '[name].js',
+              chunkFileNames: 'chunks/[name]-[hash].js',
+              assetFileNames: 'assets/[name]-[hash][extname]',
+            }
+          : undefined,
+      },
+    },
+  };
+});

--- a/ts/examples/vite-strict-csp-svelte/vite.config.ts
+++ b/ts/examples/vite-strict-csp-svelte/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig(({ isSsrBuild }) => {
       manifest: !ssr,
       ssr: ssr ? path.resolve(root, 'src/entry-server.ts') : undefined,
       rollupOptions: {
+        preserveEntrySignatures: ssr ? undefined : 'exports-only',
         input: ssr
           ? path.resolve(root, 'src/entry-server.ts')
           : path.resolve(root, 'src/entry-client.ts'),

--- a/ts/package.json
+++ b/ts/package.json
@@ -183,7 +183,9 @@
     "example:vite:svelte:library:build": "vite build --config examples/vite-ssr-svelte-library/vite.config.ts && vite build --ssr src/entry-server.ts --config examples/vite-ssr-svelte-library/vite.config.ts",
     "example:vite:svelte:library:serve": "tsx examples/vite-ssr-svelte-library/node-server.ts",
     "example:operator-visibility:build": "tsx examples/operator-visibility-react/build.ts",
-    "example:operator-visibility:serve": "tsx examples/operator-visibility-react/node-server.ts"
+    "example:operator-visibility:serve": "tsx examples/operator-visibility-react/node-server.ts",
+    "example:vite:svelte:strict-csp:build": "vite build --config examples/vite-strict-csp-svelte/vite.config.ts && vite build --ssr src/entry-server.ts --config examples/vite-strict-csp-svelte/vite.config.ts",
+    "example:vite:svelte:strict-csp:serve": "tsx examples/vite-strict-csp-svelte/node-server.ts"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1005.0",

--- a/ts/test/helpers/strict-csp.ts
+++ b/ts/test/helpers/strict-csp.ts
@@ -1,0 +1,355 @@
+import assert from 'node:assert/strict';
+
+import { JSDOM } from 'jsdom';
+
+import {
+  startFaceNavigation,
+  type FaceNavigationBootstrapContext,
+} from '../../src/spa.js';
+
+export interface StrictCspDocumentAssertionOptions {
+  allowedOrigin?: string | URL;
+  scopeSelector?: string;
+  url?: string | URL;
+}
+
+export interface StrictCspFetchFixture {
+  body: string;
+  contentType?: string;
+  status?: number;
+  url?: string;
+}
+
+export interface StrictCspFixtureFetchResult {
+  fetcher: typeof fetch;
+  requests: string[];
+}
+
+export interface StrictCspNavigationExerciseOptions {
+  currentHtml: string;
+  currentUrl?: string | URL;
+  dataByUrl: Record<string, unknown>;
+  importModule?: (
+    specifier: string,
+  ) => Promise<{
+    hydrateFaceNavigation?: (
+      context: FaceNavigationBootstrapContext,
+    ) => void | Promise<void>;
+  }>;
+  nextHtml: string;
+  nextUrl: string | URL;
+}
+
+export interface StrictCspNavigationExerciseResult {
+  dom: JSDOM;
+  fetched: string[];
+  hydrated: Array<{ data: unknown; text: string | null; url: string }>;
+}
+
+const DEFAULT_URL = 'http://localhost/';
+const RAW_HEAD_ALLOWED_TAGS = new Set(['link', 'meta', 'script', 'title']);
+
+export function assertStrictCspDocument(
+  html: string,
+  options: StrictCspDocumentAssertionOptions = {},
+): void {
+  const dom = new JSDOM(html, { url: String(options.url ?? DEFAULT_URL) });
+  try {
+    assertStrictCspDom(dom.window.document, options);
+  } finally {
+    dom.window.close();
+  }
+}
+
+export function assertStrictCspDom(
+  doc: Document,
+  options: StrictCspDocumentAssertionOptions = {},
+): void {
+  const allowedOrigin = new URL(
+    String(
+      options.allowedOrigin ?? doc.defaultView?.location.origin ?? DEFAULT_URL,
+    ),
+  ).origin;
+  assertNoInlineHeadOrBodyTags(doc, allowedOrigin);
+  assertNoRawHeadNodes(doc);
+  assertNoUnsafeAttributes(doc, options.scopeSelector ?? 'html');
+}
+
+export function createStrictCspFixtureFetch(
+  fixtures: Record<string, StrictCspFetchFixture | string | unknown>,
+  options: { baseUrl?: string | URL } = {},
+): StrictCspFixtureFetchResult {
+  const baseUrl = String(options.baseUrl ?? DEFAULT_URL);
+  const normalized = new Map<string, StrictCspFetchFixture>();
+
+  for (const [key, value] of Object.entries(fixtures)) {
+    const url = new URL(key, baseUrl).toString();
+    if (typeof value === 'string') {
+      normalized.set(url, { body: value, contentType: contentTypeForUrl(url) });
+    } else if (isFetchFixture(value)) {
+      normalized.set(url, value);
+    } else {
+      normalized.set(url, {
+        body: JSON.stringify(value),
+        contentType: 'application/json; charset=utf-8',
+      });
+    }
+  }
+
+  const requests: string[] = [];
+  const fetcher = (async (input) => {
+    const url = new URL(String(input), baseUrl).toString();
+    requests.push(url);
+    const fixture = normalized.get(url);
+    if (!fixture) {
+      return new Response('Not Found', {
+        status: 404,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }
+
+    return new Response(fixture.body, {
+      status: fixture.status ?? 200,
+      headers: {
+        'content-type': fixture.contentType ?? contentTypeForUrl(url),
+      },
+    });
+  }) as typeof fetch;
+
+  return { fetcher, requests };
+}
+
+export async function exerciseStrictCspExternalNavigation(
+  options: StrictCspNavigationExerciseOptions,
+): Promise<StrictCspNavigationExerciseResult> {
+  const currentUrl = String(options.currentUrl ?? DEFAULT_URL);
+  const nextUrl = new URL(String(options.nextUrl), currentUrl).toString();
+
+  assertStrictCspDocument(options.currentHtml, { url: currentUrl });
+  assertStrictCspDocument(options.nextHtml, { url: nextUrl });
+
+  const dom = new JSDOM(options.currentHtml, { url: currentUrl });
+  dom.window.scrollTo = (() => {}) as typeof dom.window.scrollTo;
+
+  const { fetcher, requests } = createStrictCspFixtureFetch(
+    {
+      [nextUrl]: {
+        body: options.nextHtml,
+        contentType: 'text/html; charset=utf-8',
+      },
+      ...Object.fromEntries(
+        Object.entries(options.dataByUrl).map(([url, data]) => [
+          url,
+          {
+            body: JSON.stringify(data),
+            contentType: 'application/json; charset=utf-8',
+          },
+        ]),
+      ),
+    },
+    { baseUrl: currentUrl },
+  );
+
+  const hydrated: Array<{ data: unknown; text: string | null; url: string }> =
+    [];
+  const controller = startFaceNavigation({
+    document: dom.window.document,
+    window: dom.window as unknown as Window,
+    fetcher,
+    importModule:
+      options.importModule ??
+      (async () => ({
+        hydrateFaceNavigation: (context) => {
+          hydrated.push({
+            data: context.data,
+            text: context.view?.textContent?.trim() ?? null,
+            url: context.url.toString(),
+          });
+        },
+      })),
+  });
+
+  try {
+    await controller.navigate(nextUrl);
+    assertStrictCspDom(dom.window.document);
+    return { dom, fetched: requests, hydrated };
+  } catch (error) {
+    dom.window.close();
+    throw error;
+  } finally {
+    controller.stop();
+  }
+}
+
+export function installStrictCspBrowserGlobals(dom: JSDOM): () => void {
+  const previous = new Map<PropertyKey, unknown>();
+  const had = new Map<PropertyKey, boolean>();
+
+  const setGlobal = (name: PropertyKey, value: unknown): void => {
+    had.set(name, Object.prototype.hasOwnProperty.call(globalThis, name));
+    previous.set(name, (globalThis as Record<PropertyKey, unknown>)[name]);
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  };
+
+  const win = dom.window;
+  setGlobal('window', win);
+  setGlobal('document', win.document);
+  setGlobal('navigator', win.navigator);
+  setGlobal('HTMLElement', win.HTMLElement);
+  setGlobal('SVGElement', win.SVGElement);
+  setGlobal('Element', win.Element);
+  setGlobal('Node', win.Node);
+  setGlobal('Text', win.Text);
+  setGlobal('Comment', win.Comment);
+  setGlobal('CustomEvent', win.CustomEvent);
+  setGlobal('Event', win.Event);
+  setGlobal('MutationObserver', win.MutationObserver);
+
+  win.requestAnimationFrame =
+    win.requestAnimationFrame ?? ((cb) => setTimeout(cb, 0));
+  win.cancelAnimationFrame =
+    win.cancelAnimationFrame ?? ((id) => clearTimeout(id));
+  setGlobal('requestAnimationFrame', win.requestAnimationFrame.bind(win));
+  setGlobal('cancelAnimationFrame', win.cancelAnimationFrame.bind(win));
+
+  return () => {
+    for (const [name, existed] of had) {
+      if (existed) {
+        Object.defineProperty(globalThis, name, {
+          configurable: true,
+          value: previous.get(name),
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, name);
+      }
+    }
+  };
+}
+
+export async function flushStrictCspBrowserTasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function assertNoRawHeadNodes(doc: Document): void {
+  for (const node of Array.from(doc.head.childNodes)) {
+    if (node.nodeType === doc.TEXT_NODE) {
+      assert.equal(
+        node.textContent?.trim() ?? '',
+        '',
+        `strict CSP raw head text node: ${node.textContent ?? ''}`,
+      );
+      continue;
+    }
+
+    assert.notEqual(
+      node.nodeType,
+      doc.COMMENT_NODE,
+      'strict CSP raw head comment node',
+    );
+
+    if (node.nodeType === doc.ELEMENT_NODE) {
+      const tagName = (node as Element).tagName.toLowerCase();
+      assert.ok(
+        RAW_HEAD_ALLOWED_TAGS.has(tagName),
+        `strict CSP unexpected raw head element: ${(node as Element).outerHTML}`,
+      );
+    }
+  }
+}
+
+function assertNoInlineHeadOrBodyTags(
+  doc: Document,
+  allowedOrigin: string,
+): void {
+  for (const script of Array.from(doc.querySelectorAll('script'))) {
+    const src = script.getAttribute('src');
+    assert.ok(src, `strict CSP inline script tag: ${script.outerHTML}`);
+    assert.equal(
+      script.textContent?.trim() ?? '',
+      '',
+      `strict CSP script body: ${script.outerHTML}`,
+    );
+    assertSameOriginUrl(src, allowedOrigin, doc.URL, 'strict CSP script src');
+  }
+
+  const styleTag = doc.querySelector('style');
+  assert.equal(
+    styleTag,
+    null,
+    `strict CSP inline style tag: ${styleTag?.outerHTML ?? ''}`,
+  );
+
+  for (const link of Array.from(doc.querySelectorAll('link[href]'))) {
+    const href = link.getAttribute('href');
+    if (href)
+      assertSameOriginUrl(href, allowedOrigin, doc.URL, 'strict CSP link href');
+  }
+}
+
+function assertNoUnsafeAttributes(doc: Document, scopeSelector: string): void {
+  const scopes = Array.from(doc.querySelectorAll(scopeSelector));
+  assert.ok(
+    scopes.length > 0,
+    `strict CSP validation scope not found: ${scopeSelector}`,
+  );
+
+  for (const scope of scopes) {
+    const elements = [scope, ...Array.from(scope.querySelectorAll('*'))];
+    for (const element of elements) {
+      for (const name of element.getAttributeNames()) {
+        assert.ok(
+          !/^on[a-z]/i.test(name),
+          `strict CSP inline event handler attribute ${name}: ${element.outerHTML}`,
+        );
+        assert.notEqual(
+          name.toLowerCase(),
+          'style',
+          `strict CSP inline style attribute: ${element.outerHTML}`,
+        );
+      }
+    }
+  }
+}
+
+function assertSameOriginUrl(
+  value: string,
+  allowedOrigin: string,
+  baseUrl: string,
+  label: string,
+): void {
+  const url = new URL(value, baseUrl);
+  assert.equal(
+    url.origin,
+    allowedOrigin,
+    `${label} must be same-origin: ${url.toString()}`,
+  );
+}
+
+function contentTypeForUrl(url: string): string {
+  const pathname = new URL(url, DEFAULT_URL).pathname;
+  if (pathname.endsWith('.json')) return 'application/json; charset=utf-8';
+  if (
+    pathname.endsWith('.html') ||
+    pathname === '/' ||
+    !pathname.includes('.')
+  ) {
+    return 'text/html; charset=utf-8';
+  }
+  return 'text/plain; charset=utf-8';
+}
+
+function isFetchFixture(value: unknown): value is StrictCspFetchFixture {
+  return Boolean(
+    value &&
+    typeof value === 'object' &&
+    'body' in value &&
+    typeof (value as StrictCspFetchFixture).body === 'string',
+  );
+}

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -33,4 +33,5 @@ await import('./unit/operator-visibility-example.test.js');
 await import('./unit/vite-ssr-example.test.js');
 await import('./unit/vite-ssr-vue-example.test.js');
 await import('./unit/vite-ssr-svelte-example.test.js');
+await import('./unit/vite-strict-csp-svelte-example.test.js');
 await import('./unit/vite-ssr-svelte-library-example.test.js');

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -5,6 +5,7 @@ await import('./unit/app.test.js');
 await import('./unit/spa.test.js');
 await import('./unit/ops.test.js');
 await import('./unit/oac-form.test.js');
+await import('./unit/strict-csp-harness.test.js');
 await import('./unit/lambda-url.test.js');
 await import('./unit/aws-s3.test.js');
 await import('./unit/ssg.test.js');

--- a/ts/test/unit/strict-csp-harness.test.ts
+++ b/ts/test/unit/strict-csp-harness.test.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  assertStrictCspDocument,
+  createStrictCspFixtureFetch,
+  exerciseStrictCspExternalNavigation,
+} from '../helpers/strict-csp.js';
+
+test('strict CSP harness: rejects inline script/style/raw head/event/style attributes', () => {
+  const valid = `<!doctype html><html lang="en"><head><title>Strict</title><link href="/assets/app.css" rel="stylesheet"><script src="/assets/app.js" type="module"></script></head><body><main data-facetheory-view><a href="/next">Next</a></main></body></html>`;
+  assert.doesNotThrow(() =>
+    assertStrictCspDocument(valid, { url: 'http://localhost/' }),
+  );
+
+  assert.throws(
+    () =>
+      assertStrictCspDocument(
+        `<!doctype html><html><head><script>window.inline=true</script></head><body></body></html>`,
+      ),
+    /inline script tag|script body/,
+  );
+
+  assert.throws(
+    () =>
+      assertStrictCspDocument(
+        `<!doctype html><html><head><style>body{color:red}</style></head><body></body></html>`,
+      ),
+    /inline style tag/,
+  );
+
+  assert.throws(
+    () =>
+      assertStrictCspDocument(
+        `<!doctype html><html><head><!-- raw --><title>Raw</title></head><body></body></html>`,
+      ),
+    /raw head comment/,
+  );
+
+  assert.throws(
+    () =>
+      assertStrictCspDocument(
+        `<!doctype html><html><head><title>Unsafe attrs</title></head><body><main data-facetheory-view onclick="run()" style="color:red"></main></body></html>`,
+      ),
+    /inline event handler attribute|inline style attribute/,
+  );
+});
+
+test('strict CSP harness: fixture fetch serves same-origin HTML and hydration JSON', async () => {
+  const { fetcher, requests } = createStrictCspFixtureFetch(
+    {
+      '/next':
+        '<!doctype html><html><head><title>Next</title></head><body>Next</body></html>',
+      '/_facetheory/data/next.json': { page: 'next' },
+    },
+    { baseUrl: 'http://localhost/' },
+  );
+
+  const htmlResp = await fetcher('http://localhost/next');
+  assert.equal(
+    htmlResp.headers.get('content-type'),
+    'text/html; charset=utf-8',
+  );
+  assert.equal(
+    await htmlResp.text(),
+    '<!doctype html><html><head><title>Next</title></head><body>Next</body></html>',
+  );
+
+  const jsonResp = await fetcher('http://localhost/_facetheory/data/next.json');
+  assert.deepEqual(await jsonResp.json(), { page: 'next' });
+  assert.deepEqual(requests, [
+    'http://localhost/next',
+    'http://localhost/_facetheory/data/next.json',
+  ]);
+});
+
+test('strict CSP harness: navigates with external hydration before module hook', async () => {
+  const currentHtml = `<!doctype html>
+    <html lang="en">
+      <head>
+        <title>Home</title>
+        <link href="/assets/app.css" rel="stylesheet">
+        <link id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration" href="/_facetheory/data/home.json" type="application/json">
+        <script src="/assets/app.js" type="module"></script>
+      </head>
+      <body><main data-facetheory-view><a href="/next" id="next-link">Next</a><p>Home</p></main></body>
+    </html>`;
+  const nextHtml = `<!doctype html>
+    <html lang="en">
+      <head>
+        <title>Next</title>
+        <link href="/assets/app.css" rel="stylesheet">
+        <link id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration" href="/_facetheory/data/next.json" type="application/json">
+        <script src="/assets/app.js" type="module"></script>
+      </head>
+      <body><main data-facetheory-view><p>Next Page</p></main></body>
+    </html>`;
+
+  const result = await exerciseStrictCspExternalNavigation({
+    currentHtml,
+    nextHtml,
+    nextUrl: 'http://localhost/next',
+    dataByUrl: {
+      '/_facetheory/data/next.json': { page: 'next' },
+    },
+  });
+
+  try {
+    assert.deepEqual(result.fetched, [
+      'http://localhost/next',
+      'http://localhost/_facetheory/data/next.json',
+    ]);
+    assert.equal(result.dom.window.location.pathname, '/next');
+    assert.deepEqual(result.hydrated, [
+      {
+        data: { page: 'next' },
+        text: 'Next Page',
+        url: 'http://localhost/next',
+      },
+    ]);
+  } finally {
+    result.dom.window.close();
+  }
+});

--- a/ts/test/unit/vite-strict-csp-svelte-example.test.ts
+++ b/ts/test/unit/vite-strict-csp-svelte-example.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { execFile } from 'node:child_process';
+import { readFile, rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+
+import type { ViteManifest } from '../../src/vite.js';
+
+const execFileAsync = promisify(execFile);
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertNoInlineCspOutput(html: string): void {
+  assert.ok(!html.includes('id="__FACETHEORY_DATA__"'));
+  assert.ok(!/<script\b(?![^>]*\bsrc=)[^>]*>/i.test(html));
+  assert.ok(!/<script\b[^>]*>[\s\S]*?\S[\s\S]*?<\/script>/i.test(html));
+  assert.ok(!/<style\b/i.test(html));
+  assert.ok(!/\sstyle="/i.test(html));
+  assert.ok(!/\son[a-z]+=/i.test(html));
+}
+
+test(
+  'vite strict CSP svelte example: renders external assets and hydration sidecar metadata',
+  { concurrency: false },
+  async () => {
+    const cwd = path.resolve('.');
+
+    const distDir = path.resolve('examples/vite-strict-csp-svelte/dist');
+    await rm(distDir, { recursive: true, force: true });
+
+    await execFileAsync(
+      'npm',
+      ['run', 'example:vite:svelte:strict-csp:build'],
+      { cwd },
+    );
+
+    const manifestPath = path.resolve(
+      'examples/vite-strict-csp-svelte/dist/client/.vite/manifest.json',
+    );
+    const manifestRaw = await readFile(manifestPath, 'utf8');
+    const manifest = JSON.parse(manifestRaw) as ViteManifest;
+    const entry = manifest['src/entry-client.ts'];
+    assert.ok(entry);
+    assert.ok(entry.css?.length, 'strict example must emit external CSS');
+    assert.ok(entry.assets?.length, 'strict example must emit external assets');
+
+    const serverEntryPath = path.resolve(
+      'examples/vite-strict-csp-svelte/dist/server/entry-server.js',
+    );
+    assert.ok(await exists(serverEntryPath));
+
+    const serverMod = await import(pathToFileURL(serverEntryPath).href);
+    const app = serverMod.createViteStrictCspSvelteExampleApp(manifest);
+
+    const resp = await app.handle({ method: 'GET', path: '/' });
+    assert.equal(resp.status, 200);
+    assert.equal(resp.headers['content-security-policy']?.length, 1);
+
+    const body = new TextDecoder().decode(resp.body as Uint8Array);
+    assert.ok(body.includes('FaceTheory Strict CSP Svelte'));
+    assert.ok(body.includes('Svelte + Vite without inline output'));
+    assert.ok(body.includes('Hello from strict external hydration home'));
+    assert.ok(body.includes('data-facetheory-view'));
+    assert.ok(body.includes('id="__FACETHEORY_DATA_URL__"'));
+    assert.ok(
+      body.includes('href="/_facetheory/data/strict-csp-svelte-home.json"'),
+    );
+    assert.ok(body.includes('type="module"'));
+    assertNoInlineCspOutput(body);
+
+    assert.equal(
+      serverMod.strictCspSvelteHydrationJsonForPath('/'),
+      JSON.stringify(serverMod.strictCspSvelteDataForPath('/')),
+    );
+
+    const injectedPaths = new Set<string>();
+    for (const match of body.matchAll(
+      /<(?:link|script|img)\b[^>]*(?:href|src)="([^"]+)"/g,
+    )) {
+      const candidate = match[1];
+      if (!candidate || !candidate.startsWith('/assets/')) continue;
+      injectedPaths.add(candidate);
+    }
+    assert.ok(injectedPaths.size > 0);
+
+    for (const injectedPath of injectedPaths) {
+      const builtPath = path.resolve(
+        'examples/vite-strict-csp-svelte/dist/client',
+        `.${injectedPath}`,
+      );
+      assert.ok(
+        await exists(builtPath),
+        `missing built asset: ${injectedPath}`,
+      );
+    }
+  },
+);

--- a/ts/test/unit/vite-strict-csp-svelte-example.test.ts
+++ b/ts/test/unit/vite-strict-csp-svelte-example.test.ts
@@ -7,9 +7,27 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
+import { JSDOM } from 'jsdom';
+
+import type { FaceNavigationBootstrapModule } from '../../src/spa.js';
 import type { ViteManifest } from '../../src/vite.js';
+import {
+  assertStrictCspDocument,
+  createStrictCspFixtureFetch,
+  exerciseStrictCspExternalNavigation,
+  flushStrictCspBrowserTasks,
+  installStrictCspBrowserGlobals,
+} from '../helpers/strict-csp.js';
 
 const execFileAsync = promisify(execFile);
+
+declare global {
+  interface Window {
+    __FACETHEORY_STRICT_CSP_SVELTE_DATA__?: unknown;
+    __FACETHEORY_STRICT_CSP_SVELTE_HYDRATED__?: number;
+    __FACETHEORY_STRICT_CSP_SVELTE_NAVIGATED__?: number;
+  }
+}
 
 async function exists(filePath: string): Promise<boolean> {
   try {
@@ -18,15 +36,6 @@ async function exists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-function assertNoInlineCspOutput(html: string): void {
-  assert.ok(!html.includes('id="__FACETHEORY_DATA__"'));
-  assert.ok(!/<script\b(?![^>]*\bsrc=)[^>]*>/i.test(html));
-  assert.ok(!/<script\b[^>]*>[\s\S]*?\S[\s\S]*?<\/script>/i.test(html));
-  assert.ok(!/<style\b/i.test(html));
-  assert.ok(!/\sstyle="/i.test(html));
-  assert.ok(!/\son[a-z]+=/i.test(html));
 }
 
 test(
@@ -76,7 +85,7 @@ test(
       body.includes('href="/_facetheory/data/strict-csp-svelte-home.json"'),
     );
     assert.ok(body.includes('type="module"'));
-    assertNoInlineCspOutput(body);
+    assertStrictCspDocument(body, { url: 'http://localhost/' });
 
     assert.equal(
       serverMod.strictCspSvelteHydrationJsonForPath('/'),
@@ -102,6 +111,124 @@ test(
         await exists(builtPath),
         `missing built asset: ${injectedPath}`,
       );
+    }
+  },
+);
+
+test(
+  'vite strict CSP svelte example: browser harness hydrates and navigates with external data',
+  { concurrency: false },
+  async () => {
+    const cwd = path.resolve('.');
+    await execFileAsync(
+      'npm',
+      ['run', 'example:vite:svelte:strict-csp:build'],
+      { cwd },
+    );
+
+    const manifestPath = path.resolve(
+      'examples/vite-strict-csp-svelte/dist/client/.vite/manifest.json',
+    );
+    const manifest = JSON.parse(
+      await readFile(manifestPath, 'utf8'),
+    ) as ViteManifest;
+    const serverEntryPath = path.resolve(
+      'examples/vite-strict-csp-svelte/dist/server/entry-server.js',
+    );
+    const serverMod = await import(pathToFileURL(serverEntryPath).href);
+    const app = serverMod.createViteStrictCspSvelteExampleApp(manifest);
+
+    const homeResp = await app.handle({ method: 'GET', path: '/' });
+    const homeHtml = new TextDecoder().decode(homeResp.body as Uint8Array);
+    const nextResp = await app.handle({ method: 'GET', path: '/next' });
+    const nextHtml = new TextDecoder().decode(nextResp.body as Uint8Array);
+
+    assertStrictCspDocument(homeHtml, { url: 'http://localhost/' });
+    assertStrictCspDocument(nextHtml, { url: 'http://localhost/next' });
+
+    const homeData = serverMod.strictCspSvelteDataForPath('/');
+    const nextData = serverMod.strictCspSvelteDataForPath('/next');
+    const { fetcher, requests } = createStrictCspFixtureFetch(
+      {
+        '/_facetheory/data/strict-csp-svelte-home.json': homeData,
+      },
+      { baseUrl: 'http://localhost/' },
+    );
+
+    const dom = new JSDOM(homeHtml, { url: 'http://localhost/' });
+    const restoreGlobals = installStrictCspBrowserGlobals(dom);
+    const originalFetch = globalThis.fetch;
+    const errors: unknown[][] = [];
+    const originalConsoleError = console.error;
+    const originalWindowConsoleError = dom.window.console.error;
+    let clientModule: FaceNavigationBootstrapModule | null = null;
+    globalThis.fetch = fetcher;
+    console.error = (...args: unknown[]) => errors.push(args);
+    dom.window.console.error = (...args: unknown[]) => errors.push(args);
+
+    try {
+      const clientEntry = manifest['src/entry-client.ts'];
+      assert.ok(clientEntry?.file);
+      const clientEntryPath = path.resolve(
+        'examples/vite-strict-csp-svelte/dist/client',
+        clientEntry.file,
+      );
+      clientModule = (await import(
+        `${pathToFileURL(clientEntryPath).href}?strictCspHydration=${Date.now()}`
+      )) as FaceNavigationBootstrapModule;
+      await flushStrictCspBrowserTasks();
+
+      assert.deepEqual(requests, [
+        'http://localhost/_facetheory/data/strict-csp-svelte-home.json',
+      ]);
+      assert.deepEqual(
+        dom.window.__FACETHEORY_STRICT_CSP_SVELTE_DATA__,
+        homeData,
+      );
+      assert.equal(dom.window.__FACETHEORY_STRICT_CSP_SVELTE_HYDRATED__, 1);
+      assert.deepEqual(errors, []);
+    } finally {
+      console.error = originalConsoleError;
+      dom.window.console.error = originalWindowConsoleError;
+      globalThis.fetch = originalFetch;
+      restoreGlobals();
+      dom.window.close();
+    }
+
+    const navigation = await exerciseStrictCspExternalNavigation({
+      currentHtml: homeHtml,
+      currentUrl: 'http://localhost/',
+      nextHtml,
+      nextUrl: 'http://localhost/next',
+      dataByUrl: {
+        '/_facetheory/data/strict-csp-svelte-next.json': nextData,
+      },
+      importModule: async () => {
+        assert.ok(clientModule);
+        return clientModule;
+      },
+    });
+
+    try {
+      assert.deepEqual(navigation.fetched, [
+        'http://localhost/next',
+        'http://localhost/_facetheory/data/strict-csp-svelte-next.json',
+      ]);
+      assert.deepEqual(
+        navigation.dom.window.__FACETHEORY_STRICT_CSP_SVELTE_DATA__,
+        nextData,
+      );
+      assert.equal(
+        navigation.dom.window.__FACETHEORY_STRICT_CSP_SVELTE_NAVIGATED__,
+        1,
+      );
+      assert.equal(
+        navigation.dom.window.document.title,
+        'FaceTheory Strict CSP Svelte',
+      );
+      assert.equal(navigation.dom.window.location.pathname, '/next');
+    } finally {
+      navigation.dom.window.close();
     }
   },
 );


### PR DESCRIPTION
## Milestone
strict-csp-example-validation — strict-CSP Svelte/Vite example plus reusable browser validation harness.

Stacked on PR #187 (`facetheory/strict-csp-adapter-parity`) per Factory assignment.

## Linear
- THE-1167 — [13] Add a strict-CSP Svelte/Vite installed-client example
- THE-1168 — [14] Add strict-CSP browser validation harness

## Render modes and adapters affected
- SSR: Svelte/Vite strict-CSP example renders `/` and `/next` with external CSS/assets, same-origin module bootstrap, and external hydration JSON sidecars.
- SPA/navigation: strict-CSP browser harness exercises external hydration before navigation hooks.
- Core runtime/adapters: no `ts/src/**` changes in this milestone.

## Determinism impact
Preserves strict-CSP determinism by asserting no inline scripts/styles, no raw head output, no event-handler/style attributes in validated scopes, and hydration data equivalence across server output, client hydration, and same-origin navigation.

## Backward compatibility
Additive. Existing non-strict examples and runtime behavior are unchanged.

## Tasks
- [x] THE-1167 — Add strict-CSP Svelte/Vite installed-client example
- [x] THE-1168 — Add strict-CSP browser validation harness

## Validation
- [x] `git diff --check origin/facetheory/strict-csp-adapter-parity...HEAD`
- [x] `git diff --check`
- [x] `scripts/verify-version-alignment.sh` — PASS (`3.1.2`)
- [x] `cd ts && npm ci`
- [x] `cd ts && npm run typecheck`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm test` — PASS (315 pass / 1 skip)
- [x] `cd ts && npm run build`
- [x] `cd ts && npm run check` — skipped; script is not defined in `ts/package.json`
- [x] `cd ts && npm run example:vite:svelte:strict-csp:build`
- [x] `cd ts && node --import tsx test/unit/strict-csp-harness.test.ts`
- [x] `cd ts && node --import tsx test/unit/vite-strict-csp-svelte-example.test.ts`
- [x] `cd ts && PORT=4187 npm run example:vite:svelte:strict-csp:serve` smoke via `curl` for `/`, `/next`, and both hydration JSON sidecars; verified sidecar links/data and no inline script/style output.

## Notes
- The strict-CSP Svelte example Vite config preserves client entry exports so the navigation smoke can exercise the same built module hook used by FaceTheory SPA navigation.

## Cross-repo coordination
None.