### PR TITLE
feat(stitch-admin): add wizard reconciliation plan (diff list) primitive

### DIFF
--- a/docs/wizard-primitives.md
+++ b/docs/wizard-primitives.md
@@ -25,7 +25,7 @@ primitive twice and asserting byte-identical SSR output.
 | Layer | Module | What it exports |
 | --- | --- | --- |
 | Framework-neutral types | `@theory-cloud/facetheory/stitch-admin` | `WizardProgressState`, `WizardPackageSummary`, `WizardFindingList`, `WizardReconcileSummary`, `WizardCapabilityReview`, `WizardEnablementChecklist`, `WizardRecoveryStatus`, `WizardEmptyStateConfig`, `WizardSafetyPolicy`, and supporting enums. |
-| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
+| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
 
 Vue and Svelte adapter parity is intentionally deferred for this milestone.
 The TheoryMCP control plane that consumes these primitives today is React; the
@@ -62,6 +62,70 @@ the primitive *does* enforce at render time:
 These render-time levers are belt-and-suspenders: the host should still avoid
 passing raw secrets into the primitive at all.
 
+## When to use `WizardReconciliationPlanPanel` vs `WizardReconcileSummaryPanel`
+
+These two primitives describe different things and live side by side:
+
+- **`WizardReconcileSummaryPanel`** describes a **before/after diff** with
+  kinds `added`, `removed`, `changed`, `unchanged`, `redacted`. Use it when
+  you want to show the user what changed between two snapshots.
+
+- **`WizardReconciliationPlanPanel`** (alias `WizardDiffListPanel`) describes
+  the **plan** the host intends to execute next, with the richer operation
+  kinds:
+
+  | Canonical kind | Stable alias              | Meaning                                                 |
+  | -------------- | ------------------------- | ------------------------------------------------------- |
+  | `create`       | —                         | Will create a new resource                              |
+  | `update`       | —                         | Will update an existing resource                        |
+  | `satisfied`    | `already_satisfied`       | Desired state already matches; no work                  |
+  | `conflict`     | —                         | Incompatible with another row or external state         |
+  | `blocked`      | —                         | Cannot proceed; the host explains why in `reason`       |
+  | `external`     | `external_step_required`  | Will be completed outside this wizard                   |
+  | `noop`         | `not_requested`           | Explicitly requested as a no-op                         |
+
+  Aliases are accepted on input and normalized to the canonical kind at
+  render time. The canonical kind appears in `data-row-kind`; the original
+  alias is preserved in `data-row-kind-input` so callers can grep either
+  form during regression debugging.
+
+### Accessible expand/collapse contract
+
+`WizardReconciliationPlanPanel` rows may carry an optional list of structured
+`details`. When they do, the primitive renders an expand/collapse affordance
+that follows these rules:
+
+- The toggle is a real `<button type="button">` (keyboard-operable, focusable
+  by default; no custom div-with-onClick).
+- `aria-expanded="true|false"` mirrors `row.expanded`. The primitive never
+  toggles state itself — it is a controlled surface.
+- `aria-controls` points at the detail panel id; the detail panel uses the
+  matching `id` plus `role="region"` and the standard `hidden` attribute when
+  not expanded.
+- The toggle's `aria-label` is text — "Show details for &lt;status label&gt;"
+  / "Hide details for &lt;status label&gt;" — so screen-readers and
+  high-contrast viewers see the same information independent of color.
+- The status pill exposes its label via `aria-label="Status: …"`.
+
+The host wires an `onToggleRow(rowKey, nextExpanded)` callback to update its
+own state. On the next render, the row's `expanded` value updates and the
+primitive renders the new state. There is no client-side `useState` inside
+the primitive, which is what keeps SSR and hydrated DOM byte-identical.
+
+### Redaction levers
+
+The reconciliation plan primitive shares the redaction model with the rest of
+the wizard contracts. Two levers, both enforced at render time:
+
+- `WizardReconciliationPlanDetail.redacted = true` — that one detail's value
+  renders as `[redacted]`.
+- `WizardReconciliationPlanRow.redacted = true` — every detail value in that
+  row renders as `[redacted]`. The row's `summary` and `reason` still render
+  so reviewers can see why the row exists, but the values do not leak.
+
+The row's safety policy literal is still required and is still rendered into
+the DOM (`data-safety-policy`, plus the footnote).
+
 ## Consuming the primitives from TheoryMCP
 
 The TheoryMCP control plane is the first consumer. Suggested integration shape:
@@ -72,11 +136,43 @@ import {
   WizardPackageSummaryPanel,
   WizardFindingListPanel,
   WizardReconcileSummaryPanel,
+  WizardReconciliationPlanPanel,
+  // alias of WizardReconciliationPlanPanel — same component, "DiffList" naming
+  WizardDiffListPanel,
   WizardCapabilityReviewPanel,
   WizardEnablementChecklistPanel,
   WizardRecoveryStatusPanel,
   WizardEmptyState,
 } from '@theory-cloud/facetheory/react/stitch-admin';
