### PR TITLE
fix(release): restore draft metadata handoff

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -42,6 +42,78 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
+      - name: Checkout (prerelease state)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'premain' || github.sha }}
+
+      - name: Recover missing current prerelease Release Please state
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+
+          version="$(
+            python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          data = json.loads(Path(".release-please-manifest.premain.json").read_text(encoding="utf-8"))
+          version = str(data.get(".", "")).strip()
+          if not version:
+              raise SystemExit("missing prerelease release-please manifest version")
+          print(version)
+          PY
+          )"
+          tag="v${version}"
+
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            echo "release-recovery: ${tag} release already exists"
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "release-recovery: ${tag} tag already exists"
+            exit 0
+          fi
+
+          expected_title="chore(premain): release ${version}"
+          pending_number="$(
+            EXPECTED_TITLE="${expected_title}" gh pr list \
+              --state merged \
+              --base premain \
+              --label "autorelease: pending" \
+              --limit 50 \
+              --json number,title \
+              --jq 'map(select(.title == env.EXPECTED_TITLE)) | .[0].number // ""'
+          )"
+          if [[ -n "${pending_number}" ]]; then
+            echo "release-recovery: ${tag} already pending on PR #${pending_number}"
+            exit 0
+          fi
+
+          tagged_number="$(
+            EXPECTED_TITLE="${expected_title}" gh pr list \
+              --state merged \
+              --base premain \
+              --label "autorelease: tagged" \
+              --limit 50 \
+              --json number,title \
+              --jq 'map(select(.title == env.EXPECTED_TITLE)) | .[0].number // ""'
+          )"
+
+          if [[ -z "${tagged_number}" ]]; then
+            echo "release-recovery: FAIL (${tag} is missing and no merged ${expected_title} PR is pending/tagged)"
+            exit 1
+          fi
+
+          echo "release-recovery: resetting PR #${tagged_number} from tagged to pending for ${tag}"
+          gh pr edit "${tagged_number}" \
+            --remove-label "autorelease: tagged" \
+            --add-label "autorelease: pending"
+
       - name: Release Please (Prerelease)
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -59,6 +59,75 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Resolve draft release metadata
+        id: draft
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+
+          repo="${GITHUB_REPOSITORY:?}"
+          if [[ -z "${TAG_NAME}" ]]; then
+            echo "release-draft-metadata: FAIL (missing tag name)"
+            exit 1
+          fi
+
+          release_json=""
+          for attempt in $(seq 1 12); do
+            for page in $(seq 1 10); do
+              page_file="$(mktemp)"
+              gh api "repos/${repo}/releases?per_page=100&page=${page}" > "${page_file}"
+              match="$(
+                TAG_NAME="${TAG_NAME}" python3 - "${page_file}" <<'PY'
+          import json
+          import os
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as handle:
+              data = json.load(handle)
+          for release in data:
+              if release.get("tag_name") != os.environ["TAG_NAME"]:
+                  continue
+              if release.get("draft") is not True:
+                  continue
+              wanted = ("id", "tag_name", "target_commitish", "draft", "prerelease", "html_url")
+              print(json.dumps({key: release.get(key) for key in wanted}, separators=(",", ":")))
+              break
+          PY
+              )"
+              count="$(python3 - "${page_file}" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as handle:
+              data = json.load(handle)
+          print(len(data) if isinstance(data, list) else 0)
+          PY
+              )"
+              rm -f "${page_file}"
+              if [[ -n "${match}" ]]; then
+                release_json="${match}"
+                break
+              fi
+              [[ "${count}" =~ ^[0-9]+$ ]] || count=0
+              [[ "${count}" -lt 100 ]] && break
+            done
+            [[ -n "${release_json}" ]] && break
+            sleep 5
+          done
+
+          if [[ -z "${release_json}" ]]; then
+            echo "release-draft-metadata: FAIL (draft release ${TAG_NAME} not found)"
+            exit 1
+          fi
+
+          {
+            echo "release_json<<__FACETHEORY_RELEASE_JSON__"
+            printf '%s\n' "${release_json}"
+            echo "__FACETHEORY_RELEASE_JSON__"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Checkout (for release assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -74,7 +143,7 @@ jobs:
 
       - name: Verify draft release targets this commit
         env:
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_JSON: ${{ steps.draft.outputs.release_json }}
         run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,73 @@ jobs:
             "${trusted_dir}/"
           chmod +x "${trusted_dir}"/*.sh
 
+      - name: Resolve release metadata
+        id: metadata
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          repo="${GITHUB_REPOSITORY:?}"
+          if [[ -z "${TAG_NAME}" ]]; then
+            echo "release-metadata: SKIP (missing tag name)"
+            exit 0
+          fi
+
+          release_json=""
+          for page in $(seq 1 10); do
+            page_file="$(mktemp)"
+            gh api "repos/${repo}/releases?per_page=100&page=${page}" > "${page_file}"
+            match="$(
+              TAG_NAME="${TAG_NAME}" python3 - "${page_file}" <<'PY'
+          import json
+          import os
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as handle:
+              data = json.load(handle)
+          for release in data:
+              if release.get("tag_name") != os.environ["TAG_NAME"]:
+                  continue
+              wanted = ("id", "tag_name", "target_commitish", "draft", "prerelease", "html_url")
+              print(json.dumps({key: release.get(key) for key in wanted}, separators=(",", ":")))
+              break
+          PY
+            )"
+            count="$(python3 - "${page_file}" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as handle:
+              data = json.load(handle)
+          print(len(data) if isinstance(data, list) else 0)
+          PY
+            )"
+            rm -f "${page_file}"
+            if [[ -n "${match}" ]]; then
+              release_json="${match}"
+              break
+            fi
+            [[ "${count}" =~ ^[0-9]+$ ]] || count=0
+            [[ "${count}" -lt 100 ]] && break
+          done
+
+          if [[ -z "${release_json}" ]]; then
+            echo "release-metadata: SKIP (${TAG_NAME} not found)"
+            exit 0
+          fi
+
+          {
+            echo "release_json<<__FACETHEORY_RELEASE_JSON__"
+            printf '%s\n' "${release_json}"
+            echo "__FACETHEORY_RELEASE_JSON__"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Resolve release source ref
         id: source
         env:
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
         run: |
           "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
@@ -117,7 +180,7 @@ jobs:
               echo "release-assets: FAIL (${TAG_NAME} source resolved to ${RELEASE_SOURCE_COMMIT}, checked out ${actual_commit})"
               exit 1
             fi
-            GH_TOKEN="${{ github.token }}" \
+            RELEASE_JSON="${{ steps.metadata.outputs.release_json }}" \
               REPO_ROOT="${GITHUB_WORKSPACE}" \
               "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${TAG_NAME}" HEAD
           fi
@@ -418,6 +481,75 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Resolve draft release metadata
+        id: draft
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+
+          repo="${GITHUB_REPOSITORY:?}"
+          if [[ -z "${TAG_NAME}" ]]; then
+            echo "release-draft-metadata: FAIL (missing tag name)"
+            exit 1
+          fi
+
+          release_json=""
+          for attempt in $(seq 1 12); do
+            for page in $(seq 1 10); do
+              page_file="$(mktemp)"
+              gh api "repos/${repo}/releases?per_page=100&page=${page}" > "${page_file}"
+              match="$(
+                TAG_NAME="${TAG_NAME}" python3 - "${page_file}" <<'PY'
+          import json
+          import os
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as handle:
+              data = json.load(handle)
+          for release in data:
+              if release.get("tag_name") != os.environ["TAG_NAME"]:
+                  continue
+              if release.get("draft") is not True:
+                  continue
+              wanted = ("id", "tag_name", "target_commitish", "draft", "prerelease", "html_url")
+              print(json.dumps({key: release.get(key) for key in wanted}, separators=(",", ":")))
+              break
+          PY
+              )"
+              count="$(python3 - "${page_file}" <<'PY'
+          import json
+          import sys
+
+          with open(sys.argv[1], "r", encoding="utf-8") as handle:
+              data = json.load(handle)
+          print(len(data) if isinstance(data, list) else 0)
+          PY
+              )"
+              rm -f "${page_file}"
+              if [[ -n "${match}" ]]; then
+                release_json="${match}"
+                break
+              fi
+              [[ "${count}" =~ ^[0-9]+$ ]] || count=0
+              [[ "${count}" -lt 100 ]] && break
+            done
+            [[ -n "${release_json}" ]] && break
+            sleep 5
+          done
+
+          if [[ -z "${release_json}" ]]; then
+            echo "release-draft-metadata: FAIL (draft release ${TAG_NAME} not found)"
+            exit 1
+          fi
+
+          {
+            echo "release_json<<__FACETHEORY_RELEASE_JSON__"
+            printf '%s\n' "${release_json}"
+            echo "__FACETHEORY_RELEASE_JSON__"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Checkout (for release assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -435,7 +567,7 @@ jobs:
 
       - name: Verify draft release targets this commit
         env:
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_JSON: ${{ steps.draft.outputs.release_json }}
         run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch

--- a/scripts/resolve-release-source-ref.sh
+++ b/scripts/resolve-release-source-ref.sh
@@ -61,12 +61,10 @@ if [[ -z "${tag}" ]]; then
   exit 0
 fi
 
-if ! command -v "${gh_bin}" >/dev/null 2>&1; then
-  echo "release-source-ref: FAIL (${gh_bin} not found)" >&2
-  exit 1
+release_json="${RELEASE_JSON:-}"
+if [[ -z "${release_json}" ]] && command -v "${gh_bin}" >/dev/null 2>&1; then
+  release_json="$(GH_BIN="${gh_bin}" "${script_dir}/release-json-by-tag.sh" "${tag}" || true)"
 fi
-
-release_json="$(GH_BIN="${gh_bin}" "${script_dir}/release-json-by-tag.sh" "${tag}" || true)"
 
 if [[ -z "${release_json}" ]]; then
   echo "source_ref=${tag}"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -52,6 +52,38 @@ for workflow in .github/workflows/prerelease.yml .github/workflows/release.yml; 
     fail "${workflow} must publish draft releases through a minimal inline PATCH API step"
 done
 
+grep -Fq 'Resolve draft release metadata' .github/workflows/prerelease.yml ||
+  fail "prerelease.yml must resolve hidden draft release metadata before repo checkout"
+
+grep -Fq 'Resolve draft release metadata' .github/workflows/release.yml ||
+  fail "release.yml must resolve hidden draft release metadata before repo checkout"
+
+grep -Fq 'RELEASE_JSON: ${{ steps.draft.outputs.release_json }}' .github/workflows/prerelease.yml ||
+  fail "prerelease.yml must pass draft metadata to verification without a token"
+
+grep -Fq 'RELEASE_JSON: ${{ steps.draft.outputs.release_json }}' .github/workflows/release.yml ||
+  fail "release.yml must pass draft metadata to verification without a token"
+
+grep -Fq 'RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}' .github/workflows/release.yml ||
+  fail "release.yml existing-tag path must pass resolved release metadata without a token"
+
+python3 - <<'PY' || fail "release draft verification steps must not receive GitHub tokens"
+from pathlib import Path
+
+for workflow in (Path(".github/workflows/release.yml"), Path(".github/workflows/prerelease.yml")):
+    lines = workflow.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        if "verify-release-draft-target.sh" not in line:
+            continue
+        if "verify-release-draft-target.sh\"" not in line and "run: scripts/verify-release-draft-target.sh" not in line:
+            continue
+        window = "\n".join(lines[max(0, index - 8): index + 1])
+        if "GH_TOKEN:" in window or "GITHUB_TOKEN:" in window or "secrets.RELEASE_PLEASE_TOKEN" in window:
+            raise SystemExit(f"{workflow}:{index + 1}")
+        if "RELEASE_JSON" not in window:
+            raise SystemExit(f"{workflow}:{index + 1}")
+PY
+
 grep -Fq 'scripts/check-release-baseline-ready.sh .release-please-manifest.premain.json' .github/workflows/prerelease-pr.yml ||
   fail "prerelease-pr.yml must verify the current premain prerelease baseline before generating the next RC PR"
 

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -55,6 +55,12 @@ done
 grep -Fq 'Resolve draft release metadata' .github/workflows/prerelease.yml ||
   fail "prerelease.yml must resolve hidden draft release metadata before repo checkout"
 
+grep -Fq 'Recover missing current prerelease Release Please state' .github/workflows/prerelease.yml ||
+  fail "prerelease.yml must recover missing tagged prerelease Release Please state"
+
+grep -Fq 'expected_title="chore(premain): release ${version}"' .github/workflows/prerelease.yml ||
+  fail "prerelease.yml must recover the merged premain Release Please PR for the current RC"
+
 grep -Fq 'Resolve draft release metadata' .github/workflows/release.yml ||
   fail "release.yml must resolve hidden draft release metadata before repo checkout"
 

--- a/scripts/test-resolve-release-source-ref.sh
+++ b/scripts/test-resolve-release-source-ref.sh
@@ -132,6 +132,19 @@ if grep -Fq 'release view v1.2.3-rc' "${log_file}"; then
   fail "draft lookup fell through to release view despite list API match"
 fi
 
+env_out="$(
+  RELEASE_JSON='{"id":102,"tag_name":"v1.2.3-rc","target_commitish":"3333333333333333333333333333333333333333","draft":true,"prerelease":true,"html_url":"https://github.test/releases/env"}' \
+  GH_BIN="${tmpdir}/missing-gh" \
+  bash "${script_path}" v1.2.3-rc \
+    2>"${tmpdir}/env.err"
+)"
+grep -Fxq 'source_ref=3333333333333333333333333333333333333333' <<<"${env_out}" ||
+  fail "environment-provided release metadata did not resolve source_ref"
+grep -Fxq 'release_is_draft=true' <<<"${env_out}" ||
+  fail "environment-provided release metadata did not preserve draft state"
+grep -Fxq 'release_id=102' <<<"${env_out}" ||
+  fail "environment-provided release metadata did not preserve release_id"
+
 branch_out="$(
   FAKE_GH_LOG="${log_file}" \
   FAKE_RELEASE_MODE=draft-branch \

--- a/scripts/test-verify-release-draft-target.sh
+++ b/scripts/test-verify-release-draft-target.sh
@@ -64,6 +64,16 @@ write_fake_gh "${bin_a}" "v3.1.2-rc" "${head_a}" "true" "true"
 REPO_ROOT="${work_a}" GH_BIN="${bin_a}/gh" bash "${script_path}" "v3.1.2-rc" "HEAD" >/dev/null ||
   fail "untagged draft target did not pass"
 
+# The release-capable token is intentionally confined to an inline workflow
+# metadata step. The repo-controlled verifier must be able to validate that
+# metadata without invoking gh or receiving the token itself.
+work_env="$(setup_repo env-draft "${tmpdir}")"
+head_env="$(git -C "${work_env}" rev-parse HEAD)"
+release_json_env="{\"tagName\":\"v3.1.2-rc\",\"targetCommitish\":\"${head_env}\",\"isDraft\":true,\"isPrerelease\":true,\"url\":\"https://github.test/releases/untagged-env\"}"
+REPO_ROOT="${work_env}" GH_BIN="${tmpdir}/missing-gh" RELEASE_JSON="${release_json_env}" \
+  bash "${script_path}" "v3.1.2-rc" "HEAD" >/dev/null ||
+  fail "environment-provided draft metadata did not pass without gh"
+
 # A draft release pointing somewhere other than the checked-out commit must fail
 # closed; otherwise assets can be built from different code than the release.
 work_b="$(setup_repo wrong-target "${tmpdir}")"

--- a/scripts/verify-release-draft-target.sh
+++ b/scripts/verify-release-draft-target.sh
@@ -37,13 +37,15 @@ fi
 
 expected_commit="$(git rev-parse "${expected_ref}^{commit}")"
 
-gh_bin="${GH_BIN:-gh}"
-if ! command -v "${gh_bin}" >/dev/null 2>&1; then
-  echo "release-draft-target: FAIL (${gh_bin} not found)"
-  exit 1
+release_json="${RELEASE_JSON:-}"
+if [[ -z "${release_json}" ]]; then
+  gh_bin="${GH_BIN:-gh}"
+  if ! command -v "${gh_bin}" >/dev/null 2>&1; then
+    echo "release-draft-target: FAIL (${gh_bin} not found)"
+    exit 1
+  fi
+  release_json="$(GH_BIN="${gh_bin}" "${script_dir}/release-json-by-tag.sh" "${tag}" 2>/dev/null || true)"
 fi
-
-release_json="$(GH_BIN="${gh_bin}" "${script_dir}/release-json-by-tag.sh" "${tag}" 2>/dev/null || true)"
 if [[ -z "${release_json}" ]]; then
   echo "release-draft-target: FAIL (draft release ${tag} not found)"
   exit 1


### PR DESCRIPTION
## Summary

- restores the prerelease/stable draft-release metadata handoff after the release-token hardening change
- keeps `build-release-assets` jobs at `contents: read`
- confines the release-capable token to minimal inline GitHub API metadata lookup/publish steps, not repo-controlled scripts
- passes sanitized draft metadata to repo scripts through `RELEASE_JSON` so target verification still fails closed without needing a token

## Root cause

`Prerelease (premain)` run `26000947297` failed on PR #200's release commit because `build-release-assets` attempted to discover the untagged draft `v3.2.1-rc` with a read-only `github.token`. The cleanup job later found and deleted the same draft with the release-capable token, proving the draft existed but was hidden from the read-only discovery path.

## Security posture

This keeps the PR #195 security intent intact: release-capable credentials are not passed to repo-controlled scripts or build/rubric/package steps. The only new release-capable use is inline workflow metadata lookup that emits non-secret release fields (`tag`, `target_commitish`, draft/prerelease flags, id/url). Repo scripts validate those fields without a token.

## Validation

- `./scripts/test-verify-release-draft-target.sh`
- `./scripts/test-resolve-release-source-ref.sh`
- `./scripts/test-release-workflow-changelog-preservation.sh`
- `./scripts/verify-version-alignment.sh`
- `git diff --check`
- YAML parse for `.github/workflows/*.yml`
- `make rubric`

## Recovery note

Merging this PR fixes the workflow code. The missing `v3.2.1-rc` artifact still needs Release Please-compatible recovery afterward: repair Release Please state for PR #200 and rerun `Prerelease (premain)` via the fixed workflow, rather than manually creating a tag or GitHub Release.
