### PR TITLE
fix(release): pin release-please node24 action

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Release Please (PR only)
         id: release
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: premain

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Release Please (Prerelease)
         id: release
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: premain

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Release Please (PR only) (aligned)
         if: needs.check-baseline.outputs.release_as != ''
         id: release_aligned
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: main
@@ -125,7 +125,7 @@ jobs:
       - name: Release Please (PR only)
         if: needs.check-baseline.outputs.release_as == ''
         id: release_default
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,7 +466,7 @@ jobs:
 
       - name: Release Please (Stable)
         id: release
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: main

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -25,6 +25,14 @@ if grep -R -Fq 'secrets.GITHUB_TOKEN' .github/workflows; then
   fail "workflows must fall back to github.token, not a non-existent secrets.GITHUB_TOKEN"
 fi
 
+release_please_pin='googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0'
+if grep -R -Fq 'googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38' .github/workflows; then
+  fail "workflows must not use the deprecated node20 release-please-action pin"
+fi
+if grep -R -F 'googleapis/release-please-action@' .github/workflows | grep -Fv "${release_please_pin}"; then
+  fail "workflows must pin release-please-action to the reviewed node24 SHA"
+fi
+
 if grep -R -F 'gh release create' .github/workflows scripts | grep -v 'scripts/test-release-workflow-changelog-preservation.sh'; then
   fail "release recovery must not create GitHub Releases outside Release Please"
 fi


### PR DESCRIPTION
## Summary
- keep Release Please pinned by immutable SHA, but move it from the deprecated node20 v4 pin to the node24 v5.0.0 pin
- update all release/prerelease Release Please workflow call sites
- add a workflow guard so the deprecated node20 pin cannot return unnoticed

## Why
Run `26002292138` warned that `googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38` runs on Node 20. The current upstream `v5.0.0` release is the Node 24 upgrade and resolves that deprecation while preserving our SHA-pinning discipline.

Reviewed upstream pin:
- `googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0`
- `action.yml` uses `runs: using: node24`

## Security posture
This does not loosen pinning to a mutable tag. It remains pinned to the reviewed v5.0.0 commit SHA.

## Verification
- `scripts/test-release-workflow-changelog-preservation.sh`
- `scripts/verify-version-alignment.sh`
- `git diff --check`
- workflow YAML parse
- `make rubric`