+```
+
+A typical reconciliation step in the TheoryMCP Agent Import & Completion
+Wizard:
+
+```tsx
+<WizardReconciliationPlanPanel
+  plan={{
+    rows: [
+      { key: 'ns', label: 'Create namespace acme', kind: 'create',
+        summary: 'Will create namespace acme in tenant theory-mcp' },
+      { key: 'agent', label: 'Update agent acme', kind: 'update',
+        summary: 'Bump declared capabilities' },
+      { key: 'binding', label: 'Mailbox binding', kind: 'already_satisfied',
+        summary: 'Mailbox allowlist already includes the agent' },
+      { key: 'github', label: 'GitHub binding', kind: 'conflict',
+        reason: 'Existing binding targets theory-cloud/Other; resolve before continuing.' },
+      { key: 'policy', label: 'Enforcement policy', kind: 'blocked',
+        reason: 'Operator review record not present.' },
+      { key: 'secret', label: 'Rotate signing secret', kind: 'external_step_required',
+        reason: 'Cannot rotate from this wizard; complete in the rotation tool.' },
+      { key: 'deploy', label: 'Deployment', kind: 'not_requested',
+        summary: 'Deployment intentionally not part of this run' },
+    ],
+    totals: { create: 1, update: 1, satisfied: 1, conflict: 1, blocked: 1, external: 1, noop: 1 },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  }}
+  onToggleRow={(rowKey, nextExpanded) => host.setRowExpanded(rowKey, nextExpanded)}
+/>
 ```
 
 A typical wizard page picks the primitive(s) it needs for the current step and

--- a/ts/src/react/stitch-admin/index.ts
+++ b/ts/src/react/stitch-admin/index.ts
@@ -129,3 +129,20 @@ export {
   type WizardStep,
   type WizardStepStatus,
 } from './wizard.js';
+
+export {
+  WizardReconciliationPlanPanel,
+  WizardDiffListPanel,
+  type WizardReconciliationPlanPanelProps,
+  type WizardDiffListPanelProps,
+  type WizardDiffList,
+  type WizardDiffListCanonicalKind,
+  type WizardDiffListDetail,
+  type WizardDiffListOperationKind,
+  type WizardDiffListRow,
+  type WizardReconciliationPlan,
+  type WizardReconciliationPlanCanonicalKind,
+  type WizardReconciliationPlanDetail,
+  type WizardReconciliationPlanOperationKind,
+  type WizardReconciliationPlanRow,
+} from './wizard-reconciliation-plan.js';

--- a/ts/src/react/stitch-admin/wizard-reconciliation-plan.ts
+++ b/ts/src/react/stitch-admin/wizard-reconciliation-plan.ts
@@ -1,0 +1,513 @@
+import * as React from 'react';
+
+import type {
+  WizardDiffList,
+  WizardDiffListCanonicalKind,
+  WizardDiffListDetail,
+  WizardDiffListOperationKind,
+  WizardDiffListRow,
+  WizardReconciliationPlan,
+  WizardReconciliationPlanCanonicalKind,
+  WizardReconciliationPlanDetail,
+  WizardReconciliationPlanOperationKind,
+  WizardReconciliationPlanRow,
+} from '../../stitch-admin/wizard-reconciliation-plan-types.js';
+import {
+  canonicalizeWizardReconciliationPlanKind,
+} from '../../stitch-admin/wizard-reconciliation-plan-types.js';
+import type { WizardSafetyPolicy } from '../../stitch-admin/wizard-types.js';
+import { MetadataBadgeGroup } from './operator-notices.js';
+
+const h = React.createElement;
+
+const REDACTED_MARKER = '[redacted]';
+
+export type {
+  WizardDiffList,
+  WizardDiffListCanonicalKind,
+  WizardDiffListDetail,
+  WizardDiffListOperationKind,
+  WizardDiffListRow,
+  WizardReconciliationPlan,
+  WizardReconciliationPlanCanonicalKind,
+  WizardReconciliationPlanDetail,
+  WizardReconciliationPlanOperationKind,
+  WizardReconciliationPlanRow,
+};
+
+interface KindPalette {
+  background: string;
+  color: string;
+  border: string;
+  label: string;
+  prominent: boolean;
+}
+
+const KIND_PALETTE: Record<WizardReconciliationPlanCanonicalKind, KindPalette> = {
+  create: {
+    background: 'var(--stitch-color-tertiary-container, #004c45)',
+    color: 'var(--stitch-color-on-tertiary-container, #52c1b4)',
+    border: 'var(--stitch-color-tertiary-container, #004c45)',
+    label: 'Will create',
+    prominent: false,
+  },
+  update: {
+    background: 'var(--stitch-color-primary-container, #e0e0ff)',
+    color: 'var(--stitch-color-on-primary-container, #000066)',
+    border: 'var(--stitch-color-primary-container, #e0e0ff)',
+    label: 'Will update',
+    prominent: false,
+  },
+  satisfied: {
+    background: 'var(--stitch-color-surface-container-high, #e2e7ff)',
+    color: 'var(--stitch-color-on-surface-variant, #464553)',
+    border: 'var(--stitch-color-outline-variant, #c6c5d0)',
+    label: 'Already satisfied',
+    prominent: false,
+  },
+  conflict: {
+    background: 'var(--stitch-color-error-container, #ffdad6)',
+    color: 'var(--stitch-color-on-error-container, #93000a)',
+    border: 'var(--stitch-color-on-error-container, #93000a)',
+    label: 'Conflict',
+    prominent: true,
+  },
+  blocked: {
+    background: 'var(--stitch-color-error-container, #ffdad6)',
+    color: 'var(--stitch-color-on-error-container, #93000a)',
+    border: 'var(--stitch-color-on-error-container, #93000a)',
+    label: 'Blocked',
+    prominent: true,
+  },
+  external: {
+    background: 'var(--stitch-color-secondary-container, #ffecc0)',
+    color: 'var(--stitch-color-on-secondary-container, #3f2e00)',
+    border: 'var(--stitch-color-on-secondary-container, #3f2e00)',
+    label: 'External step required',
+    prominent: true,
+  },
+  noop: {
+    background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+    color: 'var(--stitch-color-on-surface-variant, #464553)',
+    border: 'var(--stitch-color-outline-variant, #c6c5d0)',
+    label: 'No-op',
+    prominent: false,
+  },
+};
+
+const CANONICAL_KINDS: WizardReconciliationPlanCanonicalKind[] = [
+  'create',
+  'update',
+  'satisfied',
+  'conflict',
+  'blocked',
+  'external',
+  'noop',
+];
+
+export interface WizardReconciliationPlanPanelProps {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  plan: WizardReconciliationPlan;
+  emptyLabel?: React.ReactNode;
+  /**
+   * Optional caller-supplied callback fired when a row's toggle button is
+   * activated. Hosts wire this to their state so the next render updates
+   * `row.expanded`. The primitive itself never toggles state.
+   */
+  onToggleRow?: (rowKey: string, nextExpanded: boolean) => void;
+}
+
+/**
+ * Renders a wizard reconciliation plan (a.k.a. wizard diff list). Hosts
+ * compute the plan; FaceTheory only displays it.
+ *
+ * Accessibility contract:
+ * - The toggle is a real `<button type="button">`.
+ * - The button carries `aria-expanded`, `aria-controls`, and a deterministic
+ *   `data-row-expanded` attribute so SSR output and hydrated DOM match.
+ * - The detail panel uses an `id` matching `aria-controls` and is hidden via
+ *   the standard `hidden` attribute when not expanded.
+ * - The status badge label is text (color-independent) so screen-readers and
+ *   high-contrast viewers see the same information.
+ */
+export function WizardReconciliationPlanPanel(
+  props: WizardReconciliationPlanPanelProps,
+): React.ReactElement {
+  const {
+    title = 'Reconciliation plan',
+    description,
+    plan,
+    emptyLabel = 'No plan rows.',
+    onToggleRow,
+  } = props;
+
+  return h(
+    'section',
+    {
+      className: 'facetheory-stitch-wizard-reconciliation-plan',
+      'data-safety-policy': plan.safetyPolicy,
+      'data-row-count': String(plan.rows.length),
+      'data-conflict-count': String(plan.totals.conflict),
+      'data-blocked-count': String(plan.totals.blocked),
+      'data-external-count': String(plan.totals.external),
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        padding: '20px',
+        borderRadius: 'var(--stitch-radius-lg, 12px)',
+        background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+      },
+    },
+    h(
+      'header',
+      {
+        style: {
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: '12px',
+          flexWrap: 'wrap',
+        },
+      },
+      h(
+        'div',
+        { style: { display: 'flex', flexDirection: 'column', gap: '4px' } },
+        h('h2', { style: { margin: 0, fontSize: '16px' } }, title),
+        description !== undefined
+          ? h(
+              'p',
+              {
+                style: {
+                  margin: 0,
+                  fontSize: '13px',
+                  lineHeight: 1.5,
+                  color: 'var(--stitch-color-on-surface-variant, #464553)',
+                },
+              },
+              description,
+            )
+          : null,
+      ),
+      renderCounts(plan.totals),
+    ),
+    plan.rows.length > 0
+      ? h(
+          'ul',
+          {
+            role: 'list',
+            style: {
+              margin: 0,
+              padding: 0,
+              listStyle: 'none',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '8px',
+            },
+          },
+          plan.rows.map((row) => renderRow(row, onToggleRow)),
+        )
+      : h(
+          'div',
+          {
+            className: 'facetheory-stitch-wizard-reconciliation-plan-empty',
+            role: 'status',
+            style: {
+              padding: '14px',
+              borderRadius: 'var(--stitch-radius-md, 10px)',
+              background: 'var(--stitch-color-surface-container, #eaedff)',
+              color: 'var(--stitch-color-on-surface-variant, #464553)',
+              fontSize: '14px',
+            },
+          },
+          emptyLabel,
+        ),
+    renderSafetyFootnote(plan.safetyPolicy),
+  );
+}
+
+/** DiffList alias for callers who prefer the diff-list framing. */
+export const WizardDiffListPanel = WizardReconciliationPlanPanel;
+export type WizardDiffListPanelProps = WizardReconciliationPlanPanelProps;
+
+function renderCounts(
+  totals: Record<WizardReconciliationPlanCanonicalKind, number>,
+): React.ReactElement {
+  return h(
+    'div',
+    {
+      className: 'facetheory-stitch-wizard-reconciliation-plan-counts',
+      style: { display: 'flex', gap: '6px', flexWrap: 'wrap' },
+    },
+    CANONICAL_KINDS.map((kind) => {
+      const palette = KIND_PALETTE[kind];
+      return h(
+        'span',
+        {
+          key: kind,
+          className: `facetheory-stitch-wizard-reconciliation-plan-count facetheory-stitch-wizard-reconciliation-plan-count-${kind}`,
+          'data-kind-summary': kind,
+          'data-kind-count': String(totals[kind]),
+          style: {
+            display: 'inline-flex',
+            alignItems: 'center',
+            padding: '2px 10px',
+            borderRadius: '9999px',
+            background: palette.background,
+            color: palette.color,
+            fontSize: '12px',
+            fontWeight: 600,
+            lineHeight: 1.4,
+          },
+        },
+        `${palette.label}: ${totals[kind]}`,
+      );
+    }),
+  );
+}
+
+function renderRow(
+  row: WizardReconciliationPlanRow,
+  onToggleRow: WizardReconciliationPlanPanelProps['onToggleRow'],
+): React.ReactElement {
+  const canonical = canonicalizeWizardReconciliationPlanKind(row.kind);
+  const palette = KIND_PALETTE[canonical];
+  const statusLabel = row.statusLabel ?? palette.label;
+  const expanded = row.expanded === true;
+  const detailPanelId = `facetheory-wizard-plan-row-${row.key}-details`;
+  const hasDetails = Array.isArray(row.details) && row.details.length > 0;
+  const ariaRole = palette.prominent ? 'alert' : 'listitem';
+
+  return h(
+    'li',
+    {
+      key: row.key,
+      className: `facetheory-stitch-wizard-reconciliation-plan-row facetheory-stitch-wizard-reconciliation-plan-row-${canonical}${palette.prominent ? ' facetheory-stitch-wizard-reconciliation-plan-row-prominent' : ''}${row.redacted ? ' facetheory-stitch-wizard-reconciliation-plan-row-redacted' : ''}`,
+      'data-row-key': row.key,
+      'data-row-kind': canonical,
+      'data-row-kind-input': row.kind,
+      'data-row-prominent': palette.prominent ? 'true' : 'false',
+      'data-row-expanded': expanded ? 'true' : 'false',
+      'data-row-redacted': row.redacted ? 'true' : 'false',
+      role: ariaRole,
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        padding: '12px',
+        borderRadius: 'var(--stitch-radius-md, 10px)',
+        background: 'var(--stitch-color-surface-container, #eaedff)',
+        border: `1px solid ${palette.border}`,
+        ...(palette.prominent ? { boxShadow: `inset 0 0 0 1px ${palette.color}` } : null),
+      },
+    },
+    h(
+      'div',
+      {
+        style: {
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 1fr) auto',
+          alignItems: 'center',
+          gap: '12px',
+        },
+      },
+      h(
+        'div',
+        { style: { display: 'flex', flexDirection: 'column', gap: '4px', minWidth: 0 } },
+        h('strong', { style: { fontSize: '14px' } }, row.label as React.ReactNode),
+        row.summary !== undefined
+          ? h(
+              'span',
+              {
+                className: 'facetheory-stitch-wizard-reconciliation-plan-row-summary',
+                style: {
+                  fontSize: '13px',
+                  lineHeight: 1.5,
+                  color: 'var(--stitch-color-on-surface-variant, #464553)',
+                  overflowWrap: 'anywhere',
+                },
+              },
+              row.summary as React.ReactNode,
+            )
+          : null,
+      ),
+      h(
+        'span',
+        {
+          className: `facetheory-stitch-wizard-reconciliation-plan-row-status facetheory-stitch-wizard-reconciliation-plan-row-status-${canonical}`,
+          'data-status-chip': canonical,
+          'aria-label': `Status: ${statusLabel}`,
+          style: {
+            display: 'inline-flex',
+            alignItems: 'center',
+            padding: '2px 10px',
+            borderRadius: '9999px',
+            background: palette.background,
+            color: palette.color,
+            fontSize: '12px',
+            fontWeight: 600,
+            lineHeight: 1.4,
+            whiteSpace: 'nowrap',
+          },
+        },
+        statusLabel,
+      ),
+    ),
+    row.reason !== undefined
+      ? h(
+          'p',
+          {
+            className: `facetheory-stitch-wizard-reconciliation-plan-row-reason facetheory-stitch-wizard-reconciliation-plan-row-reason-${canonical}`,
+            style: {
+              margin: 0,
+              fontSize: '13px',
+              lineHeight: 1.5,
+              color: palette.prominent ? palette.color : 'var(--stitch-color-on-surface-variant, #464553)',
+              fontWeight: palette.prominent ? 600 : 400,
+            },
+          },
+          row.reason,
+        )
+      : null,
+    row.metadata !== undefined
+      ? h(MetadataBadgeGroup, { metadata: row.metadata })
+      : null,
+    hasDetails ? renderToggle(row, detailPanelId, expanded, statusLabel, onToggleRow) : null,
+    hasDetails ? renderDetailPanel(row, detailPanelId, expanded) : null,
+  );
+}
+
+function renderToggle(
+  row: WizardReconciliationPlanRow,
+  detailPanelId: string,
+  expanded: boolean,
+  statusLabel: string,
+  onToggleRow: WizardReconciliationPlanPanelProps['onToggleRow'],
+): React.ReactElement {
+  return h(
+    'button',
+    {
+      type: 'button',
+      className: 'facetheory-stitch-wizard-reconciliation-plan-row-toggle',
+      'aria-expanded': expanded ? 'true' : 'false',
+      'aria-controls': detailPanelId,
+      'aria-label': `${expanded ? 'Hide' : 'Show'} details for ${statusLabel}`,
+      'data-row-toggle-key': row.key,
+      onClick: onToggleRow !== undefined
+        ? () => onToggleRow(row.key, !expanded)
+        : undefined,
+      style: {
+        alignSelf: 'flex-start',
+        appearance: 'none',
+        background: 'transparent',
+        border: '1px solid var(--stitch-color-outline-variant, #c6c5d0)',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+        borderRadius: 'var(--stitch-radius-sm, 8px)',
+        padding: '4px 10px',
+        fontSize: '12px',
+        fontWeight: 600,
+        cursor: onToggleRow !== undefined ? 'pointer' : 'default',
+      },
+    },
+    expanded ? 'Hide details' : 'Show details',
+  );
+}
+
+function renderDetailPanel(
+  row: WizardReconciliationPlanRow,
+  detailPanelId: string,
+  expanded: boolean,
+): React.ReactElement {
+  return h(
+    'div',
+    {
+      id: detailPanelId,
+      className: 'facetheory-stitch-wizard-reconciliation-plan-row-details',
+      role: 'region',
+      hidden: !expanded,
+      'aria-hidden': expanded ? 'false' : 'true',
+      style: {
+        display: expanded ? 'flex' : 'none',
+        flexDirection: 'column',
+        gap: '6px',
+        padding: '10px 12px',
+        borderRadius: 'var(--stitch-radius-md, 10px)',
+        background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+      },
+    },
+    expanded
+      ? h(
+          'dl',
+          {
+            style: {
+              margin: 0,
+              display: 'grid',
+              gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 2fr)',
+              gap: '6px 12px',
+              fontSize: '13px',
+            },
+          },
+          (row.details ?? []).map((detail) => renderDetail(detail, row.redacted === true)),
+        )
+      : null,
+  );
+}
+
+function renderDetail(
+  detail: WizardReconciliationPlanDetail,
+  rowRedacted: boolean,
+): React.ReactElement {
+  const redacted = detail.redacted === true || rowRedacted;
+  return h(
+    React.Fragment,
+    { key: detail.key },
+    h(
+      'dt',
+      {
+        style: {
+          margin: 0,
+          fontWeight: 600,
+          color: 'var(--stitch-color-on-surface-variant, #464553)',
+          overflowWrap: 'anywhere',
+        },
+        'data-detail-key': detail.key,
+      },
+      detail.label as React.ReactNode,
+    ),
+    h(
+      'dd',
+      {
+        style: {
+          margin: 0,
+          color: 'var(--stitch-color-on-surface, #131b2e)',
+          overflowWrap: 'anywhere',
+          fontFamily: redacted
+            ? 'var(--stitch-font-label, ui-monospace, SFMono-Regular, Menlo, monospace)'
+            : 'inherit',
+        },
+        'data-detail-redacted': redacted ? 'true' : 'false',
+      },
+      redacted ? REDACTED_MARKER : (detail.value as React.ReactNode) ?? '',
+    ),
+  );
+}
+
+function renderSafetyFootnote(policy: WizardSafetyPolicy): React.ReactElement {
+  return h(
+    'p',
+    {
+      className: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+      style: {
+        margin: 0,
+        fontSize: '11px',
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+      },
+    },
+    `Safety policy: ${policy}`,
+  );
+}

--- a/ts/src/stitch-admin/index.ts
+++ b/ts/src/stitch-admin/index.ts
@@ -29,6 +29,21 @@ export type {
 } from './wizard-types.js';
 
 export type {
+  WizardDiffList,
+  WizardDiffListCanonicalKind,
+  WizardDiffListDetail,
+  WizardDiffListOperationKind,
+  WizardDiffListRow,
+  WizardReconciliationPlan,
+  WizardReconciliationPlanCanonicalKind,
+  WizardReconciliationPlanDetail,
+  WizardReconciliationPlanOperationKind,
+  WizardReconciliationPlanRow,
+} from './wizard-reconciliation-plan-types.js';
+
+export { canonicalizeWizardReconciliationPlanKind } from './wizard-reconciliation-plan-types.js';
+
+export type {
   AuthorityState,
   ConfidenceLevel,
   ConfidenceMetadata,

--- a/ts/src/stitch-admin/wizard-reconciliation-plan-types.ts
+++ b/ts/src/stitch-admin/wizard-reconciliation-plan-types.ts
@@ -1,0 +1,169 @@
+/**
+ * Framework-neutral types for the FaceTheory wizard reconciliation plan
+ * primitive. This is the richer cousin of `WizardReconcileSummary`:
+ *
+ * - `WizardReconcileSummary` (from `wizard-types.ts`) describes a before/after
+ *   diff with kinds `added | removed | changed | unchanged | redacted`.
+ *
+ * - `WizardReconciliationPlan` (this file) describes the *plan* the host
+ *   intends to execute next, with operation kinds that include not just
+ *   create/update but also `satisfied`, `conflict`, `blocked`, `external`,
+ *   and `noop`. It is the natural shape for the TheoryMCP Agent Import &
+ *   Completion Wizard "what will happen if you click Enable" step.
+ *
+ * The contract is presentational: hosts (e.g. the TheoryMCP control plane)
+ * compute the plan and pass rows in. FaceTheory:
+ *
+ *   - never decides whether an operation is safe, destructive, allowed by
+ *     TheoryMCP route authority, allowed by email/GitHub bindings, or
+ *     externally complete;
+ *   - never computes redaction; it only renders `[redacted]` when the host
+ *     marks a row or detail as redacted;
+ *   - never opens, fetches, or hashes evidence;
+ *   - renders the same DOM for the same input on SSR and hydrated client.
+ */
+
+import type { OperatorVisibilityMetadata } from './operator-visibility-types.js';
+import type { WizardSafetyPolicy } from './wizard-types.js';
+
+/**
+ * Operation kinds for a row in a wizard reconciliation plan.
+ *
+ * Canonical seven kinds plus stable aliases:
+ *
+ * - `create`                       — operation will create a new resource
+ * - `update`                       — operation will update an existing resource
+ * - `satisfied` / `already_satisfied` — desired state already matches; no work
+ * - `conflict`                     — incompatible with another row or external state
+ * - `blocked`                      — cannot proceed (host explains why)
+ * - `external` / `external_step_required` — completed outside this wizard
+ * - `noop` / `not_requested`       — explicitly requested as a no-op
+ *
+ * Aliases normalize to the canonical kind on render.
+ */
+export type WizardReconciliationPlanOperationKind =
+  | 'create'
+  | 'update'
+  | 'satisfied'
+  | 'already_satisfied'
+  | 'conflict'
+  | 'blocked'
+  | 'external'
+  | 'external_step_required'
+  | 'noop'
+  | 'not_requested';
+
+/** Canonical (non-alias) operation kinds the totals object is keyed on. */
+export type WizardReconciliationPlanCanonicalKind =
+  | 'create'
+  | 'update'
+  | 'satisfied'
+  | 'conflict'
+  | 'blocked'
+  | 'external'
+  | 'noop';
+
+/**
+ * Optional structured detail row inside a reconciliation plan row. Hosts
+ * pre-redact values; the primitive renders `[redacted]` when `redacted: true`.
+ * Adapters narrow node-shaped fields to their native node type.
+ */
+export interface WizardReconciliationPlanDetail {
+  /** Stable identifier used for keying inside the row. */
+  key: string;
+  /** Display label. */
+  label: unknown;
+  /** Pre-redacted value (caller-supplied). */
+  value?: unknown;
+  /** Set to `true` when the underlying value is sensitive. */
+  redacted?: boolean;
+}
+
+/**
+ * A single row in a wizard reconciliation plan. Hosts compute everything the
+ * primitive needs.
+ */
+export interface WizardReconciliationPlanRow {
+  /** Stable identifier used for keying. */
+  key: string;
+  /** Display label. */
+  label: unknown;
+  kind: WizardReconciliationPlanOperationKind;
+  /**
+   * Optional short summary copy (e.g. "Will create namespace 'acme'"). The
+   * primitive renders this verbatim — it does not compose it from `kind`.
+   */
+  summary?: unknown;
+  /**
+   * Optional stable caller-supplied status label, e.g. "Will create" /
+   * "Already satisfied" / "Conflict with existing binding". The primitive
+   * renders this verbatim alongside an icon-free, color-independent badge.
+   * If absent, a deterministic default label derived from `kind` is used.
+   */
+  statusLabel?: string;
+  /**
+   * Optional caller-supplied reason copy. Required in practice for
+   * `conflict`, `blocked`, `external`, and `noop` rows so reviewers can
+   * understand why no work happens; the primitive does not enforce that the
+   * field is present, but tests and docs ask hosts to supply it.
+   */
+  reason?: string;
+  /**
+   * Optional structured detail rows shown only when the row is expanded.
+   * Each detail entry may carry its own redaction flag.
+   */
+  details?: WizardReconciliationPlanDetail[];
+  /**
+   * Caller-controlled expansion state. The primitive renders the panel and
+   * mirrors this value in `aria-expanded`; it never toggles itself.
+   */
+  expanded?: boolean;
+  /**
+   * Mark the entire row as sensitive. When true, the summary/reason are
+   * still rendered but all detail values are replaced with the redaction
+   * marker. Hosts should still avoid passing raw secrets in.
+   */
+  redacted?: boolean;
+  metadata?: OperatorVisibilityMetadata;
+}
+
+/**
+ * Reconciliation plan envelope. Hosts pre-compute the totals (keyed by
+ * canonical kind), the safety-policy assertion, and the row order.
+ */
+export interface WizardReconciliationPlan {
+  rows: WizardReconciliationPlanRow[];
+  totals: Record<WizardReconciliationPlanCanonicalKind, number>;
+  safetyPolicy: WizardSafetyPolicy;
+}
+
+/**
+ * Stable alias matching the alternate "DiffList" naming preference. Callers
+ * who think of this surface as a diff list rather than a reconciliation plan
+ * can import the alias.
+ */
+export type WizardDiffList = WizardReconciliationPlan;
+export type WizardDiffListRow = WizardReconciliationPlanRow;
+export type WizardDiffListDetail = WizardReconciliationPlanDetail;
+export type WizardDiffListOperationKind = WizardReconciliationPlanOperationKind;
+export type WizardDiffListCanonicalKind = WizardReconciliationPlanCanonicalKind;
+
+/**
+ * Resolve any operation kind (canonical or alias) to its canonical form. The
+ * primitive uses this so totals/labels/data attributes are stable regardless
+ * of which alias the host supplied.
+ */
+export function canonicalizeWizardReconciliationPlanKind(
+  kind: WizardReconciliationPlanOperationKind,
+): WizardReconciliationPlanCanonicalKind {
+  switch (kind) {
+    case 'already_satisfied':
+      return 'satisfied';
+    case 'external_step_required':
+      return 'external';
+    case 'not_requested':
+      return 'noop';
+    default:
+      return kind;
+  }
+}

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -19,6 +19,8 @@ await import('./unit/stitch-tokens.test.js');
 await import('./unit/stitch-shell.test.js');
 await import('./unit/stitch-hosted-auth.test.js');
 await import('./unit/stitch-admin.test.js');
+await import('./unit/stitch-admin-wizard.test.js');
+await import('./unit/stitch-admin-wizard-reconciliation-plan.test.js');
 await import('./unit/portal-fixtures.test.js');
 await import('./unit/antd-coverage.test.js');
 await import('./unit/portal-reference.test.js');

--- a/ts/test/unit/stitch-admin-wizard-reconciliation-plan.test.ts
+++ b/ts/test/unit/stitch-admin-wizard-reconciliation-plan.test.ts
@@ -1,0 +1,414 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as React from 'react';
+
+import { createFaceApp } from '../../src/app.js';
+import { createReactFace } from '../../src/adapters/react.js';
+import { createAntdIntegration } from '../../src/react/antd.js';
+import {
+  canonicalizeWizardReconciliationPlanKind,
+  type WizardReconciliationPlan,
+} from '../../src/stitch-admin/index.js';
+import {
+  WizardDiffListPanel,
+  WizardReconciliationPlanPanel,
+} from '../../src/react/stitch-admin/index.js';
+
+const h = React.createElement;
+
+async function renderSSR(element: React.ReactElement): Promise<string> {
+  const app = createFaceApp({
+    faces: [
+      createReactFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => element,
+        renderOptions: {
+          integrations: [createAntdIntegration({ hashed: false })],
+        },
+      }),
+    ],
+  });
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  return new TextDecoder().decode(resp.body as Uint8Array);
+}
+
+function countMatches(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Kind canonicalization                                                       */
+/* -------------------------------------------------------------------------- */
+
+test('canonicalizeWizardReconciliationPlanKind normalizes alias kinds to canonical kinds', () => {
+  assert.equal(canonicalizeWizardReconciliationPlanKind('create'), 'create');
+  assert.equal(canonicalizeWizardReconciliationPlanKind('update'), 'update');
+  assert.equal(canonicalizeWizardReconciliationPlanKind('satisfied'), 'satisfied');
+  assert.equal(canonicalizeWizardReconciliationPlanKind('already_satisfied'), 'satisfied');
+  assert.equal(canonicalizeWizardReconciliationPlanKind('conflict'), 'conflict');
+  assert.equal(canonicalizeWizardReconciliationPlanKind('blocked'), 'blocked');
+  assert.equal(canonicalizeWizardReconciliationPlanKind('external'), 'external');
+  assert.equal(canonicalizeWizardReconciliationPlanKind('external_step_required'), 'external');
+  assert.equal(canonicalizeWizardReconciliationPlanKind('noop'), 'noop');
+  assert.equal(canonicalizeWizardReconciliationPlanKind('not_requested'), 'noop');
+});
+
+/* -------------------------------------------------------------------------- */
+/* Caller-supplied state passthrough                                           */
+/* -------------------------------------------------------------------------- */
+
+test('WizardReconciliationPlanPanel renders caller-supplied rows in order with canonical + alias data attributes', async () => {
+  const plan: WizardReconciliationPlan = {
+    rows: [
+      {
+        key: 'ns',
+        label: 'Create namespace acme',
+        kind: 'create',
+        summary: 'Will create namespace acme in tenant theory-mcp',
+      },
+      {
+        key: 'agent',
+        label: 'Update agent acme',
+        kind: 'update',
+        summary: 'Bump declared capabilities',
+      },
+      {
+        key: 'binding',
+        label: 'Mailbox binding',
+        kind: 'already_satisfied',
+        summary: 'Mailbox allowlist already includes the agent',
+      },
+      {
+        key: 'github',
+        label: 'GitHub binding',
+        kind: 'conflict',
+        summary: 'Existing GitHub binding points at a different repo',
+        reason: 'Existing binding targets theory-cloud/Other; resolve before continuing.',
+      },
+      {
+        key: 'policy',
+        label: 'Enforcement policy',
+        kind: 'blocked',
+        summary: 'Awaiting operator review',
+        reason: 'Operator review record not present.',
+      },
+      {
+        key: 'secret',
+        label: 'Rotate signing secret',
+        kind: 'external_step_required',
+        summary: 'Use TheoryMCP rotation tool',
+        reason: 'Cannot rotate from this wizard; complete in the rotation tool.',
+      },
+      {
+        key: 'noop-deploy',
+        label: 'Deployment',
+        kind: 'not_requested',
+        summary: 'Deployment intentionally not part of this run',
+      },
+    ],
+    totals: {
+      create: 1,
+      update: 1,
+      satisfied: 1,
+      conflict: 1,
+      blocked: 1,
+      external: 1,
+      noop: 1,
+    },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+
+  const body = await renderSSR(h(WizardReconciliationPlanPanel, { plan }));
+
+  // Container exposes the safety policy and prominent counts.
+  assert.ok(body.includes('facetheory-stitch-wizard-reconciliation-plan'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(body.includes('data-row-count="7"'));
+  assert.ok(body.includes('data-conflict-count="1"'));
+  assert.ok(body.includes('data-blocked-count="1"'));
+  assert.ok(body.includes('data-external-count="1"'));
+
+  // Caller-supplied row order preserved.
+  const order = ['ns', 'agent', 'binding', 'github', 'policy', 'secret', 'noop-deploy'];
+  let prev = -1;
+  for (const key of order) {
+    const idx = body.indexOf(`data-row-key="${key}"`);
+    assert.ok(idx > prev, `row ${key} must appear after the previous row in SSR output`);
+    prev = idx;
+  }
+
+  // Aliases canonicalized in data-row-kind, original recorded in data-row-kind-input.
+  assert.ok(body.includes('data-row-kind="satisfied"'));
+  assert.ok(body.includes('data-row-kind-input="already_satisfied"'));
+  assert.ok(body.includes('data-row-kind="external"'));
+  assert.ok(body.includes('data-row-kind-input="external_step_required"'));
+  assert.ok(body.includes('data-row-kind="noop"'));
+  assert.ok(body.includes('data-row-kind-input="not_requested"'));
+
+  // Default status labels render when caller does not supply statusLabel.
+  assert.ok(body.includes('Will create'));
+  assert.ok(body.includes('Will update'));
+  assert.ok(body.includes('Already satisfied'));
+  assert.ok(body.includes('Conflict'));
+  assert.ok(body.includes('Blocked'));
+  assert.ok(body.includes('External step required'));
+  assert.ok(body.includes('No-op'));
+
+  // Caller-supplied reason copy renders for conflict/blocked/external.
+  assert.ok(body.includes('Existing binding targets theory-cloud/Other; resolve before continuing.'));
+  assert.ok(body.includes('Operator review record not present.'));
+  assert.ok(body.includes('Cannot rotate from this wizard; complete in the rotation tool.'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Prominent rendering for conflict/blocked/external                           */
+/* -------------------------------------------------------------------------- */
+
+test('WizardReconciliationPlanPanel marks conflict/blocked/external rows as prominent and uses role="alert"', async () => {
+  const plan: WizardReconciliationPlan = {
+    rows: [
+      { key: 'c', label: 'c', kind: 'conflict', reason: 'reason' },
+      { key: 'b', label: 'b', kind: 'blocked', reason: 'reason' },
+      { key: 'e', label: 'e', kind: 'external', reason: 'reason' },
+      { key: 's', label: 's', kind: 'satisfied' },
+      { key: 'n', label: 'n', kind: 'noop' },
+    ],
+    totals: { create: 0, update: 0, satisfied: 1, conflict: 1, blocked: 1, external: 1, noop: 1 },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+
+  const body = await renderSSR(h(WizardReconciliationPlanPanel, { plan }));
+
+  // Three prominent rows → three role="alert" entries (one per prominent row).
+  assert.equal(countMatches(body, 'role="alert"'), 3);
+  // Non-prominent rows use role="listitem" inside the role="list" ul.
+  assert.ok(body.includes('role="listitem"'));
+  // Class marker exposed for prominent rendering.
+  assert.equal(countMatches(body, 'facetheory-stitch-wizard-reconciliation-plan-row-prominent'), 3);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Accessible expand/collapse contract                                         */
+/* -------------------------------------------------------------------------- */
+
+test('WizardReconciliationPlanPanel expand/collapse uses real button + aria-expanded + aria-controls', async () => {
+  const plan: WizardReconciliationPlan = {
+    rows: [
+      {
+        key: 'expanded-row',
+        label: 'Expanded row',
+        kind: 'create',
+        statusLabel: 'Will create resource',
+        expanded: true,
+        details: [
+          { key: 'path', label: 'Path', value: '/agents/acme' },
+          { key: 'sha', label: 'Manifest sha', value: 'abc12345' },
+        ],
+      },
+      {
+        key: 'collapsed-row',
+        label: 'Collapsed row',
+        kind: 'update',
+        statusLabel: 'Will update resource',
+        expanded: false,
+        details: [{ key: 'note', label: 'Note', value: 'bump' }],
+      },
+      {
+        key: 'no-details-row',
+        label: 'No details',
+        kind: 'satisfied',
+      },
+    ],
+    totals: { create: 1, update: 1, satisfied: 1, conflict: 0, blocked: 0, external: 0, noop: 0 },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+
+  const body = await renderSSR(h(WizardReconciliationPlanPanel, { plan }));
+
+  // Real <button type="button"> elements with aria-expanded reflecting state.
+  assert.ok(body.includes('<button type="button"'));
+  assert.ok(body.includes('aria-expanded="true"'));
+  assert.ok(body.includes('aria-expanded="false"'));
+  assert.ok(body.includes('aria-controls="facetheory-wizard-plan-row-expanded-row-details"'));
+  assert.ok(body.includes('aria-controls="facetheory-wizard-plan-row-collapsed-row-details"'));
+
+  // Color-independent accessible labels.
+  assert.ok(body.includes('aria-label="Hide details for Will create resource"'));
+  assert.ok(body.includes('aria-label="Show details for Will update resource"'));
+  assert.ok(body.includes('aria-label="Status: Will create resource"'));
+
+  // Expanded row renders its detail values.
+  assert.ok(body.includes('/agents/acme'));
+  assert.ok(body.includes('abc12345'));
+
+  // Collapsed row hides the detail panel via the standard `hidden` attribute
+  // and aria-hidden="true"; expanded row uses aria-hidden="false".
+  const expandedPanelIdx = body.indexOf('id="facetheory-wizard-plan-row-expanded-row-details"');
+  assert.ok(expandedPanelIdx > -1);
+  // Slice and check the attributes on the expanded panel are not hidden.
+  const expandedPanelSnippet = body.slice(expandedPanelIdx, expandedPanelIdx + 400);
+  assert.ok(!expandedPanelSnippet.includes('hidden=""'));
+  assert.ok(expandedPanelSnippet.includes('aria-hidden="false"'));
+
+  const collapsedPanelIdx = body.indexOf('id="facetheory-wizard-plan-row-collapsed-row-details"');
+  assert.ok(collapsedPanelIdx > -1);
+  const collapsedPanelSnippet = body.slice(collapsedPanelIdx, collapsedPanelIdx + 400);
+  assert.ok(collapsedPanelSnippet.includes('hidden=""'));
+  assert.ok(collapsedPanelSnippet.includes('aria-hidden="true"'));
+
+  // Collapsed row does not render its detail content into the SSR body.
+  assert.ok(!body.includes('bump'));
+
+  // Rows without details do not render a toggle button.
+  const noDetailsRowIdx = body.indexOf('data-row-key="no-details-row"');
+  const noDetailsRowSnippet = body.slice(noDetailsRowIdx, noDetailsRowIdx + 1200);
+  assert.ok(!noDetailsRowSnippet.includes('data-row-toggle-key='));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Redaction levers                                                            */
+/* -------------------------------------------------------------------------- */
+
+test('WizardReconciliationPlanPanel replaces detail values with redaction marker when row or detail is redacted', async () => {
+  const plan: WizardReconciliationPlan = {
+    rows: [
+      {
+        key: 'public-row',
+        label: 'Public values',
+        kind: 'update',
+        expanded: true,
+        details: [
+          { key: 'public', label: 'Public', value: 'visible-value' },
+          { key: 'sensitive', label: 'Sensitive', value: 'should-not-appear', redacted: true },
+        ],
+      },
+      {
+        key: 'redacted-row',
+        label: 'All-redacted row',
+        kind: 'update',
+        redacted: true,
+        expanded: true,
+        details: [
+          { key: 'a', label: 'A', value: 'never-shown-a' },
+          { key: 'b', label: 'B', value: 'never-shown-b' },
+        ],
+      },
+    ],
+    totals: { create: 0, update: 2, satisfied: 0, conflict: 0, blocked: 0, external: 0, noop: 0 },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+
+  const body = await renderSSR(h(WizardReconciliationPlanPanel, { plan }));
+
+  // Public value renders verbatim; sensitive raw value never appears.
+  assert.ok(body.includes('visible-value'));
+  assert.ok(!body.includes('should-not-appear'));
+  // Row-level redaction hides every detail value.
+  assert.ok(!body.includes('never-shown-a'));
+  assert.ok(!body.includes('never-shown-b'));
+  // Three redactions: one detail-level (sensitive) + two row-level (a, b).
+  assert.equal(countMatches(body, '[redacted]'), 3);
+  // data-detail-redacted attribute reflects the lever.
+  assert.ok(body.includes('data-detail-redacted="true"'));
+  // Row-level redacted marker.
+  assert.ok(body.includes('data-row-redacted="true"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Stable per-kind counts                                                      */
+/* -------------------------------------------------------------------------- */
+
+test('WizardReconciliationPlanPanel renders caller-supplied per-kind counts verbatim', async () => {
+  const plan: WizardReconciliationPlan = {
+    rows: [
+      { key: 'c1', label: 'c1', kind: 'create' },
+      { key: 'c2', label: 'c2', kind: 'create' },
+      { key: 'u1', label: 'u1', kind: 'update' },
+    ],
+    totals: {
+      create: 2,
+      update: 1,
+      satisfied: 5,
+      conflict: 7,
+      blocked: 9,
+      external: 11,
+      noop: 13,
+    },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+
+  const body = await renderSSR(h(WizardReconciliationPlanPanel, { plan }));
+
+  assert.ok(body.includes('Will create: 2'));
+  assert.ok(body.includes('Will update: 1'));
+  assert.ok(body.includes('Already satisfied: 5'));
+  assert.ok(body.includes('Conflict: 7'));
+  assert.ok(body.includes('Blocked: 9'));
+  assert.ok(body.includes('External step required: 11'));
+  assert.ok(body.includes('No-op: 13'));
+  // data-kind-count attributes also reflect caller totals exactly.
+  assert.ok(body.includes('data-kind-summary="conflict"'));
+  assert.ok(body.includes('data-kind-count="7"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Determinism: byte-identical SSR for the same input                          */
+/* -------------------------------------------------------------------------- */
+
+test('WizardReconciliationPlanPanel produces byte-identical SSR output for the same input', async () => {
+  const plan: WizardReconciliationPlan = {
+    rows: [
+      {
+        key: 'a',
+        label: 'a',
+        kind: 'create',
+        details: [{ key: 'd', label: 'd', value: 'v' }],
+        expanded: true,
+      },
+      { key: 'b', label: 'b', kind: 'conflict', reason: 'because' },
+      { key: 'c', label: 'c', kind: 'noop' },
+    ],
+    totals: { create: 1, update: 0, satisfied: 0, conflict: 1, blocked: 0, external: 0, noop: 1 },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+
+  const first = await renderSSR(h(WizardReconciliationPlanPanel, { plan }));
+  const second = await renderSSR(h(WizardReconciliationPlanPanel, { plan }));
+  assert.equal(first, second, 'WizardReconciliationPlanPanel must produce byte-identical SSR output');
+});
+
+/* -------------------------------------------------------------------------- */
+/* WizardDiffListPanel alias                                                   */
+/* -------------------------------------------------------------------------- */
+
+test('WizardDiffListPanel alias renders the same DOM as WizardReconciliationPlanPanel', async () => {
+  const plan: WizardReconciliationPlan = {
+    rows: [{ key: 'k', label: 'label', kind: 'update' }],
+    totals: { create: 0, update: 1, satisfied: 0, conflict: 0, blocked: 0, external: 0, noop: 0 },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const canonical = await renderSSR(h(WizardReconciliationPlanPanel, { plan }));
+  const alias = await renderSSR(h(WizardDiffListPanel, { plan }));
+  assert.equal(canonical, alias, 'WizardDiffListPanel must render identically to WizardReconciliationPlanPanel');
+});
+
+/* -------------------------------------------------------------------------- */
+/* Empty plan                                                                  */
+/* -------------------------------------------------------------------------- */
+
+test('WizardReconciliationPlanPanel renders the empty state when no rows are supplied', async () => {
+  const plan: WizardReconciliationPlan = {
+    rows: [],
+    totals: { create: 0, update: 0, satisfied: 0, conflict: 0, blocked: 0, external: 0, noop: 0 },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(
+    h(WizardReconciliationPlanPanel, { plan, emptyLabel: 'No reconciliation needed' }),
+  );
+  assert.ok(body.includes('facetheory-stitch-wizard-reconciliation-plan-empty'));
+  assert.ok(body.includes('No reconciliation needed'));
+  assert.ok(!body.includes('facetheory-stitch-wizard-reconciliation-plan-row '));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});


### PR DESCRIPTION
## Milestone

Factory assignment **THE-1448 / APW-FT2** (`facetheory-component-requests` ReconciliationPlan / DiffList) for the TheoryMCP Agent Import & Completion Wizard project.

- Linear issue: https://linear.app/theorycloud/issue/THE-1448
- Project: TheoryMCP Agent Import & Completion Wizard
- PR target: `project/theorymcp-agent-import-completion-wizard-20260521` (NOT `staging`)
- Project branch base: `project/theorymcp-agent-import-completion-wizard-20260521` @ `77abf7449b0054d179c827b1e943080479a5041b` (THE-1458 merge SHA)
- Milestone branch: `facetheory/agent-import-wizard-reconciliation-plan`
- Head commit: `cbc7512e428b072a8745862c4c1caff9ddfaf417` (signed)

## What changed

Add `WizardReconciliationPlan` (alias `WizardDiffList`) as the richer cousin of the existing `WizardReconcileSummary`. Where the reconcile summary describes a before/after diff (`added` / `removed` / `changed` / `unchanged` / `redacted`), the reconciliation plan describes the plan the wizard intends to execute next, with the seven operation kinds Factory called out: `create`, `update`, `satisfied` (alias `already_satisfied`), `conflict`, `blocked`, `external` (alias `external_step_required`), and `noop` (alias `not_requested`).

### Framework-neutral types (`ts/src/stitch-admin/wizard-reconciliation-plan-types.ts`)

- `WizardReconciliationPlan` / `WizardReconciliationPlanRow` / `WizardReconciliationPlanDetail`
- `WizardReconciliationPlanOperationKind` (canonical + alias) and `WizardReconciliationPlanCanonicalKind`
- `canonicalizeWizardReconciliationPlanKind(kind)` helper — alias → canonical
- `WizardDiffList*` aliases for callers who prefer the diff-list naming

### React adapter (`ts/src/react/stitch-admin/wizard-reconciliation-plan.ts`)

- `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel` — same component)
- Renders host-supplied rows only. No `Math.random()`, no `Date.now()`, no `window` reads at render time. The primitive never decides safety, permissions, destructive classification, route authority, GitHub/email validity, or external completion.
- `conflict`, `blocked`, and `external` rows get prominent visual treatment plus `role="alert"` so they are announced.
- Redaction enforced at render time at both the detail level (`WizardReconciliationPlanDetail.redacted`) and the row level (`WizardReconciliationPlanRow.redacted`): values render as `[redacted]` and never leak raw content.
- Safety policy literal `no-secret-or-production-like-data` rendered both via `data-safety-policy` and a footnote.

### Accessible expand/collapse contract

When a row carries `details`, the primitive renders an expand/collapse affordance:

- Real `<button type="button">` toggle (keyboard-operable, focusable by default).
- `aria-expanded` mirrors `row.expanded` exactly — the primitive never toggles itself; hosts wire `onToggleRow(rowKey, nextExpanded)` to update their own state.
- `aria-controls` points at the detail panel id; the detail panel uses `role="region"` and the standard `hidden` attribute when collapsed.
- Toggle `aria-label` is text — "Show details for &lt;status label&gt;" / "Hide details for &lt;status label&gt;" — so screen-readers and high-contrast viewers see the same information independent of color.
- Status badge exposes its label via `aria-label="Status: …"`.

### Tests (`ts/test/unit/stitch-admin-wizard-reconciliation-plan.test.ts`)

9 new unit tests covering: kind canonicalization, caller-supplied row order with canonical/alias data attributes, default + supplied status labels, conflict/blocked/external prominence + `role="alert"`, accessible expand/collapse (real button + aria-expanded + aria-controls + hidden panel), redaction levers and marker counts, caller-supplied per-kind counts rendered verbatim, byte-identical SSR determinism on repeated renders, the `WizardDiffListPanel` alias rendering identically, and the empty plan state.

### Test discovery fix (`ts/test/run-unit.ts`)

Registered the previously-orphaned wizard test files: both `stitch-admin-wizard.test.ts` (12 tests, landed via THE-1458) and the new `stitch-admin-wizard-reconciliation-plan.test.ts` (9 tests). `npm test` now reports **338 tests / 337 pass / 1 skip** (vs the 317 pre-fix number where neither wizard suite was being executed). This is a real fix: the THE-1458 wizard tests were silently never running through the project-branch test command, so wizard regressions could have slipped through.

### Docs (`docs/wizard-primitives.md`)

- Reconciliation plan added to the primitives table.
- New "When to use `WizardReconciliationPlanPanel` vs `WizardReconcileSummaryPanel`" section with the canonical-kind / alias table.
- Accessible expand/collapse contract documented.
- Redaction levers and the safety-policy literal documented.
- Worked TheoryMCP integration example.

## Validation

Run from the repo root against PR head `cbc7512e428b072a8745862c4c1caff9ddfaf417`.

- `git diff --check origin/project/theorymcp-agent-import-completion-wizard-20260521...HEAD` — clean
- `scripts/verify-version-alignment.sh` → `version-alignment: PASS (3.2.1)`
- `cd ts && npm ci` — clean (one pre-existing moderate `brace-expansion` finding on the base branch, unchanged here)
- `cd ts && npm run typecheck` — pass
- `cd ts && npm run lint` — pass
- `cd ts && npm test` → **`tests 338 / pass 337 / fail 0 / skipped 1`** (was 317 before this milestone's test-discovery fix; +12 THE-1458 wizard tests that were orphaned + +9 new THE-1448 tests)
- `cd ts && npm run build` — pass
- `scripts/pack-dev-archive.sh --output-dir /tmp/theorycloud-facetheory-dev-archives` — produces the archive plus `.sha256` sidecar; success message prints a directly-usable verify command.
- `( cd /tmp/theorycloud-facetheory-dev-archives && sha256sum --check theory-cloud-facetheory-3.2.1-dev-cbc7512e428b.tgz.sha256 )` → `theory-cloud-facetheory-3.2.1-dev-cbc7512e428b.tgz: OK`
- `make rubric` — passes `version-alignment` + `ts-pack` stages; fails ONLY on the pre-existing `npm-audit: brace-expansion (severity=moderate)` finding present identically on the project base branch (this PR does not change `ts/package-lock.json`). Recommend tracking as a separate dependency-freshness milestone.

## Temporary local archive handoff

- Command: `scripts/pack-dev-archive.sh --output-dir /tmp/theorycloud-facetheory-dev-archives`
- Default output dir: `/tmp/theorycloud-facetheory-dev-archives/`
- Archive basename (from PR head `cbc7512`): `theory-cloud-facetheory-3.2.1-dev-cbc7512e428b.tgz`
- sha256: `9b211d69b66a46d7bd751c19d7d4b53c50cc8ba2b4542a6270c5dd158c76c758`
- Verify (works from any cwd):
  ```bash
  ( cd /tmp/theorycloud-facetheory-dev-archives \
      && sha256sum --check theory-cloud-facetheory-3.2.1-dev-cbc7512e428b.tgz.sha256 )
  ```
- Verify output: `theory-cloud-facetheory-3.2.1-dev-cbc7512e428b.tgz: OK`

## Safety / scope confirmation

- No release, npm publish, Release Please PR, version bump, tag creation, or release-asset publication.
- No AWS/cloud/account/DNS/IAM mutation. No deploy. No smoke-test gate.
- No live/customer-data fixtures. No secrets. No live receipts.
- No TheoryMCP, KnowledgeTheory, framework parent, or sibling repo edits.
- No git worktrees; normal checkout only.
- PR targets the dedicated project branch, not `staging`.

## Residual risks / blockers

- `make rubric` blocked on the pre-existing `brace-expansion` npm-audit moderate finding present on the project base branch; this PR does not change `ts/package-lock.json`.
- No other open blockers.

## Files

- `ts/src/stitch-admin/wizard-reconciliation-plan-types.ts` (new)
- `ts/src/stitch-admin/index.ts` (re-export new types + helper)
- `ts/src/react/stitch-admin/wizard-reconciliation-plan.ts` (new)
- `ts/src/react/stitch-admin/index.ts` (re-export new component + alias)
- `ts/test/unit/stitch-admin-wizard-reconciliation-plan.test.ts` (new, 9 tests)
- `ts/test/run-unit.ts` (register orphaned wizard test files; +12 + +9 newly-running)
- `docs/wizard-primitives.md` (reconciliation plan section, kinds table, accessible expand/collapse contract, redaction levers, integration example)

Refs: THE-1448 (APW-FT2)