### PR TITLE
docs(csp): document strict csp release guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ See [Migration Guide](./docs/migration-guide.md#migration-4-adopt-isr-tenant-fai
 [Troubleshooting](./docs/troubleshooting.md#issue-isr-fails-closed-when-tenant-headers-are-present) for upgrade
 steps and verification.
 
+## Strict CSP Hydration
+
+Routes that need a no-inline CSP can set `FaceRenderResult.csp` to disable inline scripts, inline styles, and raw head
+HTML, emit `buildStrictCspHeader()`, and use `externalHydrationForEntry()` so hydration data is served from a
+same-origin JSON sidecar instead of inline `__FACETHEORY_DATA__`. See
+[Getting Started](./docs/getting-started.md#add-strict-no-inline-csp-hydration) and
+[Core Patterns](./docs/core-patterns.md#pattern-render-strict-no-inline-csp-pages-with-external-hydration).
+
 ## Repository Development
 
 ```bash
@@ -119,6 +127,7 @@ High-signal examples:
 - Vue Vite SSR: `npm run example:vite:vue:build && npm run example:vite:vue:serve`
 - Svelte Vite SSR: `npm run example:vite:svelte:build && npm run example:vite:svelte:serve`
 - Svelte external library host: `npm run example:vite:svelte:library:build && npm run example:vite:svelte:library:serve`
+- Strict CSP Svelte/Vite: `npm run example:vite:svelte:strict-csp:build && npm run example:vite:svelte:strict-csp:serve`
 - Operator visibility SSR example: `npm run example:operator-visibility:build && npm run example:operator-visibility:serve`
 - SSG: `npm run example:ssg:build && npm run example:ssg:serve`
 

--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -10,8 +10,8 @@ SSR/SSG/ISR.
   - **Origin B: Lambda Function URL** for SSR + ISR regeneration paths
 - **S3 bucket(s)**
   - immutable client assets (Vite output)
-  - optional SSG HTML output
-  - optional ISR HTML object storage (via `S3HtmlStore`; AWS SDK v3 client adapter: `@theory-cloud/facetheory/aws-s3`)
+  - optional SSG HTML output and strict-CSP hydration JSON sidecars under `/_facetheory/data/*`
+  - optional ISR HTML object storage plus pointer-paired strict-CSP hydration sidecars (via `S3HtmlStore`; AWS SDK v3 client adapter: `@theory-cloud/facetheory/aws-s3`)
 - **DynamoDB table**
   - ISR metadata + lease/lock state (via TableTheory `FaceTheoryIsrMetaStore` and FaceTheory adapter `@theory-cloud/facetheory/tabletheory`)
 
@@ -26,6 +26,8 @@ When using `AppTheorySsrSite` in `ssg-isr` mode:
 - use `ssrPathPatterns` for same-origin dynamic routes that must bypass the S3-primary origin group and go straight to Lambda
 - prefer an `AWS_IAM` Function URL origin for read-only SSR traffic rather than a public direct URL
 - do not forward viewer-supplied tenant headers by default; derive tenancy from trusted request context when possible
+- attach route-owned CSP headers from the Face response when strict no-inline CSP is required; CloudFront baseline
+  security headers do not replace the per-route `content-security-policy` emitted by `buildStrictCspHeader()`
 
 Mutating form routes behind Lambda Function URL OAC are dynamic routes. If an SSR, SSG, ISR, or SPA page renders a
 same-origin form that performs `POST`, `PUT`, `PATCH`, or `DELETE`, route the form action path through `ssrPathPatterns`
@@ -79,10 +81,52 @@ This is the deployment contract FaceTheory assumes for typical Vite SSR apps:
     (commonly `.vite/manifest.json`).
 - **Optional SSG hydration JSON**:
   - keys under `/_facetheory/data/*` (SSG) routed to S3
+  - strict no-inline SSG routes with hydration data automatically externalize it to this path shape, for example
+    `/about` -> `/_facetheory/data/about.json` and `/` -> `/_facetheory/data/index.json`
+  - upload and invalidate SSG HTML and its matching hydration JSON together; a stale HTML document should not point to a
+    data sidecar from a different build
 
 See:
 - `infra/apptheory-ssr-site/` for SSR + assets via AppTheory `AppTheorySsrSite`
 - `infra/apptheory-ssg-isr-site/` for SSG origin-group failover + ISR (S3 + Dynamo)
+
+## Strict CSP Hydration Routing
+
+Strict no-inline CSP changes hydration transport but not the AWS topology. The page still arrives through the same
+CloudFront distribution, and every bootstrap/data URL must resolve same-origin.
+
+SSG sidecars:
+
+- `buildSsgSite()` writes strict hydration JSON under `/_facetheory/data/*` when an SSG Face has `csp.inlineScripts === false` and hydration data.
+- Route `/_facetheory/data/*` to S3 with the same origin access posture as the static HTML output.
+- Serve sidecars as `application/json; charset=utf-8` with explicit cache headers. Their TTL should be no looser than
+  the HTML that references them unless you deploy sidecars under immutable build-specific prefixes.
+- Deploy and invalidate HTML and data sidecars as a pair so client hydration reads the same data used for the server render.
+
+ISR sidecars:
+
+- Strict ISR regeneration stores a hydration sidecar next to the generated HTML pointer in `S3HtmlStore`.
+- The sidecar pointer is derived from the HTML pointer by replacing `.html` with `.hydration.json`, so stale HTML and
+  stale hydration data remain paired through the same metadata pointer lifecycle.
+- The browser-facing data URL stays on the page route and uses the opaque `__facetheory_isr_hydration` query parameter.
+  That request must route to Lambda/FaceTheory, not directly to S3, so the runtime can validate and serve the pointer.
+- Do not create public CloudFront behaviors that expose arbitrary ISR sidecar object keys. The runtime validates the
+  pointer token and returns `404` for invalid or missing sidecars.
+
+SSR sidecars:
+
+- Per-request strict SSR data sidecars are host-defined. If a Face emits external hydration data for SSR, the `dataUrl`
+  must be same-origin and routed to Lambda/AppTheory or another host-owned same-origin JSON endpoint that can reproduce
+  the exact server-render data for that request.
+
+OAC and navigation:
+
+- `startAwsOacFormTransport({ navigationPolicy: "full-page" })` is the strict-CSP default because fetched CSP headers
+  cannot become the active document policy during `document.write()` replacement.
+- Choose `navigationPolicy: "spa"` only when the returned HTML is a FaceTheory document, the host accepts the SPA
+  navigation contract, and external hydration data is loaded before DOM mutation.
+- Route mutating action paths through `ssrPathPatterns`; do not let S3 static behaviors intercept form actions from SSG
+  or ISR pages.
 
 ## CloudFront Behaviors
 
@@ -141,6 +185,8 @@ Notes:
 
 - HTML pages:
   - `cache-control: public, max-age=0, s-maxage=600` (or environment-specific value)
+- Strict-CSP hydration JSON:
+  - serve from S3 under `/_facetheory/data/*` with cache headers coordinated with the referencing HTML
 - Hashed assets (`/assets/*`):
   - `cache-control: public, max-age=31536000, immutable`
 - Deploy updates should upload new hashed assets and invalidate changed HTML keys.
@@ -161,8 +207,9 @@ Notes:
 4. Metadata lookup in DynamoDB:
    - fresh -> serve cached HTML pointer from S3
    - stale/miss -> attempt lease lock and regenerate
-5. Regeneration writes HTML to S3 first, then atomically updates metadata pointer.
-6. On regeneration failure, previous pointer stays valid; stale serve policy applies.
+5. Strict-CSP regeneration writes the pointer-derived hydration sidecar before the HTML metadata commit.
+6. Regeneration writes HTML to S3, then atomically updates metadata pointer.
+7. On regeneration failure, previous pointer stays valid; stale HTML and stale hydration data stay paired.
 
 Default tenant note:
 - FaceTheory uses the `default` tenant unless `tenantKey` is configured.
@@ -179,6 +226,11 @@ Default tenant note:
   - immutable build assets
   - ISR objects
   - optional SSG output
+- For strict-CSP routes, confirm:
+  - every strict response carries the intended `content-security-policy` header
+  - SSG sidecars under `/_facetheory/data/*` are reachable from CloudFront and same-origin
+  - ISR hydration sidecar query URLs route to Lambda/FaceTheory and do not expose raw object keys
+  - OAC form navigation policy is explicit when CSP-protected HTML responses are expected
 - Runbook should include:
   - cache invalidation steps for SSG HTML changes
   - rollback procedure for Lambda + metadata table changes

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -15,6 +15,9 @@ This document describes production hardening guidance for FaceTheory apps and th
 - Security headers:
   - Set baseline security headers at the CDN layer (HSTS, nosniff, frame-options, referrer-policy, permissions-policy).
   - Do not attempt to set a nonce-based CSP at CloudFront (nonces are per-request).
+  - Attach strict no-inline CSP headers from the Face response when a route opts into
+    `csp: { inlineScripts:false, inlineStyles:false, rawHead:false }`; the runtime validates output but does not add the
+    header automatically.
 - Timeouts/limits:
   - Configure Lambda timeout and memory for worst-case SSR render + streaming.
   - For React streaming, ensure `abortDelayMs` is comfortably below your Lambda timeout.
@@ -73,6 +76,29 @@ Important constraint:
 Helper:
 - `createCspNonce()` is available at `ts/src/security.ts`.
 
+### Strict no-inline CSP operations
+
+Strict no-inline routes replace inline hydration with same-origin JSON sidecars and should be checked as a render/data
+pair:
+
+- SSR: confirm the response carries `content-security-policy` from the Face and the external hydration `dataUrl` is
+  same-origin. If the data is request-time, route the sidecar URL to Lambda/AppTheory or another host-owned same-origin
+  endpoint that can reproduce the exact render data.
+- SSG: confirm HTML and `/_facetheory/data/*` sidecars are uploaded together and routed to S3 through CloudFront. Cache
+  headers and invalidations should keep the HTML and sidecar from different builds from being mixed.
+- ISR: confirm `x-facetheory-isr` behavior stays normal and hydration sidecar URLs with
+  `__facetheory_isr_hydration=...` route to Lambda/FaceTheory. The runtime validates the opaque pointer token and serves
+  the pointer-derived `.hydration.json` object from the same `S3HtmlStore` used for HTML.
+- SPA navigation: confirm `startFaceNavigation()` or `startAwsOacFormTransport({ navigationPolicy: "spa" })` loads
+  external hydration data before mutating the document. Use `navigationPolicy: "full-page"` when fetched CSP-protected
+  HTML should become a real browser navigation instead of a document-write replacement.
+
+Evidence boundary:
+- A local strict-CSP test or example build proves repository behavior only.
+- A successful RC validation must name the exact FaceTheory GitHub Release tarball installed by the consuming app.
+- Do not record "AWS deployment verified", "Simulacrum verified", or "customer deployed" unless that system supplied
+  independent evidence through the owning operator or steward.
+
 ### Response headers policy guidance
 
 Recommended baseline (CDN layer preferred):
@@ -123,6 +149,31 @@ Prefer versioned prefixes for HTML/data outputs:
 If using stable keys:
 - Invalidate HTML keys (`/*` or targeted paths) on deploy.
 - Do not invalidate immutable hashed assets.
+
+### Strict CSP RC and stable release handoff
+
+Use this checklist before promoting strict-CSP changes from release candidate to stable:
+
+1. Release Please owns the RC and stable tags/releases; do not hand-create tags, GitHub Releases, changelogs, or assets.
+2. Install the RC in the validating app from the immutable GitHub Release tarball, not a workspace link.
+3. Ask Simulacrum validation to exercise the strict-CSP surface it owns, including:
+   - an SSR strict route with explicit CSP header attachment
+   - SSG sidecar routing through CloudFront/S3 for `/_facetheory/data/*`
+   - ISR sidecar hydration through the Lambda/FaceTheory query-param URL
+   - OAC form navigation policy behavior when CSP-protected HTML responses are involved
+4. Capture evidence as RC validation, not as publication proof: exact RC version, PR/release URL, commands or browser
+   route checks, observed headers/URLs, and whether app-local workarounds were removed.
+5. Stable promotion criteria:
+   - FaceTheory CI and local release checks are green
+   - strict-CSP docs and examples match the implementation
+   - Simulacrum or another authorized consumer has validated the RC from the release tarball if the release scope depends
+     on deployed behavior
+   - no docs claim AWS/customer deployment proof beyond the evidence captured
+   - `main` is back-merged to `staging` after stable release per the normal release flow
+
+Rollback:
+- pin consumers to the previous FaceTheory release tarball, or remove the strict-CSP opt-in on affected routes.
+- do not weaken OAC, expose direct Lambda Function URLs, or remove CSP headers as the framework rollback path.
 
 ### ISR lock contention diagnostics
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -37,7 +37,7 @@ Use this table as the public entrypoint map for package consumers. It reflects t
 
 | Export                                               | Surface                              | Primary interfaces                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | ---------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `@theory-cloud/facetheory`                           | Core runtime                         | `createFaceApp`, `FaceApp`, `FaceModule`, `FaceMode`, `FaceRequest`, `FaceResponse`, `FaceRenderResult`, `buildSsgSite`, `createLambdaUrlStreamingHandler`, `S3HtmlStore`, `InMemoryHtmlStore`, `InMemoryIsrMetaStore`, `blockingIsrCacheControl`, `viteAssetsForEntry`, `viteHydrationForEntry`, `createCspNonce`, `readFaceHydrationData`, `parseFaceNavigationSnapshot`, `fetchFaceNavigationSnapshot`, `applyFaceNavigationSnapshot`, `loadFaceNavigationModule`, `startFaceNavigation`, `startAwsOacFormTransport`, `createAwsOacUrlEncodedFormPayload` |
+| `@theory-cloud/facetheory`                           | Core runtime                         | `createFaceApp`, `FaceApp`, `FaceModule`, `FaceMode`, `FaceRequest`, `FaceResponse`, `FaceRenderResult`, `buildSsgSite`, `createLambdaUrlStreamingHandler`, `S3HtmlStore`, `InMemoryHtmlStore`, `InMemoryIsrMetaStore`, `blockingIsrCacheControl`, `viteAssetsForEntry`, `viteHydrationForEntry`, `externalHydrationForEntry`, `createCspNonce`, `buildStrictCspHeader`, `validateStrictCspDocument`, `readFaceHydrationData`, `parseFaceNavigationSnapshot`, `fetchFaceNavigationSnapshot`, `applyFaceNavigationSnapshot`, `loadFaceNavigationModule`, `startFaceNavigation`, `startAwsOacFormTransport`, `createAwsOacUrlEncodedFormPayload` |
 | `@theory-cloud/facetheory/apptheory`                 | AppTheory adapter                    | `createAppTheoryFaceHandler`, `appTheoryContextToFaceRequest`, `faceResponseToAppTheoryResponse`                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `@theory-cloud/facetheory/aws-s3`                    | AWS SDK S3 adapter                   | `createAwsSdkS3HtmlStoreClient`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `@theory-cloud/facetheory/stitch-tokens`             | Shared Stitch token utilities        | `StitchTokenSet` (with optional `surface` classification), `StitchCssVarOptions` (supports `prefix` and `additionalPrefixes`), `stitchToCssVars`, `stitchCssVarsToRootBlock`                                                                                                                                                                                                                                                                                                                                                                                 |
@@ -115,7 +115,7 @@ These contracts shape every adapter and delivery mode. If you change one of thes
 | `FaceMode`         | Rendering mode                       | One of `ssr`, `ssg`, or `isr`.                                                                                                                                                                                                                           |
 | `FaceRequest`      | Normalized request input             | Supports headers, cookies, query, body, base64 marker, and optional `cspNonce`.                                                                                                                                                                          |
 | `FaceResponse`     | Runtime response                     | Includes normalized headers, cookies array, status, body, and `isBase64`.                                                                                                                                                                                |
-| `FaceRenderResult` | Render output before HTTP conversion | Supports document-shell attrs (`lang`, `htmlAttrs`, `bodyAttrs`), `head`, `headTags`, `styleTags`, `html`, cookies, headers, and hydration payload. `head.html` is legacy escaped head text; prefer structured `headTags` / `styleTags` for actual tags. |
+| `FaceRenderResult` | Render output before HTTP conversion | Supports document-shell attrs (`lang`, `htmlAttrs`, `bodyAttrs`), `head`, `headTags`, `styleTags`, `csp`, `html`, cookies, headers, and hydration payload. `head.html` is legacy escaped head text; prefer structured `headTags` / `styleTags` for actual tags. |
 | `FaceContext`      | Per-request context                  | Exposes normalized request, route params, and proxy match.                                                                                                                                                                                               |
 | `FaceAppOptions`   | App constructor options              | Accepts `faces`, optional ISR config, and optional observability hooks.                                                                                                                                                                                  |
 | `FaceIsrOptions`   | ISR runtime tuning                   | Configures HTML store, metadata store, lease timing, contention policy, cache key, tenant key, and cache-control generation.                                                                                                                             |
@@ -194,6 +194,8 @@ React:
 - `renderReactStream(..., { styleStrategy: 'all-ready' | 'shell' })`
 - Integrations compose through `createState`, `wrapTree`, `contribute`, and `finalize`
 - Keep request-local mutable data inside `createState`; static integration instances can then be reused safely across renders
+- Strict no-inline CSP (`csp.inlineScripts === false`) rejects React shell streaming. Use the default `all-ready` style strategy so FaceTheory can validate the complete document before bytes flush.
+- Strict no-inline styles (`csp.inlineStyles === false`) reject adapter-emitted inline styles, including Emotion/AntD extraction output. Use external CSS/asset delivery for routes that must run under a no-inline policy.
 
 Vue:
 
@@ -206,6 +208,7 @@ Svelte:
 - `renderSvelte()` supports legacy `Component.render()` and Svelte 5 server rendering
 - `renderSvelte()` passes the same request-local integration state through `wrapTree`, `contribute`, and `finalize`
 - Packaged Svelte libraries should import their CSS from the client entry and use `viteAssetsForEntry()` + `viteHydrationForEntry()` to keep SSR asset tags and hydration aligned
+- Strict no-inline CSP rejects raw Svelte SSR head output and inline CSS fallback output. Keep strict Svelte pages on structured FaceTheory `headTags`, external CSS from the client entry, and external hydration data.
 
 ## ISR Storage And Cache APIs
 
@@ -251,12 +254,90 @@ Use these helpers when a Vite SSR build needs deterministic asset tags and a mat
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `viteAssetsForEntry(manifest, entry, options)`          | Produces deterministic `modulepreload`, `stylesheet`, and optional asset hint tags. |
 | `viteHydrationForEntry(manifest, entry, data, options)` | Produces a `FaceHydration` payload using the manifest bootstrap module.             |
+| `externalHydrationForEntry(manifest, entry, data, options)` | Produces a same-origin external hydration contract for strict no-inline CSP routes. |
 | `viteDynamicImportPolicy()`                             | Returns the current dynamic import policy, which is `ignore`.                       |
 
 Current behavior:
 
 - `dynamicImports` from Vite manifests are intentionally ignored
 - `includeAssets: true` adds preload or prefetch hints for manifest asset files
+
+## Strict CSP Rendering
+
+FaceTheory supports two CSP-compatible rendering styles:
+
+- **Nonce-compatible CSP** keeps FaceTheory-owned inline hydration scripts and inline style tags available, but adds a
+  per-request `nonce` through `FaceRequest.cspNonce`. Use this only for per-request SSR HTML where the CSP header can
+  carry the same nonce as the document.
+- **Strict no-inline CSP** sets `FaceRenderResult.csp` to `{ inlineScripts: false, inlineStyles: false, rawHead: false }`
+  and requires all executable code, CSS, and hydration data to be external and same-origin. This is the required shape
+  for cached SSG/ISR HTML when a nonce would not be stable across requests.
+
+Core strict-CSP exports:
+
+- `FaceCspPolicy` is the route-level render policy surface. `inlineScripts:false` rejects inline script bodies,
+  inline hydration JSON, inline event-handler attributes, and cross-origin bootstrap/data URLs. `inlineStyles:false`
+  rejects inline style tags and `style` attributes. `rawHead:false` rejects caller-owned raw head HTML.
+- `buildStrictCspHeader({ cspNonce? })` returns FaceTheory's same-origin CSP header baseline. Header attachment is
+  explicit through `FaceRenderResult.headers`; FaceTheory validates output but does not silently add response headers.
+- `validateStrictCspDocument(html, { policy })` is the body-level validator used by the runtime before returning strict
+  buffered HTML. It catches raw body output that structured head validation cannot see.
+- `externalHydrationForEntry(manifest, entry, data, { dataUrl, ...options })` pairs Vite asset tags with
+  `FaceExternalHydration`. The rendered document emits a `<link rel="facetheory-hydration" ...>` marker instead of
+  `__FACETHEORY_DATA__` inline JSON, and the client bootstrap fetches `dataUrl` before hydration.
+
+Strict route sketch:
+
+```ts
+import {
+  buildStrictCspHeader,
+  externalHydrationForEntry,
+  viteAssetsForEntry,
+} from "@theory-cloud/facetheory";
+
+const strictCsp = {
+  inlineScripts: false,
+  inlineStyles: false,
+  rawHead: false,
+} as const;
+
+renderOptions: async (_ctx, data) => {
+  const { headTags } = viteAssetsForEntry(manifest, "src/entry-client.ts", {
+    includeAssets: true,
+  });
+
+  return {
+    csp: strictCsp,
+    headers: {
+      "content-security-policy": buildStrictCspHeader(),
+    },
+    headTags,
+    hydration: externalHydrationForEntry(
+      manifest,
+      "src/entry-client.ts",
+      data,
+      { dataUrl: "/_facetheory/data/home.json" },
+    ),
+  };
+};
+```
+
+Adapter notes:
+
+- React strict no-inline routes cannot use shell streaming because bytes would flush before whole-document validation.
+  Use `styleStrategy: "all-ready"` and avoid inline CSS-in-JS extraction on routes with `inlineStyles:false`.
+- Vue strict no-inline routes must use external hydration data and external stylesheet assets.
+- Svelte strict no-inline routes must avoid `<svelte:head>` raw SSR output and Svelte component `<style>` fallback
+  output. Import CSS from the Vite client entry and emit head through FaceTheory's structured `headTags`.
+
+Client navigation:
+
+- `startFaceNavigation()` parses the next FaceTheory document, loads external hydration JSON before DOM mutation, then
+  invokes `hydrateFaceNavigation(context)` when the bootstrap module exports it.
+- Navigation rejects cross-origin documents, cross-origin bootstrap modules, and cross-origin external hydration URLs
+  before mutating the current document.
+- A route that still uses legacy inline hydration remains compatible in non-strict mode, but a strict no-inline route
+  must migrate to `FaceExternalHydration`.
 
 ## OAC Mutating Form Helpers
 

--- a/docs/cdk/aws-deployment.md
+++ b/docs/cdk/aws-deployment.md
@@ -13,9 +13,9 @@ FaceTheory's supported production shape is:
 ## Origin Layout
 
 Primary components:
-- S3 bucket for hashed assets and optional SSG HTML output
+- S3 bucket for hashed assets, optional SSG HTML output, and strict-CSP SSG hydration JSON sidecars
 - Lambda Function URL origin for SSR and ISR
-- Optional S3 bucket or prefix for ISR HTML objects
+- Optional S3 bucket or prefix for ISR HTML objects and pointer-derived strict-CSP hydration sidecars
 - DynamoDB table for ISR metadata and lease state
 
 Recommended static paths:
@@ -44,6 +44,9 @@ Reference-stack stance:
 - do not model viewer-supplied tenant-header passthrough as the default copy-paste shape
 - keep same-origin mutating form action paths on Lambda/AppTheory behaviors, usually through `ssrPathPatterns`
 - use FaceTheory's marked URL-encoded OAC form helper for browser forms that submit through Lambda Function URL OAC
+- keep `/_facetheory/data/*` on S3 for SSG hydration sidecars, but keep ISR hydration query URLs on Lambda/FaceTheory
+- attach strict CSP headers from the Face response; baseline CloudFront response headers do not substitute for a
+  route-owned `content-security-policy`
 
 ### Mutating Forms Behind Lambda Function URL OAC
 
@@ -63,6 +66,37 @@ The helper hashes the exact `application/x-www-form-urlencoded` bytes it sends a
 signing. It fails closed for marked multipart, text/plain, unknown encodings, cross-origin actions, unsafe redirect
 handling, and default document replacement of CSP-protected HTML responses. Do not turn `ssrUrlAuthType` to `NONE` as a
 durable solution; use it only as an explicitly authorized temporary rollback with an owner and removal date.
+
+### Strict CSP Hydration Sidecars
+
+Strict no-inline CSP uses same-origin external hydration data instead of inline `__FACETHEORY_DATA__`.
+
+SSG:
+
+- `/_facetheory/data/*` should be listed in `directS3PathPatterns` so CloudFront serves generated hydration JSON from S3.
+- Upload and invalidate each generated HTML file and its hydration JSON sidecar together.
+- Use JSON content type and cache headers coordinated with the referencing HTML; hashed client assets can still be
+  immutable.
+
+ISR:
+
+- Hydration sidecars are stored in the same `S3HtmlStore` namespace as generated HTML, with `.hydration.json` derived
+  from the HTML pointer.
+- The browser URL is the route URL plus `__facetheory_isr_hydration=<opaque-token>`. Route that request to
+  Lambda/FaceTheory so the runtime can validate and serve the sidecar.
+- Do not add a public S3 behavior for arbitrary ISR object keys or expose the raw pointer as a stable client contract.
+
+SSR:
+
+- If a strict SSR Face uses a dynamic external hydration endpoint, route that same-origin JSON endpoint to
+  Lambda/AppTheory and make sure it returns the exact data used by the server render.
+
+OAC navigation policy:
+
+- Use `startAwsOacFormTransport()`'s default full-page navigation for strict-CSP form outcomes unless the host has
+  explicitly chosen the SPA navigation contract.
+- Use `navigationPolicy: "spa"` only when the response is a FaceTheory document and external hydration can be loaded
+  before DOM mutation.
 
 ## CloudFront Behavior Options
 
@@ -106,12 +140,14 @@ SSR:
 
 SSG:
 - HTML can use bounded shared caching
+- strict hydration JSON under `/_facetheory/data/*` should use cache headers coordinated with the HTML that references it
 - hashed assets should be long-lived and immutable
 
 ISR:
 - use FaceTheory's blocking ISR cache helper semantics
 - observe `x-facetheory-isr` on responses
 - do not treat ISR HTML as immutable static content
+- treat pointer-derived hydration sidecars as part of the ISR HTML generation result, not as independent static assets
 
 ## ISR Storage Notes
 

--- a/docs/cdk/operations.md
+++ b/docs/cdk/operations.md
@@ -30,9 +30,26 @@ React streaming:
 - Prefer security headers at CloudFront rather than inside every route
 - Use per-request CSP nonces only for per-request SSR HTML
 - Do not bake per-request nonces into cached SSG or ISR HTML
+- For strict no-inline CSP routes, attach the route CSP header from the Face response and verify no inline
+  scripts/styles/raw head output reaches the browser
 
 Useful helper:
 - `createCspNonce()`
+- `buildStrictCspHeader()`
+
+## Strict CSP Deployment Checks
+
+Use these checks when a deployment includes routes with
+`csp: { inlineScripts:false, inlineStyles:false, rawHead:false }`:
+
+- SSG: `/_facetheory/data/*` reaches the S3 origin and returns JSON sidecars with cache headers coordinated with the
+  referencing HTML.
+- ISR: hydration sidecar URLs with `__facetheory_isr_hydration=...` reach Lambda/FaceTheory, not direct S3 object keys.
+- SSR: dynamic external hydration endpoints are same-origin and routed to the runtime that produced the server render.
+- CSP header: the HTML response includes the intended `content-security-policy`; baseline CloudFront headers alone are
+  not enough.
+- OAC forms: choose full-page navigation for CSP-protected HTML outcomes unless the host deliberately uses the SPA
+  navigation policy and validates external hydration before DOM mutation.
 
 ## Deploy And Roll Back
 
@@ -47,6 +64,16 @@ Rollback:
 1. Revert the Lambda artifact or alias
 2. Revert assets by prefix or prior artifact
 3. Invalidate non-hashed keys if they may still be cached
+
+## Release Validation Notes
+
+Strict-CSP release validation is evidence-driven:
+
+- validate release candidates from immutable GitHub Release tarballs, not workspace links
+- ask Simulacrum or another authorized consuming app to exercise the strict-CSP routes it owns before stable promotion
+- capture exact version, route URLs, headers, sidecar URLs, and navigation behavior as evidence
+- do not claim Simulacrum, AWS, or customer deployment success from local tests alone
+- stable promotion remains the normal Release Please path; do not hand-create release tags or assets
 
 ## ISR Incident Checks
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -319,6 +319,89 @@ Why this is incorrect:
 - It bypasses the package asset graph and makes stylesheet delivery drift from the hydrated client bundle.
 - It creates a second, undocumented integration path that tests will not cover.
 
+## Pattern: Render strict no-inline CSP pages with external hydration
+
+Problem:
+You need a FaceTheory route to pass a CSP that forbids inline scripts, inline styles, and raw head HTML while still
+hydrating the same data that was used for the server render.
+
+**CORRECT**
+
+```ts
+import {
+  buildStrictCspHeader,
+  externalHydrationForEntry,
+  viteAssetsForEntry,
+} from "@theory-cloud/facetheory";
+
+const strictCsp = {
+  inlineScripts: false,
+  inlineStyles: false,
+  rawHead: false,
+} as const;
+
+renderOptions: async (_ctx, data) => {
+  const { headTags } = viteAssetsForEntry(manifest, "src/entry-client.ts", {
+    includeAssets: true,
+  });
+
+  return {
+    csp: strictCsp,
+    headers: {
+      "content-security-policy": buildStrictCspHeader(),
+    },
+    headTags,
+    hydration: externalHydrationForEntry(
+      manifest,
+      "src/entry-client.ts",
+      data,
+      { dataUrl: "/_facetheory/data/example.json" },
+    ),
+  };
+};
+```
+
+Why this is correct:
+
+- The strict policy tells FaceTheory to validate both structured head output and the rendered body before returning HTML.
+- Hydration data is fetched from a same-origin JSON sidecar instead of being embedded in `__FACETHEORY_DATA__`.
+- Vite owns the client module and CSS/asset graph, so scripts and styles remain external and deterministic.
+- The CSP header is attached explicitly by the Face; FaceTheory validates output, but it does not silently choose a
+  response policy for the host.
+
+Framework notes:
+
+- React routes that set `inlineScripts:false` must not use shell streaming. Use `styleStrategy: "all-ready"` so
+  FaceTheory can validate the whole document before bytes flush.
+- React + Emotion/AntD inline style extraction is incompatible with `inlineStyles:false`; use external CSS for strict
+  no-inline routes.
+- Svelte strict routes should avoid `<svelte:head>` raw output and component `<style>` fallback output. Import CSS from
+  the client entry and emit titles/meta/links through FaceTheory `headTags`.
+- `startFaceNavigation()` loads the external hydration sidecar before applying a same-origin navigation snapshot and
+  calling `hydrateFaceNavigation(context)`.
+
+Reference example:
+
+- `ts/examples/vite-strict-csp-svelte/`
+
+**INCORRECT**
+
+```ts
+return {
+  csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+  headTags: [{ type: "raw", html: "<script>window.boot()</script>" }],
+  hydration: viteHydrationForEntry(manifest, "src/entry-client.ts", data),
+  html: '<main style="display:none">...</main>',
+};
+```
+
+Why this is incorrect:
+
+- `viteHydrationForEntry()` emits legacy inline hydration JSON; strict no-inline routes need `FaceExternalHydration`.
+- Raw head HTML, inline event handlers, inline style attributes, inline style tags, and inline scripts all fail closed
+  under the strict policy.
+- Warning-only documentation is not enough: strict routes should let FaceTheory fail before returning invalid HTML.
+
 ## Pattern: Mark same-origin mutating forms for OAC transport
 
 Problem:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,6 +96,63 @@ runtime.get("/{proxy+}", createAppTheoryFaceHandler({ app }));
 export const handler = createLambdaFunctionURLStreamingHandler(runtime);
 ```
 
+## Add Strict No-Inline CSP Hydration
+
+Use this path when a route must run without inline scripts, inline styles, or raw head HTML. The server render still owns
+the first paint, but hydration data moves to a same-origin JSON sidecar instead of the legacy inline
+`__FACETHEORY_DATA__` script.
+
+```ts
+import {
+  buildStrictCspHeader,
+  externalHydrationForEntry,
+  viteAssetsForEntry,
+} from "@theory-cloud/facetheory";
+
+const strictCsp = {
+  inlineScripts: false,
+  inlineStyles: false,
+  rawHead: false,
+} as const;
+
+renderOptions: async (_ctx, data) => {
+  const { headTags } = viteAssetsForEntry(manifest, "src/entry-client.ts", {
+    includeAssets: true,
+  });
+
+  return {
+    csp: strictCsp,
+    headers: {
+      "content-security-policy": buildStrictCspHeader(),
+    },
+    headTags,
+    hydration: externalHydrationForEntry(
+      manifest,
+      "src/entry-client.ts",
+      data,
+      { dataUrl: "/_facetheory/data/home.json" },
+    ),
+  };
+};
+```
+
+Client bootstrap modules should fetch the `<link rel="facetheory-hydration">` URL before hydrating and should reject
+cross-origin data URLs or redirects. The repository example at `ts/examples/vite-strict-csp-svelte/` demonstrates the
+full Svelte/Vite shape: external CSS/assets, same-origin module bootstrap, external hydration JSON, no `<svelte:head>`
+raw output, and SPA navigation that loads external data before `hydrateFaceNavigation(context)`.
+
+Validation:
+
+```bash
+cd ts
+npm run example:vite:svelte:strict-csp:build
+node --import tsx test/unit/vite-strict-csp-svelte-example.test.ts
+```
+
+If a route still needs FaceTheory-owned inline scripts or styles, use the nonce-compatible CSP path for per-request SSR
+HTML only: pass `FaceRequest.cspNonce`, include the matching nonce in your CSP header, and do not cache that HTML as
+SSG/ISR unless the header and cached nonce stay identical for every request.
+
 ## Add An OAC-Safe Mutating SSR Form
 
 When a FaceTheory app is deployed through `AppTheorySsrSite` with Lambda Function URL OAC and `AWS_IAM`, native browser

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -178,6 +178,57 @@ Rollback:
 Do not make `ssrUrlAuthType: NONE` a durable rollback. If an operator explicitly authorizes it to recover a broken
 deployment, record an owner, expiration date, and restoration plan back to `AWS_IAM` + OAC.
 
+## Migration 7: Move Legacy Inline Hydration To Strict CSP External Hydration
+
+Use this path when a route currently relies on inline `__FACETHEORY_DATA__`, inline style output, or raw head HTML and
+now needs to satisfy a strict no-inline CSP.
+
+1. Classify the route's policy:
+   - **Nonce-compatible SSR** can keep FaceTheory-owned inline hydration/styles only when each request receives a
+     unique `FaceRequest.cspNonce` and the response CSP header carries the matching nonce.
+   - **Strict no-inline** must set `csp: { inlineScripts: false, inlineStyles: false, rawHead: false }` and move scripts,
+     CSS, and hydration data to same-origin external resources.
+2. Replace `viteHydrationForEntry(manifest, entry, data)` with
+   `externalHydrationForEntry(manifest, entry, data, { dataUrl })`.
+3. Serve the `dataUrl` JSON sidecar from the same origin as the page:
+   - SSG sidecars should be uploaded under the static `/_facetheory/data/*` output and routed to S3.
+   - ISR sidecars should be stored with the HTML pointer-derived sidecar object so stale HTML and stale data remain
+     paired.
+   - SSR sidecars can be served by the same Lambda route family when the data is request-time and not static.
+4. Move CSS into the Vite client entry and emit assets with `viteAssetsForEntry(...)` instead of inline `<style>` tags.
+5. Replace raw head HTML and framework-specific head shortcuts with FaceTheory structured `headTags`.
+6. For Svelte strict pages, avoid `<svelte:head>` raw SSR output and component `<style>` fallback output; use external
+   CSS imported by the client entry.
+7. For React streaming strict pages, use `styleStrategy: "all-ready"` and avoid Emotion/AntD inline style extraction on
+   routes with `inlineStyles:false`.
+8. If the route uses SPA-style navigation, export `hydrateFaceNavigation(context)` and confirm
+   `startFaceNavigation()` loads external hydration data before it mutates the current document.
+
+Validation:
+
+```bash
+cd ts
+npm run example:vite:svelte:strict-csp:build
+node --import tsx test/unit/strict-csp-harness.test.ts
+node --import tsx test/unit/vite-strict-csp-svelte-example.test.ts
+```
+
+Deployed verification:
+
+- request the HTML document and confirm the CSP header is attached explicitly
+- confirm the HTML contains `<link rel="facetheory-hydration" ...>` rather than `__FACETHEORY_DATA__`
+- fetch the referenced hydration sidecar through the same CloudFront origin and confirm it is same-origin JSON
+- confirm external module, CSS, and asset URLs are routed through the documented S3/Lambda behavior split
+- run a browser hydration smoke and check for hydration warnings or strict-CSP console errors
+
+Rollback:
+
+- keep the previous FaceTheory release tarball available until strict-CSP output is verified in the consuming app
+- if a route cannot yet remove inline styles or inline hydration, leave it on the nonce-compatible SSR path and do not
+  claim it is strict no-inline
+- do not weaken the deployment CSP or publish a strict-CSP release claim without matching runtime, RC, and deployment
+  evidence
+
 ## Rollback Notes
 
 - Keep the prior handler or deployable artifact available until the new path is verified.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -90,6 +90,36 @@ workspace link:
 For the original lab driver, theory-mcp-server should validate `POST /agents/new` through CloudFront OAC before stable
 promotion. A successful RC validation means the app-local workaround can be removed while keeping OAC enabled.
 
+### Strict CSP Hydration And Navigation
+
+```bash
+cd ts
+npm run example:vite:svelte:strict-csp:build
+node --import tsx test/unit/strict-csp-harness.test.ts
+node --import tsx test/unit/vite-strict-csp-svelte-example.test.ts
+```
+
+Use this when changing:
+
+- `FaceCspPolicy`, `buildStrictCspHeader()`, or `validateStrictCspDocument()`
+- `externalHydrationForEntry()` or sidecar URL/data handling
+- adapter strict-CSP enforcement for React, Vue, or Svelte
+- `startFaceNavigation()` external hydration loading or same-origin validation
+- docs that describe strict no-inline CSP, external hydration, or Svelte/Vite strict examples
+
+Local expected result:
+
+- rendered documents contain no `__FACETHEORY_DATA__` inline JSON script
+- every `<script>` has `src` and no inline body text
+- no `<style>` tags, `style` attributes, or `on*` event-handler attributes appear in validated scopes
+- strict Svelte/Vite output uses external CSS/assets and a same-origin module bootstrap
+- the browser harness loads external hydration JSON before initial hydration and before `hydrateFaceNavigation(context)`
+- same-origin navigation to the strict example's `/next` route preserves deterministic server/client hydration data
+
+For documentation reviews, explicitly check the unsafe-claim boundary: these tests prove local runtime behavior and
+example wiring, not that a release has been published, a Simulacrum RC has been validated, or an AWS/customer deployment
+has succeeded.
+
 ### React SSR And Streaming
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,6 +13,7 @@ Use this guide for recurring setup, build, and runtime failures that already hav
 | ISR route returns a deterministic 500 when tenant headers are present | Known tenant boundary headers reached ISR without an explicit tenant/cache partition          | `docs/migration-guide.md` and `ts/src/isr.ts` tenant guard behavior |
 | ISR object keys look duplicated                                       | `S3HtmlStore.keyPrefix` and `htmlPointerPrefix` repeat the same prefix                        | `docs/core-patterns.md` and `docs/cdk/aws-deployment.md`            |
 | React streaming misses late styles                                    | `styleStrategy: shell` was used where `all-ready` was needed                                  | `docs/core-patterns.md`                                             |
+| Strict-CSP route fails before returning HTML                          | The route emitted inline hydration, inline styles/scripts, raw head, or unsafe body attrs     | `FaceRenderResult.csp` and `docs/core-patterns.md`                  |
 | Form POST behind AppTheorySsrSite OAC returns 403 before Lambda       | Native browser form cannot provide `x-amz-content-sha256` for the Lambda URL OAC signing path | `startAwsOacFormTransport()` and `docs/core-patterns.md`            |
 
 ## Issue: Node.js Version Mismatch
@@ -221,6 +222,47 @@ Release handoff:
   promotion
 - if emergency rollback is needed, pin the previous FaceTheory tarball or remove the opt-in marker/bootstrap; do not
   keep `ssrUrlAuthType: NONE` as a durable solution
+
+## Issue: Strict-CSP Route Fails Before Returning HTML
+
+Symptoms:
+
+- a route with `csp: { inlineScripts: false, inlineStyles: false, rawHead: false }` returns a deterministic server error
+- the error mentions strict CSP rejecting inline script tags, inline style tags, raw head output, event handler
+  attributes, style attributes, or non-external hydration
+- a React streaming route errors when `styleStrategy: "shell"` is used
+- a Svelte strict route errors after adding `<svelte:head>` or component `<style>` output
+
+Cause:
+
+- Strict no-inline CSP is fail-closed. FaceTheory validates structured head output, adapter contributions, and the final
+  rendered body before returning a strict document.
+- Legacy `viteHydrationForEntry()` emits inline `__FACETHEORY_DATA__` and is incompatible with `inlineScripts:false`.
+- React shell streaming can flush bytes before whole-document validation and is therefore rejected under strict
+  `inlineScripts:false`.
+- Adapter style extraction that emits `<style>` tags, including Emotion/AntD inline extraction, is incompatible with
+  `inlineStyles:false`.
+
+Solution:
+
+- Move hydration data to `externalHydrationForEntry(...)` and serve the JSON from a same-origin URL.
+- Attach an explicit CSP header such as `buildStrictCspHeader()` from the Face response.
+- Move CSS into the Vite client entry so `viteAssetsForEntry()` emits external stylesheet links.
+- Replace raw head HTML and `<svelte:head>` strict output with structured FaceTheory `headTags`.
+- For React streaming strict routes, use `styleStrategy: "all-ready"` or buffer the route so validation completes before
+  bytes flush.
+
+Verification:
+
+```bash
+cd ts
+npm run example:vite:svelte:strict-csp:build
+node --import tsx test/unit/strict-csp-harness.test.ts
+node --import tsx test/unit/vite-strict-csp-svelte-example.test.ts
+```
+
+If this is an AWS or release handoff, treat the local commands as runtime evidence only. They do not prove a release was
+published, a Simulacrum RC ran, or a CloudFront/S3/Lambda deployment is serving the route.
 
 ## Issue: Streaming HTML Ships Without Expected Late Styles
 


### PR DESCRIPTION
## Milestone
strict-csp-docs-release — final strict-CSP documentation and release/deployment guidance.

Stacked on PR #188 (`facetheory/strict-csp-example-validation`) per Factory assignment.

## Linear
- THE-1169 — [15] Document strict-CSP APIs and migration guidance
- THE-1170 — [16] Document AWS deployment and release validation for strict CSP

## Render modes and adapters affected
Docs only. The docs cover SSR, SSG, ISR, SPA navigation helpers, and React/Vue/Svelte strict-CSP adapter constraints.

## Determinism impact
No runtime change. Documentation now makes the strict-CSP determinism contract explicit: nonce-compatible SSR versus strict no-inline CSP, external hydration data, same-origin navigation loading, Svelte raw-head/style limits, React streaming limits, and body validator responsibility.

## Backward compatibility
Additive docs. No release/version, Release Please, runtime, Simulacrum, AWS/deploy, live receipt, or sibling repo changes.

## Tasks
- [x] THE-1169 — Document strict-CSP APIs and migration guidance
- [x] THE-1170 — Document AWS deployment and release validation for strict CSP

## Validation
- [x] `git diff --check origin/facetheory/strict-csp-example-validation...HEAD`
- [x] `git diff --check`
- [x] `scripts/verify-version-alignment.sh` — PASS (`3.1.2`)
- [x] `cd ts && npm ci`
- [x] `cd ts && npm run typecheck`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm test` — PASS (315 pass / 1 skip)
- [x] `cd ts && npm run build`
- [x] `cd ts && npm run check` — skipped; script is not defined in `ts/package.json`
- [x] Docs scoped/unsafe-claim review — PASS for THE-1169/THE-1170 acceptance points and explicit unsafe-claim boundaries.
- [x] `scripts/stage_theorycloud_facetheory_subtree.sh --output <tmpdir>` — PASS
- [x] `scripts/verify_theorycloud_facetheory_subtree.sh <tmpdir>` — PASS

## Notes
- API/migration docs cover nonce-compatible CSP vs strict no-inline CSP, external hydration usage, SPA navigation behavior, Svelte strict head/style requirements, React streaming limits, body validator responsibility, and migration from legacy inline hydration.
- AWS/operations docs cover S3/CloudFront routing for SSG sidecars, ISR pointer-derived sidecar expectations, explicit CSP header attachment, OAC navigation policy choice, RC validation by Simulacrum from immutable release tarballs, and stable Release Please promotion criteria.
- Claims are evidence-scoped: docs do not assert publication proof, Simulacrum execution, AWS deployment proof, live receipts, or customer deployment success.

## Cross-repo coordination
None in this PR. Simulacrum validation is documented as a future RC validation handoff, not executed here.