### PR TITLE
fix(release): isolate draft metadata resolution

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -124,12 +124,14 @@ jobs:
           manifest-file: .release-please-manifest.premain.json
           skip-github-pull-request: true
 
-  build-release-assets:
+  resolve-draft-release:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+    outputs:
+      release_json: ${{ steps.draft.outputs.release_json }}
     steps:
       - name: Resolve draft release metadata
         id: draft
@@ -203,6 +205,15 @@ jobs:
             echo "__FACETHEORY_RELEASE_JSON__"
           } >> "${GITHUB_OUTPUT}"
 
+  build-release-assets:
+    needs:
+      - release-please
+      - resolve-draft-release
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
       - name: Checkout (for release assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -218,7 +229,7 @@ jobs:
 
       - name: Verify draft release targets this commit
         env:
-          RELEASE_JSON: ${{ steps.draft.outputs.release_json }}
+          RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
         run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch
@@ -408,6 +419,7 @@ jobs:
   cleanup-failed-draft:
     needs:
       - release-please
+      - resolve-draft-release
       - build-release-assets
       - publish-prerelease
     if: >-
@@ -415,6 +427,8 @@ jobs:
         always() &&
         needs.release-please.outputs.release_created == 'true' &&
         (
+          needs.resolve-draft-release.result == 'failure' ||
+          needs.resolve-draft-release.result == 'cancelled' ||
           needs.build-release-assets.result == 'failure' ||
           needs.build-release-assets.result == 'cancelled' ||
           needs.publish-prerelease.result == 'failure' ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,12 +474,14 @@ jobs:
           manifest-file: .release-please-manifest.json
           skip-github-pull-request: true
 
-  build-release-assets:
+  resolve-draft-release:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+    outputs:
+      release_json: ${{ steps.draft.outputs.release_json }}
     steps:
       - name: Resolve draft release metadata
         id: draft
@@ -553,6 +555,15 @@ jobs:
             echo "__FACETHEORY_RELEASE_JSON__"
           } >> "${GITHUB_OUTPUT}"
 
+  build-release-assets:
+    needs:
+      - release-please
+      - resolve-draft-release
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
       - name: Checkout (for release assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -570,7 +581,7 @@ jobs:
 
       - name: Verify draft release targets this commit
         env:
-          RELEASE_JSON: ${{ steps.draft.outputs.release_json }}
+          RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
         run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch
@@ -760,6 +771,7 @@ jobs:
   cleanup-failed-draft:
     needs:
       - release-please
+      - resolve-draft-release
       - build-release-assets
       - publish-release
     if: >-
@@ -767,6 +779,8 @@ jobs:
         always() &&
         needs.release-please.outputs.release_created == 'true' &&
         (
+          needs.resolve-draft-release.result == 'failure' ||
+          needs.resolve-draft-release.result == 'cancelled' ||
           needs.build-release-assets.result == 'failure' ||
           needs.build-release-assets.result == 'cancelled' ||
           needs.publish-release.result == 'failure' ||

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -77,11 +77,11 @@ for workflow in .github/workflows/prerelease.yml .github/workflows/release.yml; 
     fail "${workflow} must tolerate delayed GitHub draft release visibility"
 done
 
-grep -Fq 'RELEASE_JSON: ${{ steps.draft.outputs.release_json }}' .github/workflows/prerelease.yml ||
-  fail "prerelease.yml must pass draft metadata to verification without a token"
+grep -Fq 'RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}' .github/workflows/prerelease.yml ||
+  fail "prerelease.yml must pass control-plane draft metadata to verification without a token"
 
-grep -Fq 'RELEASE_JSON: ${{ steps.draft.outputs.release_json }}' .github/workflows/release.yml ||
-  fail "release.yml must pass draft metadata to verification without a token"
+grep -Fq 'RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}' .github/workflows/release.yml ||
+  fail "release.yml must pass control-plane draft metadata to verification without a token"
 
 grep -Fq 'RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}' .github/workflows/release.yml ||
   fail "release.yml existing-tag path must pass resolved release metadata without a token"
@@ -157,6 +157,73 @@ from pathlib import Path
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
 if not re.search(r"\n  build-release-assets:\n(?:.*\n)*?    permissions:\n      contents: read\n", text):
     raise SystemExit(1)
+PY
+
+done
+
+for workflow in .github/workflows/release.yml .github/workflows/prerelease.yml; do
+  python3 - "${workflow}" <<'PY' || fail "${workflow} draft metadata resolver must be a no-checkout control-plane job"
+import re
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1])
+text = workflow.read_text(encoding="utf-8")
+resolver_match = re.search(
+    r"\n  resolve-draft-release:\n(?P<block>(?:    .*\n|\n)+?)(?=\n  build-release-assets:)",
+    text,
+)
+if resolver_match is None:
+    raise SystemExit(f"missing resolve-draft-release job in {workflow}")
+resolver = resolver_match.group("block")
+required = (
+    "    needs: release-please\n",
+    "    if: needs.release-please.outputs.release_created == 'true'\n",
+    "    permissions:\n      contents: write\n",
+    "    outputs:\n      release_json: ${{ steps.draft.outputs.release_json }}\n",
+    "      - name: Resolve draft release metadata\n",
+    "          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}\n",
+)
+for needle in required:
+    if needle not in resolver:
+        raise SystemExit(f"missing resolver invariant {needle!r} in {workflow}")
+for forbidden in ("actions/checkout@", "run: scripts/", "make rubric", "npm ci", "build-release-assets.sh"):
+    if forbidden in resolver:
+        raise SystemExit(f"resolver job must not contain {forbidden!r} in {workflow}")
+
+build_match = re.search(
+    r"\n  build-release-assets:\n(?P<block>(?:    .*\n|\n)+?)(?=\n  publish-)",
+    text,
+)
+if build_match is None:
+    raise SystemExit(f"missing build-release-assets job in {workflow}")
+build = build_match.group("block")
+for required in (
+    "      - release-please\n",
+    "      - resolve-draft-release\n",
+    "    permissions:\n      contents: read\n",
+    "RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}",
+):
+    if required not in build:
+        raise SystemExit(f"missing build invariant {required!r} in {workflow}")
+for forbidden in ("GH_TOKEN:", "GITHUB_TOKEN:", "secrets.RELEASE_PLEASE_TOKEN"):
+    if forbidden in build:
+        raise SystemExit(f"build-release-assets must not receive {forbidden} in {workflow}")
+
+cleanup_match = re.search(
+    r"\n  cleanup-failed-draft:\n(?P<block>(?:    .*\n|\n)+?)$",
+    text,
+)
+if cleanup_match is None:
+    raise SystemExit(f"missing cleanup-failed-draft job in {workflow}")
+cleanup = cleanup_match.group("block")
+for required in (
+    "      - resolve-draft-release\n",
+    "needs.resolve-draft-release.result == 'failure'",
+    "needs.resolve-draft-release.result == 'cancelled'",
+):
+    if required not in cleanup:
+        raise SystemExit(f"cleanup must cover resolver failure invariant {required!r} in {workflow}")
 PY
 
 done


### PR DESCRIPTION
## Summary
- split draft release metadata lookup into a separate `resolve-draft-release` control-plane job for both prerelease and stable release flows
- keep `build-release-assets` read-only and tokenless, consuming only sanitized `release_json`
- extend cleanup to remove failed drafts when metadata resolution itself fails
- add workflow guard coverage for the no-checkout resolver / read-only build boundary

## Why
Runs `26002292138` and `26003309632` proved the same boundary issue: the read-only `build-release-assets` job could not see the untagged Release Please draft, while the write-scoped cleanup job immediately found and deleted it. We need release visibility without exposing release-capable credentials to checkout/build/rubric/repo scripts.

This PR uses the third shape: release-capable lookup happens in a no-checkout inline API job, and build remains a read-only artifact job.

## Security posture
- `resolve-draft-release`: `contents: write`, no checkout, no repo scripts, inline API only
- `build-release-assets`: `contents: read`, checkout/build/rubric/scripts allowed, no `GH_TOKEN`, no `GITHUB_TOKEN`, no `secrets.RELEASE_PLEASE_TOKEN`
- publish/cleanup remain inline API jobs, and cleanup now also covers resolver failure/cancellation

## Verification
- `scripts/test-release-workflow-changelog-preservation.sh`
- `scripts/verify-version-alignment.sh`
- `git diff --check`
- workflow YAML parse
- `make rubric`
