### PR TITLE
[codex] align AppTheory v1.7.0 pins

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -227,6 +227,7 @@ jobs:
           trusted_dir="${RUNNER_TEMP}/facetheory-release-scripts"
           mkdir -p "${trusted_dir}"
           cp \
+            scripts/checkout-release-source.sh \
             scripts/resolve-release-source-ref.sh \
             scripts/verify-release-branch.sh \
             scripts/verify-release-draft-target.sh \
@@ -241,15 +242,12 @@ jobs:
         run: |
           "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
 
-      - name: Checkout (for release assets)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+      - name: Checkout release source
+        run: |
           # Draft GitHub Releases do not guarantee a git tag exists until the
           # release is published. Build from the draft release source ref and
           # verify the draft's target before uploading immutable assets.
-          ref: ${{ steps.source.outputs.source_ref }}
+          "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh" "${{ steps.source.outputs.source_ref }}"
 
       - name: Fetch main + premain (release branch verification)
         run: git fetch origin main premain --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           mkdir -p "${trusted_dir}"
           cp \
             scripts/release-json-by-tag.sh \
+            scripts/checkout-release-source.sh \
             scripts/resolve-release-source-ref.sh \
             scripts/verify-release-branch.sh \
             scripts/verify-release-draft-target.sh \
@@ -112,12 +113,9 @@ jobs:
         run: |
           "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
 
-      - name: Checkout (for tag-triggered assets)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          ref: ${{ steps.source.outputs.source_ref }}
+      - name: Checkout release source
+        run: |
+          "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh" "${{ steps.source.outputs.source_ref }}"
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
@@ -577,6 +575,7 @@ jobs:
           trusted_dir="${RUNNER_TEMP}/facetheory-release-scripts"
           mkdir -p "${trusted_dir}"
           cp \
+            scripts/checkout-release-source.sh \
             scripts/resolve-release-source-ref.sh \
             scripts/verify-release-branch.sh \
             scripts/verify-release-draft-target.sh \
@@ -591,15 +590,12 @@ jobs:
         run: |
           "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
 
-      - name: Checkout (for release assets)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+      - name: Checkout release source
+        run: |
           # Draft GitHub Releases do not guarantee a git tag exists until the
           # release is published. Build from the draft release source ref and
           # verify the draft's target before uploading immutable assets.
-          ref: ${{ steps.source.outputs.source_ref }}
+          "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh" "${{ steps.source.outputs.source_ref }}"
 
       - name: Fetch main + premain (release branch verification)
         run: |

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Add the framework peers that match your adapter surface:
 
 Optional companion packages from pinned GitHub releases:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-cdk-1.6.0.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz`
 
 ## Quickstart

--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -7,13 +7,13 @@ This file records the currently pinned versions and the exact install strings we
 
 ## Pins
 
-- AppTheory (TypeScript): `v1.6.0`
-- AppTheory (CDK): `v1.6.0`
+- AppTheory (TypeScript): `v1.7.0`
+- AppTheory (CDK): `v1.7.0`
 - TableTheory (TypeScript): `v1.8.3`
 
 ## Known Audit Exception
 
-None currently. AppTheory CDK `v1.6.0` requires `aws-cdk-lib@2.254.0`, and the infra example lockfiles now resolve
+None currently. AppTheory CDK `v1.7.0` requires `aws-cdk-lib@2.254.0`, and the infra example lockfiles now resolve
 the previous nested `fast-uri` audit finding to the patched AWS CDK dependency set.
 
 ## Infra Lockfile Note
@@ -27,7 +27,7 @@ locks so `npm ci` can validate the AWS CDK package tree under npm 11.
 ```bash
   # AppTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
 
   # TableTheory (TS)
 npm install --save-exact \
