### PR TITLE
fix(release): build from draft source ref

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -214,15 +214,42 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout release workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Stage trusted release provenance scripts
+        run: |
+          set -euo pipefail
+          trusted_dir="${RUNNER_TEMP}/facetheory-release-scripts"
+          mkdir -p "${trusted_dir}"
+          cp \
+            scripts/resolve-release-source-ref.sh \
+            scripts/verify-release-branch.sh \
+            scripts/verify-release-draft-target.sh \
+            "${trusted_dir}/"
+          chmod +x "${trusted_dir}"/*.sh
+
+      - name: Resolve release source ref
+        id: source
+        env:
+          RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+
       - name: Checkout (for release assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
           # Draft GitHub Releases do not guarantee a git tag exists until the
-          # release is published. Build from the release commit and verify the
-          # draft's target before uploading immutable assets.
-          ref: ${{ github.sha }}
+          # release is published. Build from the draft release source ref and
+          # verify the draft's target before uploading immutable assets.
+          ref: ${{ steps.source.outputs.source_ref }}
 
       - name: Fetch main + premain (release branch verification)
         run: git fetch origin main premain --force
@@ -230,10 +257,14 @@ jobs:
       - name: Verify draft release targets this commit
         env:
           RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
-        run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
+        run: |
+          REPO_ROOT="${GITHUB_WORKSPACE}" \
+            "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" HEAD
 
       - name: Verify release source branch
-        run: scripts/verify-release-branch.sh "${{ needs.release-please.outputs.tag_name }}"
+        run: |
+          REPO_ROOT="${GITHUB_WORKSPACE}" \
+            "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-branch.sh" "${{ needs.release-please.outputs.tag_name }}"
 
       - name: Set SOURCE_DATE_EPOCH (deterministic artifacts)
         run: echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -564,15 +564,42 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout release workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Stage trusted release provenance scripts
+        run: |
+          set -euo pipefail
+          trusted_dir="${RUNNER_TEMP}/facetheory-release-scripts"
+          mkdir -p "${trusted_dir}"
+          cp \
+            scripts/resolve-release-source-ref.sh \
+            scripts/verify-release-branch.sh \
+            scripts/verify-release-draft-target.sh \
+            "${trusted_dir}/"
+          chmod +x "${trusted_dir}"/*.sh
+
+      - name: Resolve release source ref
+        id: source
+        env:
+          RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+
       - name: Checkout (for release assets)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
           # Draft GitHub Releases do not guarantee a git tag exists until the
-          # release is published. Build from the release commit and verify the
-          # draft's target before uploading immutable assets.
-          ref: ${{ github.sha }}
+          # release is published. Build from the draft release source ref and
+          # verify the draft's target before uploading immutable assets.
+          ref: ${{ steps.source.outputs.source_ref }}
 
       - name: Fetch main + premain (release branch verification)
         run: |
@@ -582,10 +609,14 @@ jobs:
       - name: Verify draft release targets this commit
         env:
           RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
-        run: scripts/verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
+        run: |
+          REPO_ROOT="${GITHUB_WORKSPACE}" \
+            "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" HEAD
 
       - name: Verify release source branch
-        run: scripts/verify-release-branch.sh "${{ needs.release-please.outputs.tag_name }}"
+        run: |
+          REPO_ROOT="${GITHUB_WORKSPACE}" \
+            "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-branch.sh" "${{ needs.release-please.outputs.tag_name }}"
 
       - name: Set SOURCE_DATE_EPOCH (deterministic artifacts)
         run: echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -202,11 +202,23 @@ for required in (
     "      - release-please\n",
     "      - resolve-draft-release\n",
     "    permissions:\n      contents: read\n",
+    "      - name: Checkout release workflow scripts\n",
+    "      - name: Stage trusted release provenance scripts\n",
+    "      - name: Resolve release source ref\n",
+    "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh",
+    "ref: ${{ steps.source.outputs.source_ref }}",
     "RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}",
+    "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh",
+    "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-branch.sh",
 ):
     if required not in build:
         raise SystemExit(f"missing build invariant {required!r} in {workflow}")
-for forbidden in ("GH_TOKEN:", "GITHUB_TOKEN:", "secrets.RELEASE_PLEASE_TOKEN"):
+for forbidden in (
+    "GH_TOKEN:",
+    "GITHUB_TOKEN:",
+    "secrets.RELEASE_PLEASE_TOKEN",
+    'verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"',
+):
     if forbidden in build:
         raise SystemExit(f"build-release-assets must not receive {forbidden} in {workflow}")
 


### PR DESCRIPTION
## Summary
- build generated Release Please draft assets from the draft release source ref instead of the workflow merge SHA
- stage trusted release provenance scripts before checking out the draft source, mirroring the existing tag/draft release path
- keep `build-release-assets` read-only and without release-capable token env while using the control-plane `release_json` from PR #205
- extend workflow guards so this source-ref boundary cannot regress back to verifying against `${{ github.sha }}`

## Why
After PR #205, `resolve-draft-release` successfully found the draft, but run `26003819316` failed because Release Please recreated `v3.2.1-rc` with `target_commitish=8d3b13f...` (the original Release Please merge commit), while `build-release-assets` still checked out and verified the current workflow merge commit `1c22c2a...`.

The draft target is the release source. The workflow commit is only the orchestration source. This PR separates those roles.

## Security posture
- release-capable draft lookup remains confined to the no-checkout `resolve-draft-release` control-plane job
- build remains `contents: read` with no `GH_TOKEN`, `GITHUB_TOKEN`, or `secrets.RELEASE_PLEASE_TOKEN` env
- provenance verification uses trusted scripts staged from the workflow commit before release-source checkout
- package build/rubric/asset scripts run from the draft release source checkout

## Verification
- `scripts/test-release-workflow-changelog-preservation.sh`
- `scripts/verify-version-alignment.sh`
- `git diff --check`
- workflow YAML parse
- `make rubric`
