### PR TITLE
fix(release): widen draft visibility window

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -149,7 +149,7 @@ jobs:
           # Release Please can report release_created before GitHub's releases
           # listing API exposes the untagged draft. Poll long enough for that
           # API lag without handing release-capable credentials to repo scripts.
-          for attempt in $(seq 1 36); do
+          for attempt in $(seq 1 72); do
             for page in $(seq 1 10); do
               page_file="$(mktemp)"
               gh api "repos/${repo}/releases?per_page=100&page=${page}" > "${page_file}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,7 +499,7 @@ jobs:
           # Release Please can report release_created before GitHub's releases
           # listing API exposes the untagged draft. Poll long enough for that
           # API lag without handing release-capable credentials to repo scripts.
-          for attempt in $(seq 1 36); do
+          for attempt in $(seq 1 72); do
             for page in $(seq 1 10); do
               page_file="$(mktemp)"
               gh api "repos/${repo}/releases?per_page=100&page=${page}" > "${page_file}"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -65,7 +65,7 @@ grep -Fq 'Resolve draft release metadata' .github/workflows/release.yml ||
   fail "release.yml must resolve hidden draft release metadata before repo checkout"
 
 for workflow in .github/workflows/prerelease.yml .github/workflows/release.yml; do
-  grep -Fq 'for attempt in $(seq 1 36); do' "${workflow}" ||
+  grep -Fq 'for attempt in $(seq 1 72); do' "${workflow}" ||
     fail "${workflow} must tolerate delayed GitHub draft release visibility"
 done
 


### PR DESCRIPTION
## Summary
- widen prerelease/stable draft metadata polling from 36x5s to 72x5s
- preserve the delayed-draft workflow guard for both release paths

## Root cause
The PR #202 fix was directionally right but still too short. In `Prerelease (premain)` run `26001962572`, Release Please created/commented the untagged `v3.2.1-rc` draft at `2026-05-17T20:33:35Z`. The build job polled until `20:37:02Z` and missed it; the cleanup job then found the draft id `323962608` at `20:37:07Z`. That means the GitHub releases-listing API exposed the draft just after the 36-attempt window expired.

## Security posture
This only changes the timeout in the minimal inline GitHub API step. It does not pass release-capable credentials to repo-controlled scripts, build steps, rubric, or asset generation. Scripts still receive only sanitized `RELEASE_JSON` metadata.

## Verification
- `scripts/test-release-workflow-changelog-preservation.sh`
- `scripts/verify-version-alignment.sh`
- `git diff --check`
- workflow YAML parse
- `make rubric`
