### PR TITLE
feat(stitch-admin): add wizard authority/context strip primitive

### DIFF
--- a/docs/wizard-primitives.md
+++ b/docs/wizard-primitives.md
@@ -25,7 +25,7 @@ primitive twice and asserting byte-identical SSR output.
 | Layer | Module | What it exports |
 | --- | --- | --- |
 | Framework-neutral types | `@theory-cloud/facetheory/stitch-admin` | `WizardProgressState`, `WizardPackageSummary`, `WizardFindingList`, `WizardReconcileSummary`, `WizardCapabilityReview`, `WizardEnablementChecklist`, `WizardRecoveryStatus`, `WizardEmptyStateConfig`, `WizardSafetyPolicy`, and supporting enums. |
-| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
+| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
 
 Vue and Svelte adapter parity is intentionally deferred for this milestone.
 The TheoryMCP control plane that consumes these primitives today is React; the
@@ -125,6 +125,114 @@ the wizard contracts. Two levers, both enforced at render time:
 
 The row's safety policy literal is still required and is still rendered into
 the DOM (`data-safety-policy`, plus the footnote).
+
+## Authority / server-resolved context strip
+
+`WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`)
+is the read-only context header that the TheoryMCP control plane renders above
+wizard content — the "tenant / namespace / MCP route / operator / partner /
+agent scope" surface.
+
+### Trust boundary
+
+This is the most security-relevant primitive in the wizard set, so the trust
+boundary is restated explicitly:
+
+- FaceTheory **never** resolves, verifies, derives, or validates tenant,
+  namespace, operator, MCP route, partner, agent, account, entitlement,
+  mailbox, GitHub, or authority state.
+- FaceTheory **never** enforces read-only. The read-only label (when
+  supplied) is informational text — it does not lock anything.
+- FaceTheory **never** invents copy payloads. Copyable cells use
+  `item.copyValue` if supplied, otherwise the rendered string `item.value`
+  verbatim. The host pre-resolves whatever should be copied.
+
+### Item contract
+
+Each item is a label/value cell:
+
+```ts
+interface WizardAuthorityContextItem {
+  key: string;
+  label: unknown;
+  value: unknown;
+  icon?: unknown;
+  badge?: unknown;
+  tone?: 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+  copyable?: boolean;
+  copyValue?: string;
+  title?: string;
+  href?: string;
+}
+```
+
+The cell renders as a real `<dt>` / `<dd>` pair so screen-readers read the
+pairing, and `href` is filtered through the Stitch admin safe-href filter
+(unsafe schemes like `javascript:` are dropped at render).
+
+### Layout matrix
+
+`layout` controls how items are arranged:
+
+| Value    | Behavior                                                                                            |
+| -------- | --------------------------------------------------------------------------------------------------- |
+| `strip`  | Single horizontal row. `wrap` controls whether items wrap (`true`, default) or scroll (`false`).    |
+| `grid`   | CSS Grid `auto-fit, minmax(220px, 1fr)`. Items reflow as the container narrows.                     |
+| `stack`  | Vertical stack — preferred in narrow admin sidebars.                                                |
+| `auto`   | Default. CSS-only responsive grid that stacks on narrow viewports **without hiding any cell**.      |
+
+Layout is implemented in inline CSS (no media queries inside the component,
+no JavaScript layout), so SSR output and hydrated DOM are byte-identical.
+
+### Copyable cells
+
+When `item.copyable` is `true` and a string copy payload is available, the
+component renders a real keyboard-accessible button:
+
+- `<button type="button">` (focusable by default, keyboard-operable)
+- `aria-label="Copy <label>"` so screen-readers announce the action
+- `data-copy-value="<host-supplied>"` carries the deterministic payload
+- An optional `onCopyItem(itemKey, copyValue)` prop performs the clipboard
+  write; if it's omitted, the markup still renders deterministically and the
+  host is expected to wire the action itself (e.g. via global delegation).
+
+The component never resolves what to copy; the host is the authority.
+
+### Read-only / authority cues
+
+Both cues render as **text**, not color-only:
+
+- `authorityLabel` (e.g. `"Server-derived"`, `"Autheory session"`,
+  `"Route-resolved"`) renders in the header with its own
+  `data-authority-label="true"`.
+- `readOnlyLabel` (e.g. `"Read-only"`) renders in the header with
+  `data-read-only-label="true"` and an explicit `aria-label`.
+
+The component does not imply enforcement. It is a presentational primitive;
+authority and read-only state come from the host.
+
+### Example
+
+```tsx
+<WizardAuthorityContextStripPanel
+  strip={{
+    items: [
+      { key: 'tenant', label: 'Tenant', value: 'theory-mcp' },
+      { key: 'namespace', label: 'Namespace', value: 'acme', tone: 'info' },
+      { key: 'route', label: 'MCP route', value: '/agents/acme',
+        copyable: true, copyValue: '/agents/acme' },
+      { key: 'operator', label: 'Operator', value: 'aron@equal-to.ai',
+        badge: 'session' },
+    ],
+    authorityLabel: 'Server-derived',
+    readOnlyLabel: 'Read-only',
+    layout: 'auto',
+    size: 'md',
+    safetyPolicy: 'no-secret-or-production-like-data',
+  }}
+  onCopyItem={(itemKey, value) => host.copyToClipboard(itemKey, value)}
+/>
+```
 
 ## Consuming the primitives from TheoryMCP
 

--- a/ts/src/react/stitch-admin/index.ts
+++ b/ts/src/react/stitch-admin/index.ts
@@ -146,3 +146,20 @@ export {
   type WizardReconciliationPlanOperationKind,
   type WizardReconciliationPlanRow,
 } from './wizard-reconciliation-plan.js';
+
+export {
+  WizardAuthorityContextStripPanel,
+  WizardServerResolvedContextBarPanel,
+  type WizardAuthorityContextStripPanelProps,
+  type WizardServerResolvedContextBarPanelProps,
+  type WizardAuthorityContextItem,
+  type WizardAuthorityContextItemTone,
+  type WizardAuthorityContextStrip,
+  type WizardAuthorityContextStripLayout,
+  type WizardAuthorityContextStripSize,
+  type WizardServerResolvedContextBar,
+  type WizardServerResolvedContextBarItem,
+  type WizardServerResolvedContextBarLayout,
+  type WizardServerResolvedContextBarSize,
+  type WizardServerResolvedContextBarTone,
+} from './wizard-authority-context-strip.js';