@@ -35,7 +35,7 @@ npm install --save-exact \
 
   # AppTheory CDK (only for infra projects)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-cdk-1.6.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz
 ```
 
 ## package.json Snippet (Pinned)
@@ -46,7 +46,7 @@ registry installs:
 ```json
 {
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz"
   },
   "overrides": {

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -92,7 +92,7 @@ patterns:
     solution: "Use exact release asset URLs documented in the compatibility pins."
     correct_example: |
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
       npm install --save-exact \
         https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz
     anti_patterns:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ These are only required if your application uses the corresponding integration s
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
 
 npm install --save-exact \
   https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz

--- a/gov-infra/planning/docs-init-examples/_decisions.yaml
+++ b/gov-infra/planning/docs-init-examples/_decisions.yaml
@@ -54,7 +54,7 @@ decisions:
           reason: "The repo states GitHub releases are source-of-truth and npm registry drift is unsupported."
           example: |
             npm install --save-exact \
-              https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz
+              https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
         if_no:
           choice: "Do not publish docs claiming compatibility; add TODO and pin versions first."
           reason: "Unpinned installs can break runtime and infra examples."

--- a/gov-infra/planning/docs-init-examples/_patterns.yaml
+++ b/gov-infra/planning/docs-init-examples/_patterns.yaml
@@ -37,7 +37,7 @@ patterns:
     correct_example: |
       # CORRECT: install pinned release assets
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
       npm install --save-exact \
         https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz
     anti_patterns:

--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -9,8 +9,8 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1005.0",
         "@aws-sdk/client-s3": "^3.1005.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-cdk-1.6.0.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.254.0",
@@ -2477,9 +2477,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "1.6.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz",
-      "integrity": "sha512-HPpM0ZztV5kgyzt4CMdO89XTdnHC6DOYimYLwQlwt+Zn53ofiTGzX6uvYwqkP5+at8T/EVKGE2JSo26u4/CfnA==",
+      "version": "1.7.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
+      "integrity": "sha512-MYDvBpV+L0rU3IfYbcTXy4Lowp0Z0fSMND91SLhTG8XkoSf/oaLx25Fir86WhJyPMhedR+FE6d5iiaK2mXgd0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2491,9 +2491,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "1.6.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-cdk-1.6.0.tgz",
-      "integrity": "sha512-qe4HoXWfS0w+tSbyphJ6LCoCT6cBiazEoHB1PJX2ChY65+t0svLdPAXOShXiw4xaF/62uhdk1/ZWYREimRRevA==",
+      "version": "1.7.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
+      "integrity": "sha512-dfF6FVMOo5rRuf6qN4/LWPlfycYuR9A0/jPY63rodt3oCP6Mcamunp8MitWnoQT6YUXuKdgwU6Rne6WMIMyOww==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2576,6 +2576,10 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
       "version": "2.2.3",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -2588,11 +2592,28 @@
       },
       "peerDependencies": {
         "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.7.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ]
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
@@ -3196,27 +3217,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     }
   }

--- a/infra/apptheory-ssg-isr-site/package.json
+++ b/infra/apptheory-ssg-isr-site/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1005.0",
     "@aws-sdk/client-s3": "^3.1005.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-cdk-1.6.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.254.0",

--- a/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
+++ b/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
@@ -509,7 +509,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "87725981b83e3131de3647eeab0f188498f2a4f1404116adc94cec5e3c55b2aa.zip"
+          "S3Key": "84f9b64897b38a874e5f77a62f428428a1146da9e61b6bf256a033db0a55c4e9.zip"
         },
         "Environment": {
           "Variables": {

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-cdk-1.6.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.254.0",
         "constructs": "10.6.0",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "1.6.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-cdk-1.6.0.tgz",
-      "integrity": "sha512-qe4HoXWfS0w+tSbyphJ6LCoCT6cBiazEoHB1PJX2ChY65+t0svLdPAXOShXiw4xaF/62uhdk1/ZWYREimRRevA==",
+      "version": "1.7.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
+      "integrity": "sha512-dfF6FVMOo5rRuf6qN4/LWPlfycYuR9A0/jPY63rodt3oCP6Mcamunp8MitWnoQT6YUXuKdgwU6Rne6WMIMyOww==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -583,6 +583,10 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
       "version": "2.2.3",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -595,11 +599,28 @@
       },
       "peerDependencies": {
         "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
+      "version": "7.7.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ]
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
@@ -1073,27 +1094,6 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     }
   }
 }

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,7 +12,7 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-cdk-1.6.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.254.0",
     "constructs": "10.6.0",

