### PR TITLE
fix(oac): fail closed on malformed response urls

### DIFF
--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -450,7 +450,7 @@ Why this is incorrect:
 Encoding note:
 
 - `startAwsOacFormTransport()` is intentionally URL-encoded. Submitter `formenctype` overrides form `enctype`, matching browser form resolution. Marked forms that resolve to `multipart/form-data`, `text/plain`, or another unsupported encoding are not silently transformed and do not fall back to native POST; they fail closed through `onError` until a separate, explicitly scoped transport exists.
-- Marked forms do not follow HTTP redirects in the fetch transport. Return a direct response for the mutation result, or handle the response with `onResponse` / `onNavigate` and explicitly choose a safe same-origin browser navigation after the mutating request completes.
+- Marked forms do not follow HTTP redirects in the fetch transport. Return a direct response for the mutation result, or handle the response with `onResponse` / `onNavigate` and explicitly choose a safe same-origin browser navigation after the mutating request completes. Redirected or replacement response URLs that are malformed or resolve outside the configured same-origin boundary fail closed before FaceTheory mutates the document or assigns `window.location`.
 
 ## Pattern: Use `startFaceNavigation()` with a stable view container
 

--- a/ts/src/oac-form.ts
+++ b/ts/src/oac-form.ts
@@ -577,7 +577,14 @@ async function customNavigationHandled(
 }
 
 function resolveResponseUrl(response: Response, fallback: URL): URL {
-  return new URL(response.url || fallback.toString(), fallback);
+  try {
+    return new URL(response.url || fallback.toString(), fallback);
+  } catch (error) {
+    throw new Error(
+      `FaceTheory OAC form transport rejected malformed response URL: ${response.url || '<empty>'}`,
+      { cause: error },
+    );
+  }
 }
 
 function isHtmlResponse(response: Response): boolean {

--- a/ts/test/unit/oac-form.test.ts
+++ b/ts/test/unit/oac-form.test.ts
@@ -927,6 +927,54 @@ test('oac form transport: rejects cross-origin redirect targets', async () => {
   }
 });
 
+test('oac form transport: rejects malformed redirect targets', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <form action="/save" method="post" data-facetheory-oac-form>
+        <input name="title" value="Draft">
+      </form>`,
+    { url: 'https://example.test/edit' },
+  );
+
+  try {
+    const form = dom.window.document.querySelector('form');
+    assert.ok(form instanceof dom.window.HTMLFormElement);
+
+    const assigned: string[] = [];
+    const errors: unknown[] = [];
+    const errored = new Promise<void>((resolve) => {
+      startAwsOacFormTransport({
+        document: dom.window.document,
+        fetcher: async () =>
+          responseWithUrl(
+            new Response(null, { status: 200 }),
+            'https://[malformed',
+            true,
+          ),
+        onError: (error) => {
+          errors.push(error);
+          resolve();
+        },
+        window: fakeNavigationWindow(dom, assigned),
+      });
+    });
+
+    const event = new dom.window.SubmitEvent('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+    form.dispatchEvent(event);
+    await errored;
+
+    assert.equal(event.defaultPrevented, true);
+    assert.deepEqual(assigned, []);
+    assert.equal(errors.length, 1);
+    assert.match(String(errors[0]), /rejected malformed response URL/);
+  } finally {
+    dom.window.close();
+  }
+});
+
 test('oac form transport: replaces the document for same-origin HTML responses', async () => {
   const dom = new JSDOM(
     `<!doctype html>


### PR DESCRIPTION
## Milestone
facetheory-oac-verification — verify/remediate OAC CSP and redirect findings THE-1188/THE-1189.

## Target
- Base: `audit/facetheory-remediation-20260517`
- Head: `facetheory/audit-oac-verification-20260517`
- Target base commit at branch creation: `8a3556b2e0aa9f2c02dbe973922e3fd2671ad580`

## Render modes and adapters affected
OAC browser form transport only. No SSR/SSG/ISR/SPA mode contract changes and no React/Vue/Svelte adapter changes.

## Determinism/security impact
Preserves deterministic rendering. Tightens the OAC client security boundary by failing closed when a response URL is malformed before any document mutation or `window.location` assignment.

## Issue disposition
| Issue | Disposition |
| --- | --- |
| THE-1188 | Verified fixed-existing behavior and recorded evidence: `ts/src/oac-form.ts` already refuses default `document.write` replacement when an HTML response carries `Content-Security-Policy`, and `ts/test/unit/oac-form.test.ts` includes `oac form transport: refuses default document replacement when response CSP is present`, asserting no document mutation/execution and no history replacement. No CSP code change was needed. |
| THE-1189 | Remediated/verified: mutating fetch already forces `redirect: "error"`, same-origin redirected responses navigate through the browser, and cross-origin response URLs fail closed. This PR adds explicit malformed response URL rejection before mutation/navigation plus regression coverage and docs clarifying same-origin/malformed redirect boundaries. |

## Files changed
- `ts/src/oac-form.ts` — wraps response URL resolution with an explicit OAC transport error for malformed response URLs before navigation policy handling.
- `ts/test/unit/oac-form.test.ts` — adds malformed redirect target regression coverage alongside existing same-origin, cross-origin, and CSP HTML replacement tests.
- `docs/core-patterns.md` — clarifies that malformed or cross-origin redirected/replacement response URLs fail closed before document mutation or browser navigation.

## Validation
- [x] `git diff --check`
- [x] `git merge-base --is-ancestor origin/main HEAD`
- [x] `git merge-base --is-ancestor origin/staging HEAD`
- [x] `git merge-base --is-ancestor origin/audit/facetheory-remediation-20260517 HEAD`
- [x] `scripts/verify-version-alignment.sh` — PASS (3.2.0)
- [x] `cd ts && npm ci` — PASS, 450 packages, 0 vulnerabilities
- [x] `cd ts && npm test` — PASS (316 pass / 1 skip)
- [x] `make rubric` — PASS (includes typecheck, lint, tests, version/pack/audit/release-script checks)

## Risks / blockers
- No release workflow/provenance work, sibling repo edits, AWS/cloud/account mutation, secrets changes, deploys, or live evidence claims were performed.
- THE-1188 is closed by existing implementation/test evidence plus PR documentation rather than new CSP code.