--- a/ts/src/react/stitch-admin/wizard-authority-context-strip.ts
+++ b/ts/src/react/stitch-admin/wizard-authority-context-strip.ts
@@ -1,0 +1,561 @@
+import * as React from 'react';
+
+import { safeMetadataHref } from '../../stitch-admin/safe-url.js';
+import type {
+  WizardAuthorityContextItem,
+  WizardAuthorityContextItemTone,
+  WizardAuthorityContextStrip,
+  WizardAuthorityContextStripLayout,
+  WizardAuthorityContextStripSize,
+  WizardServerResolvedContextBar,
+  WizardServerResolvedContextBarItem,
+  WizardServerResolvedContextBarLayout,
+  WizardServerResolvedContextBarSize,
+  WizardServerResolvedContextBarTone,
+} from '../../stitch-admin/wizard-authority-context-strip-types.js';
+import type { WizardSafetyPolicy } from '../../stitch-admin/wizard-types.js';
+
+const h = React.createElement;
+
+export type {
+  WizardAuthorityContextItem,
+  WizardAuthorityContextItemTone,
+  WizardAuthorityContextStrip,
+  WizardAuthorityContextStripLayout,
+  WizardAuthorityContextStripSize,
+  WizardServerResolvedContextBar,
+  WizardServerResolvedContextBarItem,
+  WizardServerResolvedContextBarLayout,
+  WizardServerResolvedContextBarSize,
+  WizardServerResolvedContextBarTone,
+};
+
+interface TonePalette {
+  background: string;
+  color: string;
+  border: string;
+}
+
+const TONE_PALETTE: Record<WizardAuthorityContextItemTone, TonePalette> = {
+  neutral: {
+    background: 'var(--stitch-color-surface-container, #eaedff)',
+    color: 'var(--stitch-color-on-surface, #131b2e)',
+    border: 'var(--stitch-color-outline-variant, #c6c5d0)',
+  },
+  info: {
+    background: 'var(--stitch-color-primary-container, #e0e0ff)',
+    color: 'var(--stitch-color-on-primary-container, #000066)',
+    border: 'var(--stitch-color-primary-container, #e0e0ff)',
+  },
+  success: {
+    background: 'var(--stitch-color-tertiary-container, #004c45)',
+    color: 'var(--stitch-color-on-tertiary-container, #52c1b4)',
+    border: 'var(--stitch-color-tertiary-container, #004c45)',
+  },
+  warning: {
+    background: 'var(--stitch-color-secondary-container, #ffecc0)',
+    color: 'var(--stitch-color-on-secondary-container, #3f2e00)',
+    border: 'var(--stitch-color-secondary-container, #ffecc0)',
+  },
+  danger: {
+    background: 'var(--stitch-color-error-container, #ffdad6)',
+    color: 'var(--stitch-color-on-error-container, #93000a)',
+    border: 'var(--stitch-color-error-container, #ffdad6)',
+  },
+};
+
+interface SizeTokens {
+  itemPadding: string;
+  itemGap: string;
+  labelFontSize: string;
+  valueFontSize: string;
+  stripGap: string;
+  stripPadding: string;
+  borderRadius: string;
+}
+
+const SIZE_TOKENS: Record<WizardAuthorityContextStripSize, SizeTokens> = {
+  sm: {
+    itemPadding: '6px 10px',
+    itemGap: '4px',
+    labelFontSize: '10px',
+    valueFontSize: '12px',
+    stripGap: '6px',
+    stripPadding: '10px',
+    borderRadius: 'var(--stitch-radius-sm, 8px)',
+  },
+  md: {
+    itemPadding: '8px 12px',
+    itemGap: '4px',
+    labelFontSize: '11px',
+    valueFontSize: '13px',
+    stripGap: '8px',
+    stripPadding: '12px',
+    borderRadius: 'var(--stitch-radius-md, 10px)',
+  },
+  lg: {
+    itemPadding: '10px 14px',
+    itemGap: '6px',
+    labelFontSize: '12px',
+    valueFontSize: '14px',
+    stripGap: '10px',
+    stripPadding: '14px',
+    borderRadius: 'var(--stitch-radius-md, 10px)',
+  },
+};
+
+export interface WizardAuthorityContextStripPanelProps {
+  /** Section heading. Adapter narrows to its native node type. Defaults are deterministic. */
+  title?: React.ReactNode;
+  /** Optional descriptive copy. */
+  description?: React.ReactNode;
+  strip: WizardAuthorityContextStrip;
+  /**
+   * Optional caller-supplied copy callback. Fired with `(itemKey, copyValue)`
+   * when the user activates the cell's "Copy" button. If omitted, the button
+   * still renders with deterministic markup so SSR and hydration match, but
+   * it performs no clipboard write — the host is responsible for wiring the
+   * action. The primitive does not invent or resolve copy payloads.
+   */
+  onCopyItem?: (itemKey: string, copyValue: string) => void;
+}
+
+/**
+ * Presentational read-only authority/context strip for wizard surfaces.
+ *
+ * Trust boundary (load-bearing):
+ *
+ *   - The primitive never resolves tenant, namespace, MCP route, operator,
+ *     partner, agent, account, entitlement, mailbox, GitHub, or authority
+ *     state.
+ *   - The primitive never enforces read-only; the read-only label (when
+ *     provided) is informational text.
+ *   - The primitive never invents copy payloads; copyable cells use
+ *     `item.copyValue` or, when absent and `item.value` is a string, the
+ *     string value verbatim.
+ *
+ * Accessibility:
+ *
+ *   - Each cell carries `<dt>` (label) and `<dd>` (value) so screen-readers
+ *     read the pairing.
+ *   - The optional authority label and read-only label are text — not
+ *     color or icon only.
+ *   - Copy buttons are real `<button type="button">` elements with an
+ *     explicit `aria-label="Copy <label>"` and a `data-copy-value` payload
+ *     supplied by the host.
+ *   - Layout is CSS-only and stacks responsively under `auto` without
+ *     hiding any label/value context.
+ */
+export function WizardAuthorityContextStripPanel(
+  props: WizardAuthorityContextStripPanelProps,
+): React.ReactElement {
+  const { title, description, strip, onCopyItem } = props;
+  const layout: WizardAuthorityContextStripLayout = strip.layout ?? 'auto';
+  const size: WizardAuthorityContextStripSize = strip.size ?? 'md';
+  const sizeTokens = SIZE_TOKENS[size];
+  const wrap = strip.wrap !== false;
+  const itemCount = strip.items.length;
+
+  return h(
+    'section',
+    {
+      className: `facetheory-stitch-wizard-authority-context-strip facetheory-stitch-wizard-authority-context-strip-layout-${layout} facetheory-stitch-wizard-authority-context-strip-size-${size}`,
+      'data-safety-policy': strip.safetyPolicy,
+      'data-layout': layout,
+      'data-size': size,
+      'data-wrap': wrap ? 'true' : 'false',
+      'data-item-count': String(itemCount),
+      'data-read-only': strip.readOnlyLabel !== undefined ? 'true' : 'false',
+      'data-has-authority-label': strip.authorityLabel !== undefined ? 'true' : 'false',
+      role: 'region',
+      'aria-label':
+        typeof title === 'string'
+          ? title
+          : 'Server-resolved context',
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+        padding: sizeTokens.stripPadding,
+        borderRadius: 'var(--stitch-radius-lg, 12px)',
+        background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+      },
+    },
+    renderHeader(title, description, strip, sizeTokens),
+    itemCount > 0
+      ? renderItems(strip, layout, sizeTokens, wrap, onCopyItem)
+      : renderEmpty(strip.emptyLabel),
+    renderSafetyFootnote(strip.safetyPolicy),
+  );
+}
+
+/** Stable alias for callers who prefer the "ServerResolvedContextBar" naming. */
+export const WizardServerResolvedContextBarPanel = WizardAuthorityContextStripPanel;
+export type WizardServerResolvedContextBarPanelProps = WizardAuthorityContextStripPanelProps;
+
+function renderHeader(
+  title: React.ReactNode | undefined,
+  description: React.ReactNode | undefined,
+  strip: WizardAuthorityContextStrip,
+  sizeTokens: SizeTokens,
+): React.ReactElement | null {
+  const hasTitle = title !== undefined;
+  const hasDescription = description !== undefined;
+  const hasAuthority = strip.authorityLabel !== undefined;
+  const hasReadOnly = strip.readOnlyLabel !== undefined;
+  const hasActions = strip.actions !== undefined;
+
+  if (!hasTitle && !hasDescription && !hasAuthority && !hasReadOnly && !hasActions) {
+    return null;
+  }
+
+  return h(
+    'header',
+    {
+      className: 'facetheory-stitch-wizard-authority-context-strip-header',
+      style: {
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        gap: '12px',
+        flexWrap: 'wrap',
+      },
+    },
+    h(
+      'div',
+      { style: { display: 'flex', flexDirection: 'column', gap: '4px', minWidth: 0 } },
+      hasTitle
+        ? h(
+            'h2',
+            { style: { margin: 0, fontSize: '14px', lineHeight: 1.4 } },
+            title as React.ReactNode,
+          )
+        : null,
+      hasDescription
+        ? h(
+            'p',
+            {
+              style: {
+                margin: 0,
+                fontSize: '12px',
+                lineHeight: 1.5,
+                color: 'var(--stitch-color-on-surface-variant, #464553)',
+              },
+            },
+            description,
+          )
+        : null,
+      hasAuthority || hasReadOnly
+        ? h(
+            'div',
+            {
+              className: 'facetheory-stitch-wizard-authority-context-strip-status',
+              style: {
+                display: 'inline-flex',
+                gap: '8px',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                marginTop: hasTitle || hasDescription ? '2px' : 0,
+                fontSize: sizeTokens.labelFontSize,
+                fontWeight: 600,
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase',
+                color: 'var(--stitch-color-on-surface-variant, #464553)',
+              },
+            },
+            hasAuthority
+              ? h(
+                  'span',
+                  {
+                    className: 'facetheory-stitch-wizard-authority-context-strip-authority',
+                    'data-authority-label': 'true',
+                  },
+                  strip.authorityLabel as React.ReactNode,
+                )
+              : null,
+            hasReadOnly
+              ? h(
+                  'span',
+                  {
+                    className: 'facetheory-stitch-wizard-authority-context-strip-readonly',
+                    'data-read-only-label': 'true',
+                    'aria-label': 'Read-only',
+                  },
+                  strip.readOnlyLabel as React.ReactNode,
+                )
+              : null,
+          )
+        : null,
+    ),
+    hasActions
+      ? h(
+          'div',
+          {
+            className: 'facetheory-stitch-wizard-authority-context-strip-actions',
+            style: { display: 'flex', gap: '8px', flexWrap: 'wrap' },
+          },
+          strip.actions as React.ReactNode,
+        )
+      : null,
+  );
+}
+
+function renderItems(
+  strip: WizardAuthorityContextStrip,
+  layout: WizardAuthorityContextStripLayout,
+  sizeTokens: SizeTokens,
+  wrap: boolean,
+  onCopyItem: WizardAuthorityContextStripPanelProps['onCopyItem'],
+): React.ReactElement {
+  const containerStyle = layoutContainerStyle(layout, sizeTokens, wrap);
+  return h(
+    'dl',
+    {
+      className: 'facetheory-stitch-wizard-authority-context-strip-items',
+      style: { margin: 0, padding: 0, ...containerStyle },
+    },
+    strip.items.map((item) => renderItem(item, sizeTokens, onCopyItem)),
+  );
+}
+
+function layoutContainerStyle(
+  layout: WizardAuthorityContextStripLayout,
+  sizeTokens: SizeTokens,
+  wrap: boolean,
+): React.CSSProperties {
+  switch (layout) {
+    case 'grid':
+      return {
+        display: 'grid',
+        gap: sizeTokens.stripGap,
+        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+      };
+    case 'stack':
+      return {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: sizeTokens.stripGap,
+      };
+    case 'strip':
+      return {
+        display: 'flex',
+        flexDirection: 'row',
+        gap: sizeTokens.stripGap,
+        flexWrap: wrap ? 'wrap' : 'nowrap',
+        overflowX: wrap ? 'visible' : 'auto',
+      };
+    case 'auto':
+    default:
+      // CSS-only responsive: auto-fit grid stacks naturally on narrow viewports
+      // without hiding any label/value context.
+      return {
+        display: 'grid',
+        gap: sizeTokens.stripGap,
+        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+      };
+  }
+}
+
+function renderItem(
+  item: WizardAuthorityContextItem,
+  sizeTokens: SizeTokens,
+  onCopyItem: WizardAuthorityContextStripPanelProps['onCopyItem'],
+): React.ReactElement {
+  const tone = item.tone ?? 'neutral';
+  const palette = TONE_PALETTE[tone];
+  const valueString =
+    item.copyValue !== undefined
+      ? item.copyValue
+      : typeof item.value === 'string'
+        ? item.value
+        : undefined;
+  const showCopy = item.copyable === true && valueString !== undefined;
+  const safeHref = safeMetadataHref(item.href);
+
+  return h(
+    'div',
+    {
+      key: item.key,
+      className: `facetheory-stitch-wizard-authority-context-strip-item facetheory-stitch-wizard-authority-context-strip-item-tone-${tone}`,
+      'data-item-key': item.key,
+      'data-item-tone': tone,
+      'data-item-copyable': showCopy ? 'true' : 'false',
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: sizeTokens.itemGap,
+        padding: sizeTokens.itemPadding,
+        borderRadius: sizeTokens.borderRadius,
+        background: palette.background,
+        color: palette.color,
+        border: `1px solid ${palette.border}`,
+        minWidth: 0,
+      },
+    },
+    h(
+      'dt',
+      {
+        className: 'facetheory-stitch-wizard-authority-context-strip-item-label',
+        style: {
+          margin: 0,
+          fontSize: sizeTokens.labelFontSize,
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: 'var(--stitch-color-on-surface-variant, #464553)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+        },
+      },
+      item.icon !== undefined
+        ? h(
+            'span',
+            {
+              className: 'facetheory-stitch-wizard-authority-context-strip-item-icon',
+              'aria-hidden': 'true',
+            },
+            item.icon as React.ReactNode,
+          )
+        : null,
+      h(
+        'span',
+        { className: 'facetheory-stitch-wizard-authority-context-strip-item-label-text' },
+        item.label as React.ReactNode,
+      ),
+      item.badge !== undefined
+        ? h(
+            'span',
+            {
+              className: 'facetheory-stitch-wizard-authority-context-strip-item-badge',
+              style: {
+                fontSize: '10px',
+                fontWeight: 600,
+                padding: '1px 6px',
+                borderRadius: '9999px',
+                background: 'var(--stitch-color-surface-container-high, #e2e7ff)',
+                color: 'var(--stitch-color-on-surface, #131b2e)',
+                marginLeft: '2px',
+              },
+            },
+            item.badge as React.ReactNode,
+          )
+        : null,
+    ),
+    h(
+      'dd',
+      {
+        className: 'facetheory-stitch-wizard-authority-context-strip-item-value',
+        title: item.title,
+        style: {
+          margin: 0,
+          fontSize: sizeTokens.valueFontSize,
+          lineHeight: 1.4,
+          color: 'var(--stitch-color-on-surface, #131b2e)',
+          fontFamily: 'var(--stitch-font-label, ui-monospace, SFMono-Regular, Menlo, monospace)',
+          overflowWrap: 'anywhere',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          minWidth: 0,
+        },
+      },
+      safeHref !== undefined
+        ? h(
+            'a',
+            {
+              href: safeHref,
+              className: 'facetheory-stitch-wizard-authority-context-strip-item-value-link',
+              style: { color: 'inherit', overflowWrap: 'anywhere' },
+            },
+            item.value as React.ReactNode,
+          )
+        : h(
+            'span',
+            {
+              className: 'facetheory-stitch-wizard-authority-context-strip-item-value-text',
+              style: { overflowWrap: 'anywhere' },
+            },
+            item.value as React.ReactNode,
+          ),
+      showCopy && valueString !== undefined
+        ? renderCopyButton(item, valueString, onCopyItem)
+        : null,
+    ),
+  );
+}
+
+function renderCopyButton(
+  item: WizardAuthorityContextItem,
+  copyValue: string,
+  onCopyItem: WizardAuthorityContextStripPanelProps['onCopyItem'],
+): React.ReactElement {
+  const labelString =
+    typeof item.label === 'string' ? item.label : `item ${item.key}`;
+  return h(
+    'button',
+    {
+      type: 'button',
+      className: 'facetheory-stitch-wizard-authority-context-strip-item-copy',
+      'aria-label': `Copy ${labelString}`,
+      'data-copy-item-key': item.key,
+      'data-copy-value': copyValue,
+      onClick:
+        onCopyItem !== undefined
+          ? () => onCopyItem(item.key, copyValue)
+          : undefined,
+      style: {
+        appearance: 'none',
+        background: 'transparent',
+        border: '1px solid var(--stitch-color-outline-variant, #c6c5d0)',
+        borderRadius: 'var(--stitch-radius-sm, 8px)',
+        padding: '2px 8px',
+        fontSize: '11px',
+        fontWeight: 600,
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+        cursor: onCopyItem !== undefined ? 'pointer' : 'default',
+        whiteSpace: 'nowrap',
+      },
+    },
+    'Copy',
+  );
+}
+
+function renderEmpty(emptyLabel: unknown): React.ReactElement {
+  return h(
+    'div',
+    {
+      className: 'facetheory-stitch-wizard-authority-context-strip-empty',
+      role: 'status',
+      style: {
+        padding: '12px',
+        borderRadius: 'var(--stitch-radius-md, 10px)',
+        background: 'var(--stitch-color-surface-container, #eaedff)',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+        fontSize: '13px',
+      },
+    },
+    emptyLabel !== undefined
+      ? (emptyLabel as React.ReactNode)
+      : 'No server-resolved context available.',
+  );
+}
+
+function renderSafetyFootnote(policy: WizardSafetyPolicy): React.ReactElement {
+  return h(
+    'p',
+    {
+      className: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+      style: {
+        margin: 0,
+        fontSize: '11px',
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+      },
+    },
+    `Safety policy: ${policy}`,
+  );
+}