--- a/scripts/checkout-release-source.sh
+++ b/scripts/checkout-release-source.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_ref="${1:-}"
+remote="${GIT_REMOTE:-origin}"
+
+if [[ -z "${source_ref}" ]]; then
+  echo "release-source-checkout: FAIL (missing source ref)" >&2
+  exit 1
+fi
+
+fetch_ref=""
+expected_commit=""
+case "${source_ref}" in
+  refs/heads/*)
+    echo "release-source-checkout: FAIL (mutable branch ref ${source_ref} is not allowed)" >&2
+    exit 1
+    ;;
+  refs/*)
+    if [[ "${source_ref}" == refs/tags/* ]]; then
+      tag_name="${source_ref#refs/tags/}"
+      if [[ -z "${tag_name}" ]] || ! git check-ref-format "refs/tags/${tag_name}" >/dev/null 2>&1; then
+        echo "release-source-checkout: FAIL (invalid tag ref ${source_ref})" >&2
+        exit 1
+      fi
+      fetch_ref="${source_ref}"
+    else
+      echo "release-source-checkout: FAIL (unsupported ref ${source_ref})" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    if [[ "${source_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+      fetch_ref="${source_ref}"
+      expected_commit="${source_ref}"
+    else
+      if ! git check-ref-format "refs/tags/${source_ref}" >/dev/null 2>&1; then
+        echo "release-source-checkout: FAIL (source ref must be an immutable commit or release tag)" >&2
+        exit 1
+      fi
+      fetch_ref="refs/tags/${source_ref}"
+    fi
+    ;;
+esac
+
+# Keep the workspace tokenless. actions/checkout ran earlier only for trusted
+# workflow scripts with persist-credentials:false; this manual fetch intentionally
+# avoids a dynamic actions/checkout ref so privileged release jobs do not use the
+# checkout action to materialize untrusted pull-request code.
+git fetch --quiet --force --depth=1 "${remote}" "${fetch_ref}"
+git checkout --quiet --detach --force FETCH_HEAD
+
+actual_commit="$(git rev-parse HEAD)"
+if [[ -n "${expected_commit}" && "${actual_commit}" != "${expected_commit}" ]]; then
+  echo "release-source-checkout: FAIL (${source_ref} resolved to ${actual_commit})" >&2
+  exit 1
+fi
+
+echo "release-source-checkout: checked out ${actual_commit}"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -40,6 +40,9 @@ fi
 grep -Fq 'facetheory-release-scripts' .github/workflows/release.yml ||
   fail "release.yml must stage trusted release provenance scripts before checking out release source code"
 
+grep -Fq 'scripts/checkout-release-source.sh' .github/workflows/release.yml ||
+  fail "release.yml must stage the tokenless release source checkout helper"
+
 grep -Fq 'resolve-release-source-ref.sh" "${TAG_NAME}"' .github/workflows/release.yml ||
   fail "release.yml must resolve existing draft source refs from trusted staged scripts before checkout"
 
@@ -75,6 +78,9 @@ grep -Fq 'Resolve draft release metadata' .github/workflows/release.yml ||
 for workflow in .github/workflows/prerelease.yml .github/workflows/release.yml; do
   grep -Fq 'for attempt in $(seq 1 72); do' "${workflow}" ||
     fail "${workflow} must tolerate delayed GitHub draft release visibility"
+  if grep -Fq 'ref: ${{ steps.source.outputs.source_ref }}' "${workflow}"; then
+    fail "${workflow} must not use actions/checkout with a dynamic release source ref"
+  fi
 done
 
 grep -Fq 'RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}' .github/workflows/prerelease.yml ||
@@ -206,7 +212,8 @@ for required in (
     "      - name: Stage trusted release provenance scripts\n",
     "      - name: Resolve release source ref\n",
     "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh",
-    "ref: ${{ steps.source.outputs.source_ref }}",
+    "      - name: Checkout release source\n",
+    "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh",
     "RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}",
     "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh",
     "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-branch.sh",
@@ -281,5 +288,31 @@ for workflow in (Path(".github/workflows/release.yml"), Path(".github/workflows/
         if "GH_TOKEN:" in window or "GITHUB_TOKEN:" in window or "secrets.RELEASE_PLEASE_TOKEN" in window:
             raise SystemExit(f"{workflow}:{index + 1}")
 PY
+
+checkout_tmp="$(mktemp -d)"
+trap 'rm -rf "${checkout_tmp}"' EXIT
+(
+  set -euo pipefail
+  git init --bare "${checkout_tmp}/remote.git" >/dev/null
+  git init "${checkout_tmp}/source" >/dev/null
+  cd "${checkout_tmp}/source"
+  git config user.email test@example.com
+  git config user.name "Test User"
+  printf 'release source\n' > README.md
+  git add README.md
+  git commit -m 'test release source' >/dev/null
+  commit="$(git rev-parse HEAD)"
+  git branch -M main
+  git remote add origin "${checkout_tmp}/remote.git"
+  git push --quiet origin main >/dev/null
+  git clone "${checkout_tmp}/remote.git" "${checkout_tmp}/work" >/dev/null 2>&1
+  cd "${checkout_tmp}/work"
+  GIT_REMOTE=origin "${repo_root}/scripts/checkout-release-source.sh" "${commit}" >/dev/null
+  [[ "$(git rev-parse HEAD)" == "${commit}" ]]
+  if GIT_REMOTE=origin "${repo_root}/scripts/checkout-release-source.sh" refs/heads/main >/dev/null 2>&1; then
+    echo "checkout-release-source accepted mutable branch" >&2
+    exit 1
+  fi
+) || fail "checkout-release-source.sh must detach immutable commits and reject mutable branches"
 
 echo "test-release-workflow-changelog-preservation: PASS"

--- a/ts/README.md
+++ b/ts/README.md
@@ -19,8 +19,8 @@ Install the peers that match your adapter surface:
 
 Optional companion packages:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-cdk-1.6.0.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz`
 
 ## Minimal App

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -15,7 +15,7 @@
         "@emotion/server": "^11.11.0",
         "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^24.12.0",
@@ -4423,9 +4423,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "1.6.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz",
-      "integrity": "sha512-HPpM0ZztV5kgyzt4CMdO89XTdnHC6DOYimYLwQlwt+Zn53ofiTGzX6uvYwqkP5+at8T/EVKGE2JSo26u4/CfnA==",
+      "version": "1.7.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
+      "integrity": "sha512-MYDvBpV+L0rU3IfYbcTXy4Lowp0Z0fSMND91SLhTG8XkoSf/oaLx25Fir86WhJyPMhedR+FE6d5iiaK2mXgd0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -194,7 +194,7 @@
     "@emotion/server": "^11.11.0",
     "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.6.0/theory-cloud-apptheory-1.6.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^24.12.0",


### PR DESCRIPTION
## Summary

- Update FaceTheory's pinned AppTheory runtime and CDK tarball URLs from `v1.6.0` to the newly published stable `v1.7.0` release.
- Regenerate the TypeScript and AppTheory infra example lockfiles so the pinned tarballs resolve with the new integrity values.
- Refresh the SSG+ISR infra snapshot for the updated bundled SSR asset hash.
- Address code scanning alerts #16 and #17 by replacing dynamic release-source `actions/checkout` steps with a staged tokenless checkout helper that only accepts immutable commits or release tags and rejects mutable branch refs.

## Why

AppTheory `v1.7.0` is now the latest published stable release with immutable GitHub Release assets. Keeping FaceTheory's AppTheory pins current preserves the AWS-first AppTheory integration path used by the runtime adapter and reference infra examples.

The release workflow changes keep the release build path tokenless while avoiding the CodeQL `actions/untrusted-checkout/medium` pattern reported for the prerelease and stable release asset jobs.

AppTheory release: https://github.com/theory-cloud/AppTheory/releases/tag/v1.7.0

## Validation

- `make rubric`
- `scripts/test-release-workflow-changelog-preservation.sh`
- `scripts/verify-version-alignment.sh`
- `cd infra/apptheory-ssr-site && npm test`
- `cd infra/apptheory-ssg-isr-site && npm test`