### PR TITLE
fix(release): tolerate delayed draft visibility

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -146,7 +146,10 @@ jobs:
           fi
 
           release_json=""
-          for attempt in $(seq 1 12); do
+          # Release Please can report release_created before GitHub's releases
+          # listing API exposes the untagged draft. Poll long enough for that
+          # API lag without handing release-capable credentials to repo scripts.
+          for attempt in $(seq 1 36); do
             for page in $(seq 1 10); do
               page_file="$(mktemp)"
               gh api "repos/${repo}/releases?per_page=100&page=${page}" > "${page_file}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,7 +496,10 @@ jobs:
           fi
 
           release_json=""
-          for attempt in $(seq 1 12); do
+          # Release Please can report release_created before GitHub's releases
+          # listing API exposes the untagged draft. Poll long enough for that
+          # API lag without handing release-capable credentials to repo scripts.
+          for attempt in $(seq 1 36); do
             for page in $(seq 1 10); do
               page_file="$(mktemp)"
               gh api "repos/${repo}/releases?per_page=100&page=${page}" > "${page_file}"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -64,6 +64,11 @@ grep -Fq 'expected_title="chore(premain): release ${version}"' .github/workflows
 grep -Fq 'Resolve draft release metadata' .github/workflows/release.yml ||
   fail "release.yml must resolve hidden draft release metadata before repo checkout"
 
+for workflow in .github/workflows/prerelease.yml .github/workflows/release.yml; do
+  grep -Fq 'for attempt in $(seq 1 36); do' "${workflow}" ||
+    fail "${workflow} must tolerate delayed GitHub draft release visibility"
+done
+
 grep -Fq 'RELEASE_JSON: ${{ steps.draft.outputs.release_json }}' .github/workflows/prerelease.yml ||
   fail "prerelease.yml must pass draft metadata to verification without a token"
 


### PR DESCRIPTION
## Summary
- extend prerelease/stable release draft metadata polling from ~60s to ~180s
- document the GitHub releases-listing lag observed after Release Please reported `release_created`
- add a release-workflow guard so future edits keep delayed draft visibility tolerance

## Root cause
The failed `Prerelease (premain)` run did recover PR #200 and Release Please did create a new untagged draft, but GitHub's releases listing API did not expose that draft until after the `build-release-assets` job's 12x5s polling window expired. The cleanup job found and removed the draft a few seconds later.

## Security posture
This keeps the PR #201 hardening intact: release-capable credentials remain confined to minimal inline GitHub API steps, and repo-controlled scripts/build/rubric still receive only sanitized release metadata, not release-capable tokens.

## Verification
- `scripts/test-release-workflow-changelog-preservation.sh`
- `scripts/verify-version-alignment.sh`
- `git diff --check`
- workflow YAML parse
- `make rubric`