--- a/ts/src/stitch-admin/index.ts
+++ b/ts/src/stitch-admin/index.ts
@@ -44,6 +44,19 @@ export type {
 export { canonicalizeWizardReconciliationPlanKind } from './wizard-reconciliation-plan-types.js';
 
 export type {
+  WizardAuthorityContextItem,
+  WizardAuthorityContextItemTone,
+  WizardAuthorityContextStrip,
+  WizardAuthorityContextStripLayout,
+  WizardAuthorityContextStripSize,
+  WizardServerResolvedContextBar,
+  WizardServerResolvedContextBarItem,
+  WizardServerResolvedContextBarLayout,
+  WizardServerResolvedContextBarSize,
+  WizardServerResolvedContextBarTone,
+} from './wizard-authority-context-strip-types.js';
+
+export type {
   AuthorityState,
   ConfidenceLevel,
   ConfidenceMetadata,

--- a/ts/src/stitch-admin/wizard-authority-context-strip-types.ts
+++ b/ts/src/stitch-admin/wizard-authority-context-strip-types.ts
@@ -1,0 +1,144 @@
+/**
+ * Framework-neutral types for the FaceTheory wizard authority/context strip
+ * primitive (also exported as the alias `WizardServerResolvedContextBar`).
+ *
+ * This is the read-only "tenant / namespace / MCP route / operator / partner
+ * / agent scope" header that the TheoryMCP control plane renders above wizard
+ * content. The contract is strictly presentational:
+ *
+ *   - FaceTheory renders only caller-supplied display values that the host
+ *     has already server-resolved.
+ *   - FaceTheory does not resolve, verify, derive, or validate tenant,
+ *     namespace, operator, MCP route, partner, agent, account, entitlement,
+ *     mailbox, GitHub, or authority state.
+ *   - FaceTheory does not enforce security; the read-only / authority badge
+ *     is text-labeled and explicitly does not imply enforcement.
+ *   - FaceTheory never invents copy payloads; copyable cells use the value
+ *     the host pre-resolved.
+ *
+ * Adapters narrow node-shaped fields (`label`, `value`, `icon`, `badge`,
+ * `actions`, `emptyLabel`) to their native node type. The shape here is
+ * shared so a Vue or Svelte adapter can wrap the same data without
+ * re-shaping it.
+ */
+
+import type { WizardSafetyPolicy } from './wizard-types.js';
+
+/** Color/tone hint for an authority context item. Adapter chooses tokens. */
+export type WizardAuthorityContextItemTone =
+  | 'neutral'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger';
+
+/** Size hint for the strip. Adapter chooses concrete spacing tokens. */
+export type WizardAuthorityContextStripSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Layout mode for the strip. `auto` uses a CSS-only responsive grid that
+ * stacks below a natural breakpoint without hiding any label/value context.
+ * The host can pin one of the other three explicitly.
+ */
+export type WizardAuthorityContextStripLayout = 'strip' | 'grid' | 'stack' | 'auto';
+
+/**
+ * A single label/value cell in the strip. Hosts supply already-resolved
+ * values; the primitive renders them verbatim.
+ */
+export interface WizardAuthorityContextItem {
+  /** Stable identifier used for React keying and copyable-action wiring. */
+  key: string;
+  /** Display label, e.g. "Tenant", "Namespace", "MCP route". */
+  label: unknown;
+  /** Display value, already server-resolved by the host. */
+  value: unknown;
+  /**
+   * Optional leading icon. Adapter narrows to its native node type.
+   * The icon must be decorative; the label still carries the meaning so
+   * read-only / authority cues do not depend on the icon.
+   */
+  icon?: unknown;
+  /**
+   * Optional small text badge (e.g. "Live", "Imported"). Adapter narrows to
+   * its native node type.
+   */
+  badge?: unknown;
+  /** Optional tone hint for the cell. Defaults to `neutral`. */
+  tone?: WizardAuthorityContextItemTone;
+  /**
+   * When true, the primitive renders an accessible "Copy" button alongside
+   * the value. The host wires the actual clipboard write via `onCopyItem`;
+   * the primitive never resolves or invents a payload.
+   */
+  copyable?: boolean;
+  /**
+   * Optional explicit copy payload. Defaults to the rendered string value
+   * when `value` is a string; otherwise the host must supply this for the
+   * copy button to carry a deterministic payload.
+   */
+  copyValue?: string;
+  /** Optional tooltip text (rendered via the standard `title` attribute). */
+  title?: string;
+  /**
+   * Optional link target. The primitive validates the URL through the
+   * Stitch admin safe-href filter so `javascript:` and other unsafe schemes
+   * are dropped.
+   */
+  href?: string;
+}
+
+/**
+ * The strip envelope. Hosts pre-compose the items, optional authority
+ * label, and optional action slot.
+ */
+export interface WizardAuthorityContextStrip {
+  items: WizardAuthorityContextItem[];
+  /**
+   * Optional caller-supplied authority label, e.g. "Server-derived",
+   * "Autheory session", "Route-resolved". Adapter narrows to its native
+   * node type. The primitive renders this verbatim; it never asserts the
+   * label is true.
+   */
+  authorityLabel?: unknown;
+  /**
+   * Optional text indicating the strip is read-only. Rendered as text (not
+   * color-only) so screen-readers and high-contrast viewers see the cue.
+   * The primitive does NOT enforce read-only; the label is informational
+   * and exists so the host can be explicit about the contract.
+   */
+  readOnlyLabel?: unknown;
+  /** Layout mode. Default `auto`. */
+  layout?: WizardAuthorityContextStripLayout;
+  /** Size hint. Default `md`. */
+  size?: WizardAuthorityContextStripSize;
+  /**
+   * Controls whether items may wrap onto multiple lines in `strip` layout.
+   * Default `true`. Ignored by `grid`, `stack`, and `auto`.
+   */
+  wrap?: boolean;
+  /**
+   * Optional action node slot, e.g. a "Refresh" or "Help" affordance. The
+   * primitive renders it as-is; it never invents actions.
+   */
+  actions?: unknown;
+  /** Optional empty-state label when `items` is empty. */
+  emptyLabel?: unknown;
+  /**
+   * Explicit safety policy assertion. The primitive renders it into the DOM
+   * via `data-safety-policy` and a footnote, so reviewers and tests can
+   * confirm the strip carries no secrets or production-like data.
+   */
+  safetyPolicy: WizardSafetyPolicy;
+}
+
+/**
+ * Stable alias matching the "ServerResolvedContextBar" naming preference
+ * from the TheoryMCP control plane. Callers who think of this surface as a
+ * server-resolved context bar can import the alias.
+ */
+export type WizardServerResolvedContextBar = WizardAuthorityContextStrip;
+export type WizardServerResolvedContextBarItem = WizardAuthorityContextItem;
+export type WizardServerResolvedContextBarLayout = WizardAuthorityContextStripLayout;
+export type WizardServerResolvedContextBarSize = WizardAuthorityContextStripSize;
+export type WizardServerResolvedContextBarTone = WizardAuthorityContextItemTone;

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -21,6 +21,7 @@ await import('./unit/stitch-hosted-auth.test.js');
 await import('./unit/stitch-admin.test.js');
 await import('./unit/stitch-admin-wizard.test.js');
 await import('./unit/stitch-admin-wizard-reconciliation-plan.test.js');
+await import('./unit/stitch-admin-wizard-authority-context-strip.test.js');
 await import('./unit/portal-fixtures.test.js');
 await import('./unit/antd-coverage.test.js');
 await import('./unit/portal-reference.test.js');

--- a/ts/test/unit/stitch-admin-wizard-authority-context-strip.test.ts
+++ b/ts/test/unit/stitch-admin-wizard-authority-context-strip.test.ts
@@ -1,0 +1,309 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as React from 'react';
+
+import { createFaceApp } from '../../src/app.js';
+import { createReactFace } from '../../src/adapters/react.js';
+import { createAntdIntegration } from '../../src/react/antd.js';
+import type { WizardAuthorityContextStrip } from '../../src/stitch-admin/index.js';
+import {
+  WizardAuthorityContextStripPanel,
+  WizardServerResolvedContextBarPanel,
+} from '../../src/react/stitch-admin/index.js';
+
+const h = React.createElement;
+
+async function renderSSR(element: React.ReactElement): Promise<string> {
+  const app = createFaceApp({
+    faces: [
+      createReactFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => element,
+        renderOptions: {
+          integrations: [createAntdIntegration({ hashed: false })],
+        },
+      }),
+    ],
+  });
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  return new TextDecoder().decode(resp.body as Uint8Array);
+}
+
+const SAMPLE_STRIP: WizardAuthorityContextStrip = {
+  items: [
+    { key: 'tenant', label: 'Tenant', value: 'theory-mcp' },
+    { key: 'namespace', label: 'Namespace', value: 'acme', tone: 'info' },
+    {
+      key: 'route',
+      label: 'MCP route',
+      value: '/agents/acme',
+      copyable: true,
+    },
+    {
+      key: 'operator',
+      label: 'Operator',
+      value: 'aron@equal-to.ai',
+      tone: 'success',
+      badge: 'session',
+    },
+  ],
+  authorityLabel: 'Server-derived',
+  readOnlyLabel: 'Read-only',
+  layout: 'auto',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+/* -------------------------------------------------------------------------- */
+/* Caller-supplied state passthrough                                          */
+/* -------------------------------------------------------------------------- */
+
+test('WizardAuthorityContextStripPanel renders caller-supplied items in order with stable data attributes', async () => {
+  const body = await renderSSR(h(WizardAuthorityContextStripPanel, { strip: SAMPLE_STRIP }));
+
+  assert.ok(body.includes('facetheory-stitch-wizard-authority-context-strip'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(body.includes('data-item-count="4"'));
+  assert.ok(body.includes('data-layout="auto"'));
+  assert.ok(body.includes('data-size="md"'));
+  assert.ok(body.includes('data-read-only="true"'));
+  assert.ok(body.includes('data-has-authority-label="true"'));
+
+  // Caller-supplied order preserved.
+  const order = ['tenant', 'namespace', 'route', 'operator'];
+  let prev = -1;
+  for (const key of order) {
+    const idx = body.indexOf(`data-item-key="${key}"`);
+    assert.ok(idx > prev, `item ${key} must appear after previous item in SSR output`);
+    prev = idx;
+  }
+
+  // Label + value pairs render as <dt>/<dd>.
+  assert.ok(body.includes('<dt'));
+  assert.ok(body.includes('Tenant'));
+  assert.ok(body.includes('theory-mcp'));
+  assert.ok(body.includes('Namespace'));
+  assert.ok(body.includes('acme'));
+  assert.ok(body.includes('Operator'));
+  assert.ok(body.includes('aron@equal-to.ai'));
+
+  // Tone hints rendered.
+  assert.ok(body.includes('data-item-tone="info"'));
+  assert.ok(body.includes('data-item-tone="success"'));
+  assert.ok(body.includes('data-item-tone="neutral"'));
+
+  // Authority + read-only labels rendered as text (not just color).
+  assert.ok(body.includes('Server-derived'));
+  assert.ok(body.includes('Read-only'));
+  assert.ok(body.includes('data-authority-label="true"'));
+  assert.ok(body.includes('data-read-only-label="true"'));
+  // The read-only span carries an explicit aria-label for accessibility.
+  assert.ok(body.includes('aria-label="Read-only"'));
+
+  // Section is announced as a region with a stable name.
+  assert.ok(body.includes('role="region"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Layout variants                                                            */
+/* -------------------------------------------------------------------------- */
+
+test('WizardAuthorityContextStripPanel exposes data-layout for each of the four layout values', async () => {
+  const layouts = ['strip', 'grid', 'stack', 'auto'] as const;
+  for (const layout of layouts) {
+    const body = await renderSSR(
+      h(WizardAuthorityContextStripPanel, {
+        strip: { ...SAMPLE_STRIP, layout },
+      }),
+    );
+    assert.ok(
+      body.includes(`data-layout="${layout}"`),
+      `data-layout should reflect layout="${layout}"`,
+    );
+    assert.ok(
+      body.includes(
+        `facetheory-stitch-wizard-authority-context-strip-layout-${layout}`,
+      ),
+      `class marker for layout="${layout}" should be present`,
+    );
+  }
+});
+
+test('WizardAuthorityContextStripPanel honours `wrap=false` on strip layout', async () => {
+  const body = await renderSSR(
+    h(WizardAuthorityContextStripPanel, {
+      strip: { ...SAMPLE_STRIP, layout: 'strip', wrap: false },
+    }),
+  );
+  assert.ok(body.includes('data-wrap="false"'));
+});
+
+test('WizardAuthorityContextStripPanel honours each size token', async () => {
+  for (const size of ['sm', 'md', 'lg'] as const) {
+    const body = await renderSSR(
+      h(WizardAuthorityContextStripPanel, {
+        strip: { ...SAMPLE_STRIP, size },
+      }),
+    );
+    assert.ok(body.includes(`data-size="${size}"`), `data-size should reflect size="${size}"`);
+    assert.ok(
+      body.includes(`facetheory-stitch-wizard-authority-context-strip-size-${size}`),
+      `class marker for size="${size}" should be present`,
+    );
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* Copyable cells                                                             */
+/* -------------------------------------------------------------------------- */
+
+test('WizardAuthorityContextStripPanel renders accessible copy button with deterministic payload', async () => {
+  const body = await renderSSR(h(WizardAuthorityContextStripPanel, { strip: SAMPLE_STRIP }));
+
+  // Real <button type="button"> for the copyable cell.
+  assert.ok(body.includes('<button type="button"'));
+  assert.ok(body.includes('aria-label="Copy MCP route"'));
+  assert.ok(body.includes('data-copy-item-key="route"'));
+  assert.ok(body.includes('data-copy-value="/agents/acme"'));
+  // Non-copyable cells do not render a copy button.
+  const tenantIdx = body.indexOf('data-item-key="tenant"');
+  const tenantSnippet = body.slice(tenantIdx, tenantIdx + 2000);
+  assert.ok(!tenantSnippet.includes('data-copy-item-key="tenant"'));
+});
+
+test('WizardAuthorityContextStripPanel uses item.copyValue when supplied instead of item.value', async () => {
+  const body = await renderSSR(
+    h(WizardAuthorityContextStripPanel, {
+      strip: {
+        items: [
+          {
+            key: 'route',
+            label: 'MCP route',
+            value: '/agents/acme',
+            copyable: true,
+            copyValue: 'mcp+route://acme/agents/import',
+          },
+        ],
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+    }),
+  );
+  assert.ok(body.includes('data-copy-value="mcp+route://acme/agents/import"'));
+  // The visible value still renders verbatim.
+  assert.ok(body.includes('/agents/acme'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Safe href                                                                  */
+/* -------------------------------------------------------------------------- */
+
+test('WizardAuthorityContextStripPanel drops unsafe href schemes', async () => {
+  const body = await renderSSR(
+    h(WizardAuthorityContextStripPanel, {
+      strip: {
+        items: [
+          { key: 'a', label: 'OK link', value: 'docs', href: '/docs/agents' },
+          { key: 'b', label: 'Hostile', value: 'click', href: 'javascript:alert(1)' },
+        ],
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+    }),
+  );
+  assert.ok(body.includes('href="/docs/agents"'));
+  assert.ok(!body.includes('javascript:alert(1)'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Empty state                                                                */
+/* -------------------------------------------------------------------------- */
+
+test('WizardAuthorityContextStripPanel renders empty state when no items are supplied', async () => {
+  const body = await renderSSR(
+    h(WizardAuthorityContextStripPanel, {
+      strip: {
+        items: [],
+        emptyLabel: 'No server-resolved context yet',
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+    }),
+  );
+  assert.ok(body.includes('facetheory-stitch-wizard-authority-context-strip-empty'));
+  assert.ok(body.includes('No server-resolved context yet'));
+  assert.ok(body.includes('data-item-count="0"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Read-only / authority cues are text-labeled, not color-only                */
+/* -------------------------------------------------------------------------- */
+
+test('WizardAuthorityContextStripPanel renders read-only and authority cues as text without relying on color', async () => {
+  const body = await renderSSR(h(WizardAuthorityContextStripPanel, { strip: SAMPLE_STRIP }));
+
+  // The cues live in actual DOM text nodes (not just data attributes / inline color).
+  const authorityIdx = body.indexOf('Server-derived');
+  const readOnlyIdx = body.indexOf('Read-only');
+  assert.ok(authorityIdx > -1);
+  assert.ok(readOnlyIdx > -1);
+
+  // The read-only span carries an explicit aria-label so screen-readers also see it.
+  assert.ok(body.includes('aria-label="Read-only"'));
+  // The authority label has its own data attribute for non-color identification.
+  assert.ok(body.includes('data-authority-label="true"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Determinism                                                                */
+/* -------------------------------------------------------------------------- */
+
+test('WizardAuthorityContextStripPanel produces byte-identical SSR output for the same input', async () => {
+  const first = await renderSSR(h(WizardAuthorityContextStripPanel, { strip: SAMPLE_STRIP }));
+  const second = await renderSSR(h(WizardAuthorityContextStripPanel, { strip: SAMPLE_STRIP }));
+  assert.equal(first, second, 'WizardAuthorityContextStripPanel must be deterministic');
+});
+
+/* -------------------------------------------------------------------------- */
+/* ServerResolvedContextBar alias                                             */
+/* -------------------------------------------------------------------------- */
+
+test('WizardServerResolvedContextBarPanel alias renders the same DOM as WizardAuthorityContextStripPanel', async () => {
+  const canonical = await renderSSR(
+    h(WizardAuthorityContextStripPanel, { strip: SAMPLE_STRIP }),
+  );
+  const alias = await renderSSR(
+    h(WizardServerResolvedContextBarPanel, { strip: SAMPLE_STRIP }),
+  );
+  assert.equal(canonical, alias, 'alias must render identically to the canonical component');
+});
+
+/* -------------------------------------------------------------------------- */
+/* No secrets / no production-like fixtures contract                          */
+/* -------------------------------------------------------------------------- */
+
+test('WizardAuthorityContextStripPanel renders the safety-policy footnote into the DOM', async () => {
+  const body = await renderSSR(h(WizardAuthorityContextStripPanel, { strip: SAMPLE_STRIP }));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+  assert.ok(body.includes('facetheory-stitch-wizard-safety-footnote'));
+});
+
+test('WizardAuthorityContextStripPanel fixture contains no obvious production-like or secret values', () => {
+  // The strip fixture above is the same one used by the rest of this suite.
+  // Sanity-check that nothing in it could plausibly be mistaken for a real
+  // secret or a production tenant/customer/release identifier.
+  const serialized = JSON.stringify(SAMPLE_STRIP);
+  const forbiddenSubstrings = [
+    'AKIA', // AWS access key id prefix
+    'aws_secret',
+    'BEGIN PRIVATE KEY',
+    'rotation-token',
+    'api_key=',
+    'Authorization:',
+  ];
+  for (const needle of forbiddenSubstrings) {
+    assert.equal(
+      serialized.includes(needle),
+      false,
+      `fixture must not include "${needle}"`,
+    );
+  }
+});


### PR DESCRIPTION
## Milestone

Factory assignment **THE-1449 / APW-FT3** (AuthorityContextStrip / ServerResolvedContextBar) for the TheoryMCP Agent Import & Completion Wizard project.

- Linear issue: THE-1449 — APW-FT3 — Request FaceTheory ServerResolvedContextBar / AuthorityContextStrip
- PR target: `project/theorymcp-agent-import-completion-wizard-20260521` (NOT `staging`)
- Project branch base: `project/theorymcp-agent-import-completion-wizard-20260521` @ `0e236080759483e5bbd6d18a3de0ffe00be99e96` (THE-1448 / PR #216 merge)
- Milestone branch: `facetheory/agent-import-wizard-authority-context-strip`
- Head commit: `7d639ca87789f0a089925d83babf6c68b320a068` (signed)

## What changed

A read-only, host-driven server-resolved context strip for wizard surfaces. The TheoryMCP control plane renders this primitive above wizard content to display tenant / namespace / MCP route / operator / partner / agent scope and related already-server-resolved values.

### Trust boundary (load-bearing)

- FaceTheory **never** resolves, verifies, derives, or validates tenant, namespace, operator, MCP route, partner, agent, account, entitlement, mailbox, GitHub, or authority state.
- FaceTheory **never** enforces read-only. The read-only label (when supplied) is informational text.
- FaceTheory **never** invents copy payloads. Copyable cells use `item.copyValue` if supplied, otherwise the rendered string `item.value` verbatim. The host is the authority.
- No raw secrets, credentials, live receipts, private keys, raw package bodies, provider tokens, customer data, or production-like confidential values in fixtures, tests, or docs (a dedicated test guards this).

### Framework-neutral types (`ts/src/stitch-admin/wizard-authority-context-strip-types.ts`)

- `WizardAuthorityContextItem` shaped `{ key, label, value, icon?, badge?, tone?, copyable?, copyValue?, title?, href? }`
- `WizardAuthorityContextStrip` with `items`, optional `authorityLabel`, `readOnlyLabel`, `layout: 'strip'|'grid'|'stack'|'auto'`, `size: 'sm'|'md'|'lg'`, `wrap`, `actions`, `emptyLabel`, plus the required `WizardSafetyPolicy` literal
- `WizardServerResolvedContextBar*` alias type set for the alternate "ServerResolvedContextBar" naming preference

### React adapter (`ts/src/react/stitch-admin/wizard-authority-context-strip.ts`)

- `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel` — same component)
- Pure presentation. No `Math.random()`, no `Date.now()`, no `window` reads, no network/route resolution at render time.
- Renders `<dt>` / `<dd>` label/value pairs so screen-readers read the pairing.
- `authorityLabel` and `readOnlyLabel` render as text — not color-only — with `data-authority-label="true"` / `data-read-only-label="true"` plus an explicit `aria-label="Read-only"` for the read-only cue.
- Copyable cells render a real `<button type="button">` with `aria-label="Copy <label>"` and `data-copy-value="<host-supplied>"`. The optional `onCopyItem(itemKey, copyValue)` callback performs the clipboard write; the markup is identical whether wired or not, so SSR and hydration match.
- `href` runs through the Stitch admin safe-href filter (`safeMetadataHref`) so `javascript:` and other unsafe schemes are dropped at render.
- All four layout values are CSS-only and stack responsively under `auto` without hiding any cell (CSS Grid `auto-fit, minmax(220px, 1fr)`).
- `data-safety-policy` plus a footnote render the wizard safety policy literal into the DOM.

### Tests (`ts/test/unit/stitch-admin-wizard-authority-context-strip.test.ts`)

13 new unit tests covering: caller-supplied item order + stable data attributes, all four layout values, wrap on strip layout, all three sizes, accessible copy button with deterministic payload + `<button type="button">` + `aria-label="Copy <label>"`, `copyValue` override of visible value, unsafe href rejection (`javascript:alert(1)` dropped), empty state, text-labeled (not color-only) read-only / authority cues, byte-identical SSR determinism on repeated render, ServerResolvedContextBar alias rendering identically, the safety-policy footnote in the DOM, and an explicit fixture guard that the test data contains no obvious production-like or secret values.

### Test discovery (`ts/test/run-unit.ts`)

Registered the new test file. `npm test` now reports **351 tests / 350 pass / 1 skip** (was 338 / 337 / 1 skip before this milestone; +13 new tests).

### Docs (`docs/wizard-primitives.md`)

Added an "Authority / server-resolved context strip" section covering the trust boundary (verbatim restatement), the item contract, the layout matrix, the copyable contract, the text-labeled read-only / authority cues, and a worked TheoryMCP integration example.

## Validation

Run from the repo root against PR head `7d639ca87789f0a089925d83babf6c68b320a068`.

- `git diff --check origin/project/theorymcp-agent-import-completion-wizard-20260521...HEAD` — clean
- `scripts/verify-version-alignment.sh` → `version-alignment: PASS (3.2.1)`
- `cd ts && npm ci` — clean
- `cd ts && npm run typecheck` — pass
- `cd ts && npm run lint` — pass
- `cd ts && npm test` → **`tests 351 / pass 350 / fail 0 / skipped 1`**
- `cd ts && npm run build` — pass
- `scripts/pack-dev-archive.sh --output-dir /tmp/theorycloud-facetheory-dev-archives` — archive + `.sha256` sidecar; success message prints the working `( cd <dir> && sha256sum --check <basename>.sha256 )` verify command.
- `( cd /tmp/theorycloud-facetheory-dev-archives && sha256sum --check theory-cloud-facetheory-3.2.1-dev-7d639ca87789.tgz.sha256 )` → `theory-cloud-facetheory-3.2.1-dev-7d639ca87789.tgz: OK`
- `make rubric` — passes `version-alignment` + `ts-pack`; fails ONLY on the pre-existing `npm-audit: brace-expansion (severity=moderate)` finding present on the project base branch. `ts/package-lock.json` unchanged in this PR.

## Temporary local archive handoff

- Command: `scripts/pack-dev-archive.sh --output-dir /tmp/theorycloud-facetheory-dev-archives`
- Default output dir: `/tmp/theorycloud-facetheory-dev-archives/`
- Archive basename (from PR head `7d639ca`): `theory-cloud-facetheory-3.2.1-dev-7d639ca87789.tgz`
- sha256: `d817a0cdbcba78ef67b3b4ff2a66f02cd1f8b073ccf6de4bbd5ef905b96953fe`
- Verify (works from any cwd):
  ```bash
  ( cd /tmp/theorycloud-facetheory-dev-archives \
      && sha256sum --check theory-cloud-facetheory-3.2.1-dev-7d639ca87789.tgz.sha256 )
  ```
- Verify output: `theory-cloud-facetheory-3.2.1-dev-7d639ca87789.tgz: OK`

## Safety / scope confirmation

- No release, npm publish, Release Please PR, version bump, tag creation, or release-asset publication.
- No AWS/cloud/account/DNS/cert/IAM/runner/action-lease mutation. No deploy. No smoke/canary.
- No live/customer-data fixtures. No secrets. No live receipts.
- No TheoryMCP, KnowledgeTheory, framework parent, or sibling repo edits.
- No git worktrees; normal checkout only.
- No PR to staging.
- The temporary archive is a pre-lab dev handoff and is explicitly **not** a release artifact.

## Residual risks / blockers

- `make rubric` blocked on the pre-existing `brace-expansion` npm-audit moderate finding present on the project base branch; `ts/package-lock.json` unchanged in this PR.
- No other open blockers.

## Files

- `ts/src/stitch-admin/wizard-authority-context-strip-types.ts` (new)
- `ts/src/stitch-admin/index.ts` (re-export new types)
- `ts/src/react/stitch-admin/wizard-authority-context-strip.ts` (new)
- `ts/src/react/stitch-admin/index.ts` (re-export new component + alias)
- `ts/test/unit/stitch-admin-wizard-authority-context-strip.test.ts` (new, 13 tests)
- `ts/test/run-unit.ts` (register the new test file)
- `docs/wizard-primitives.md` (AuthorityContextStrip section, trust boundary, layout matrix, copyable contract, integration example)

Refs: THE-1449 (APW-FT3)