### PR TITLE
feat(stitch-admin): add wizard editable token input (chip list) primitive

### DIFF
--- a/docs/wizard-primitives.md
+++ b/docs/wizard-primitives.md
@@ -1,6 +1,15 @@
 # FaceTheory wizard primitives (Stitch admin)
 
-Status: pre-1.0, framework-neutral contract plus React Stitch admin exports.
+Status: pre-1.0. The framework-neutral contract is shared across all adapters.
+`WizardEditableTokenInputPanel` / `WizardChipListPanel` (THE-1450) ship with
+full React + Vue + Svelte parity. The earlier wizard families
+(`WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`,
+`WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel`,
+`WizardAuthorityContextStripPanel`, `WizardCapabilityReviewPanel`,
+`WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`,
+`WizardEmptyState`) currently ship only the React adapter; Vue and Svelte
+parity for those families is tracked by THE-1459 as a corrective backfill
+milestone and is not part of this document's "shipped now" surface.
 
 These primitives exist so the TheoryMCP Agent Import & Completion Wizard
 (and any future Theory Cloud setup flow) can render deterministic, host-driven
@@ -24,13 +33,33 @@ primitive twice and asserting byte-identical SSR output.
 
 | Layer | Module | What it exports |
 | --- | --- | --- |
-| Framework-neutral types | `@theory-cloud/facetheory/stitch-admin` | `WizardProgressState`, `WizardPackageSummary`, `WizardFindingList`, `WizardReconcileSummary`, `WizardCapabilityReview`, `WizardEnablementChecklist`, `WizardRecoveryStatus`, `WizardEmptyStateConfig`, `WizardSafetyPolicy`, and supporting enums. |
+| Framework-neutral types | `@theory-cloud/facetheory/stitch-admin` | `WizardProgressState`, `WizardPackageSummary`, `WizardFindingList`, `WizardReconcileSummary`, `WizardReconciliationPlan`, `WizardAuthorityContextStrip`, `WizardCapabilityReview`, `WizardEnablementChecklist`, `WizardRecoveryStatus`, `WizardEmptyStateConfig`, `WizardEditableTokenInput`, `WizardSafetyPolicy`, and supporting enums and aliases. |
 | React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`), `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
+| Vue adapter | `@theory-cloud/facetheory/vue/stitch-admin` | `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`). Parity for the remaining wizard families is tracked by THE-1459. |
+| Svelte adapter | `@theory-cloud/facetheory/svelte/stitch-admin` | `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`). Parity for the remaining wizard families is tracked by THE-1459. |
 
-Vue and Svelte adapter parity is intentionally deferred for this milestone.
-The TheoryMCP control plane that consumes these primitives today is React; the
-framework-neutral contract is already in place so a future milestone can wrap
-the same types with Vue / Svelte renderers without re-shaping the data.
+### Adapter parity status
+
+- **Shipped with React + Vue + Svelte parity now (THE-1450):**
+  `WizardEditableTokenInputPanel` / `WizardChipListPanel`. SSR output is
+  byte-identical for the same props across all three adapters; the React,
+  Vue, and Svelte unit suites each render the component and assert matching
+  DOM, ARIA wiring, and feedback state.
+- **Shipped React-only today; Vue + Svelte parity tracked by THE-1459 as a
+  corrective backfill milestone:** the remaining wizard families listed
+  above (`WizardProgress`, `WizardPackageSummaryPanel`,
+  `WizardFindingListPanel`, `WizardReconcileSummaryPanel`,
+  `WizardReconciliationPlanPanel`, `WizardAuthorityContextStripPanel`,
+  `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`,
+  `WizardRecoveryStatusPanel`, `WizardEmptyState`). The framework-neutral
+  contracts for those families are already published from
+  `@theory-cloud/facetheory/stitch-admin`, so the THE-1459 backfill will
+  wrap the same types in Vue and Svelte renderers without re-shaping the
+  data.
+
+Future component-request milestones land with React + Vue + Svelte parity
+from the start; the React-only paths above are corrective scope, not the
+forward shape.
 
 ## Safety policy
 

--- a/docs/wizard-primitives.md
+++ b/docs/wizard-primitives.md
@@ -25,7 +25,7 @@ primitive twice and asserting byte-identical SSR output.
 | Layer | Module | What it exports |
 | --- | --- | --- |
 | Framework-neutral types | `@theory-cloud/facetheory/stitch-admin` | `WizardProgressState`, `WizardPackageSummary`, `WizardFindingList`, `WizardReconcileSummary`, `WizardCapabilityReview`, `WizardEnablementChecklist`, `WizardRecoveryStatus`, `WizardEmptyStateConfig`, `WizardSafetyPolicy`, and supporting enums. |
-| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
+| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`), `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
 
 Vue and Svelte adapter parity is intentionally deferred for this milestone.
 The TheoryMCP control plane that consumes these primitives today is React; the
@@ -231,6 +231,99 @@ authority and read-only state come from the host.
     safetyPolicy: 'no-secret-or-production-like-data',
   }}
   onCopyItem={(itemKey, value) => host.copyToClipboard(itemKey, value)}
+/>
+```
+
+## Editable token input / chip list
+
+`WizardEditableTokenInputPanel` (alias `WizardChipListPanel`) is the
+controlled chip/token entry primitive the TheoryMCP Agent Import &
+Completion Wizard uses for steps like "Allowed senders" and "Allowed
+domains".
+
+### Trust boundary
+
+- Client validation is **UX only**. FaceTheory never claims a token is
+  safe to write.
+- TheoryMCP must still **server-validate** allowed senders / domains
+  before writing `AgentEmailBinding` policy.
+- FaceTheory does not resolve mailbox, tenant, namespace, agent, partner,
+  provider credentials, or email policy state.
+
+### Controlled contract
+
+The host owns state. The primitive is purely controlled:
+
+- `input.value: string[]` — current token list.
+- `onChange(next: string[])` — required. The primitive calls this whenever
+  it proposes a new token list (commit on Enter/comma, Backspace removes
+  the previous when the draft is empty, or the chip's Remove button is
+  clicked). The host accepts the new list (or doesn't).
+- `input.draftValue?: string` — controlled current draft text.
+- `onDraftChange?(next: string)` — called whenever the draft text changes.
+
+There is **no hidden state** inside the primitive. SSR and hydrated DOM
+are byte-identical for the same props.
+
+### Key handling
+
+| Key       | Behavior                                                                  |
+| --------- | ------------------------------------------------------------------------- |
+| Enter     | Commit draft. Calls `onChange([...value, normalizedDraft])` and clears.   |
+| Comma     | Same as Enter.                                                            |
+| Backspace | If draft is empty and there is at least one token, remove the last one.   |
+
+Commit is suppressed when the draft is empty, when `validateToken` returns
+`{ valid: false }`, when the resulting token would be a duplicate and
+`allowDuplicates !== true`, or when `value.length >= maxTokens`. The
+primitive never enforces these limits beyond suppressing its own commit
+proposal; the host can still pass any list back via `onChange`.
+
+### Per-token metadata
+
+Optional `input.items` carries `{ value, tone?, title?, disabled?,
+removable? }` per token. Tokens without an `items` entry render with
+`neutral` tone and remain removable.
+
+### Validation feedback
+
+Feedback below the input is computed deterministically and announced via
+`role="alert"` and `aria-live="polite"`. The priority order is:
+
+1. Caller-supplied `feedbackMessage` (highest — surfaces server messages).
+2. `validateToken(draft)` returning `{ valid: false }`.
+3. Duplicate of an existing token (only when `allowDuplicates !== true`).
+4. `value.length >= maxTokens` (when `maxTokens` is supplied).
+5. No feedback.
+
+The current source is exposed via `data-feedback-source` for testing and
+debugging.
+
+### Disabled / read-only
+
+`disabled` and `readOnly` render text labels in the header (with explicit
+`aria-label`), set the standard HTML attributes, and suppress the
+draft `<input>` plus the chip Remove buttons. They are **never**
+color-only cues.
+
+### Example
+
+```tsx
+<WizardEditableTokenInputPanel
+  input={{
+    inputId: 'allowed-senders',
+    value: ['qa@example.com', 'ops@example.com'],
+    label: 'Allowed senders',
+    description: 'Server validation remains authoritative.',
+    placeholder: 'Add another address…',
+    removeLabelKind: 'sender',
+    validateToken: (token) =>
+      token.includes('@') ? { valid: true } : { valid: false, message: 'Address must contain @' },
+    safetyPolicy: 'no-secret-or-production-like-data',
+    draftValue: host.draft,
+  }}
+  onChange={(next) => host.setAllowedSenders(next)}
+  onDraftChange={(next) => host.setDraft(next)}
 />
 ```
 

--- a/ts/src/react/stitch-admin/index.ts
+++ b/ts/src/react/stitch-admin/index.ts
@@ -163,3 +163,20 @@ export {
   type WizardServerResolvedContextBarSize,
   type WizardServerResolvedContextBarTone,
 } from './wizard-authority-context-strip.js';
+
+export {
+  WizardEditableTokenInputPanel,
+  WizardChipListPanel,
+  type WizardEditableTokenInputPanelProps,
+  type WizardChipListPanelProps,
+  type WizardChipList,
+  type WizardChipListFeedbackTone,
+  type WizardChipListItem,
+  type WizardChipListTone,
+  type WizardChipListValidationResult,
+  type WizardEditableTokenInput,
+  type WizardEditableTokenInputFeedbackTone,
+  type WizardEditableTokenInputItem,
+  type WizardEditableTokenInputTone,
+  type WizardEditableTokenInputValidationResult,
+} from './wizard-editable-token-input.js';

--- a/ts/src/react/stitch-admin/wizard-editable-token-input.ts
+++ b/ts/src/react/stitch-admin/wizard-editable-token-input.ts
@@ -1,0 +1,585 @@
+import * as React from 'react';
+
+import type {
+  WizardChipList,
+  WizardChipListFeedbackTone,
+  WizardChipListItem,
+  WizardChipListTone,
+  WizardChipListValidationResult,
+  WizardEditableTokenInput,
+  WizardEditableTokenInputFeedbackTone,
+  WizardEditableTokenInputItem,
+  WizardEditableTokenInputTone,
+  WizardEditableTokenInputValidationResult,
+} from '../../stitch-admin/wizard-editable-token-input-types.js';
+import type { WizardSafetyPolicy } from '../../stitch-admin/wizard-types.js';
+
+const h = React.createElement;
+
+export type {
+  WizardChipList,
+  WizardChipListFeedbackTone,
+  WizardChipListItem,
+  WizardChipListTone,
+  WizardChipListValidationResult,
+  WizardEditableTokenInput,
+  WizardEditableTokenInputFeedbackTone,
+  WizardEditableTokenInputItem,
+  WizardEditableTokenInputTone,
+  WizardEditableTokenInputValidationResult,
+};
+
+interface ChipPalette {
+  background: string;
+  color: string;
+  border: string;
+}
+
+const CHIP_PALETTE: Record<WizardEditableTokenInputTone, ChipPalette> = {
+  neutral: {
+    background: 'var(--stitch-color-surface-container-high, #e2e7ff)',
+    color: 'var(--stitch-color-on-surface, #131b2e)',
+    border: 'var(--stitch-color-outline-variant, #c6c5d0)',
+  },
+  info: {
+    background: 'var(--stitch-color-primary-container, #e0e0ff)',
+    color: 'var(--stitch-color-on-primary-container, #000066)',
+    border: 'var(--stitch-color-primary-container, #e0e0ff)',
+  },
+  success: {
+    background: 'var(--stitch-color-tertiary-container, #004c45)',
+    color: 'var(--stitch-color-on-tertiary-container, #52c1b4)',
+    border: 'var(--stitch-color-tertiary-container, #004c45)',
+  },
+  warning: {
+    background: 'var(--stitch-color-secondary-container, #ffecc0)',
+    color: 'var(--stitch-color-on-secondary-container, #3f2e00)',
+    border: 'var(--stitch-color-secondary-container, #ffecc0)',
+  },
+  danger: {
+    background: 'var(--stitch-color-error-container, #ffdad6)',
+    color: 'var(--stitch-color-on-error-container, #93000a)',
+    border: 'var(--stitch-color-error-container, #ffdad6)',
+  },
+};
+
+const FEEDBACK_PALETTE: Record<WizardEditableTokenInputFeedbackTone, ChipPalette> = {
+  info: CHIP_PALETTE.info,
+  success: CHIP_PALETTE.success,
+  warning: CHIP_PALETTE.warning,
+  danger: CHIP_PALETTE.danger,
+};
+
+export interface WizardEditableTokenInputPanelProps {
+  input: WizardEditableTokenInput;
+  /**
+   * Required. Called whenever the primitive wants to propose a new token
+   * list (commit on Enter/comma, remove via Backspace, remove via chip
+   * button). The host owns acceptance; the primitive does not enforce.
+   */
+  onChange: (next: string[]) => void;
+  /**
+   * Called whenever the draft text changes (input typing or commit clear).
+   * If omitted, the input still renders and is keyboard-controlled, but
+   * the host must wire draft state separately.
+   */
+  onDraftChange?: (next: string) => void;
+}
+
+/**
+ * Resolved feedback state for render. Pure function of the input props.
+ */
+interface FeedbackState {
+  message: string | undefined;
+  tone: WizardEditableTokenInputFeedbackTone;
+  source: 'caller' | 'validator' | 'duplicate' | 'max-tokens' | 'none';
+}
+
+function resolveFeedback(input: WizardEditableTokenInput): FeedbackState {
+  if (input.feedbackMessage !== undefined && input.feedbackMessage !== '') {
+    return {
+      message: input.feedbackMessage,
+      tone: input.feedbackTone ?? 'info',
+      source: 'caller',
+    };
+  }
+  const draft = input.draftValue ?? '';
+  if (draft !== '' && input.validateToken !== undefined) {
+    const result = input.validateToken(draft);
+    if (!result.valid) {
+      return {
+        message: result.message ?? 'Token is not valid.',
+        tone: 'danger',
+        source: 'validator',
+      };
+    }
+  }
+  if (
+    draft !== '' &&
+    input.allowDuplicates !== true &&
+    input.value.includes(draft)
+  ) {
+    return {
+      message: `"${draft}" is already in the list.`,
+      tone: 'warning',
+      source: 'duplicate',
+    };
+  }
+  if (
+    input.maxTokens !== undefined &&
+    input.value.length >= input.maxTokens
+  ) {
+    return {
+      message: `Maximum ${input.maxTokens} tokens reached.`,
+      tone: 'warning',
+      source: 'max-tokens',
+    };
+  }
+  return { message: undefined, tone: 'info', source: 'none' };
+}
+
+function metadataForToken(
+  input: WizardEditableTokenInput,
+  token: string,
+): WizardEditableTokenInputItem | undefined {
+  if (input.items === undefined) return undefined;
+  return input.items.find((entry) => entry.value === token);
+}
+
+function deriveRemoveLabel(
+  input: WizardEditableTokenInput,
+  token: string,
+): string {
+  const kind = input.removeLabelKind ?? 'token';
+  return `Remove ${kind} ${token}`;
+}
+
+function isReadOnly(input: WizardEditableTokenInput): boolean {
+  return input.readOnly === true || input.disabled === true;
+}
+
+function commitDraft(
+  input: WizardEditableTokenInput,
+  raw: string,
+  onChange: WizardEditableTokenInputPanelProps['onChange'],
+  onDraftChange: WizardEditableTokenInputPanelProps['onDraftChange'],
+): void {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    if (onDraftChange !== undefined) onDraftChange('');
+    return;
+  }
+  let next = trimmed;
+  if (input.validateToken !== undefined) {
+    const result = input.validateToken(trimmed);
+    if (!result.valid) {
+      // Leave the draft in place so the user can correct it.
+      return;
+    }
+    if (result.normalized !== undefined) {
+      next = result.normalized;
+    }
+  }
+  if (input.allowDuplicates !== true && input.value.includes(next)) {
+    return;
+  }
+  if (input.maxTokens !== undefined && input.value.length >= input.maxTokens) {
+    return;
+  }
+  onChange([...input.value, next]);
+  if (onDraftChange !== undefined) onDraftChange('');
+}
+
+function removeAt(
+  input: WizardEditableTokenInput,
+  index: number,
+  onChange: WizardEditableTokenInputPanelProps['onChange'],
+): void {
+  if (index < 0 || index >= input.value.length) return;
+  const next = input.value.slice(0, index).concat(input.value.slice(index + 1));
+  onChange(next);
+}
+
+export function WizardEditableTokenInputPanel(
+  props: WizardEditableTokenInputPanelProps,
+): React.ReactElement {
+  const { input, onChange, onDraftChange } = props;
+  const readOnly = isReadOnly(input);
+  const disabled = input.disabled === true;
+  const feedback = resolveFeedback(input);
+  const feedbackId = `${input.inputId}-feedback`;
+  const descriptionId = input.description !== undefined ? `${input.inputId}-description` : undefined;
+  const labelId = input.label !== undefined ? `${input.inputId}-label` : undefined;
+  const draftValue = input.draftValue ?? '';
+  const tokenPrefix = input.tokenPrefix;
+  const ariaDescribedBy = [descriptionId, feedback.message !== undefined ? feedbackId : undefined]
+    .filter((id): id is string => typeof id === 'string')
+    .join(' ') || undefined;
+
+  return h(
+    'section',
+    {
+      className: `facetheory-stitch-wizard-editable-token-input facetheory-stitch-wizard-editable-token-input-${readOnly ? 'readonly' : 'editable'}${disabled ? ' facetheory-stitch-wizard-editable-token-input-disabled' : ''}`,
+      'data-safety-policy': input.safetyPolicy,
+      'data-input-id': input.inputId,
+      'data-token-count': String(input.value.length),
+      'data-allow-duplicates': input.allowDuplicates === true ? 'true' : 'false',
+      'data-max-tokens': input.maxTokens !== undefined ? String(input.maxTokens) : undefined,
+      'data-disabled': disabled ? 'true' : 'false',
+      'data-read-only': input.readOnly === true ? 'true' : 'false',
+      'data-feedback-source': feedback.source,
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        padding: '12px',
+        borderRadius: 'var(--stitch-radius-lg, 12px)',
+        background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+      },
+    },
+    renderHeader(input, labelId, descriptionId),
+    renderChipRow(input, onChange, readOnly, tokenPrefix),
+    !readOnly
+      ? renderInputRow(input, onChange, onDraftChange, ariaDescribedBy, draftValue, disabled, labelId)
+      : renderReadOnlyState(input),
+    feedback.message !== undefined
+      ? renderFeedback(feedback, feedbackId)
+      : null,
+    renderSafetyFootnote(input.safetyPolicy),
+  );
+}
+
+/** Stable alias for callers who prefer the ChipList naming. */
+export const WizardChipListPanel = WizardEditableTokenInputPanel;
+export type WizardChipListPanelProps = WizardEditableTokenInputPanelProps;
+
+function renderHeader(
+  input: WizardEditableTokenInput,
+  labelId: string | undefined,
+  descriptionId: string | undefined,
+): React.ReactElement | null {
+  if (input.label === undefined && input.description === undefined) return null;
+  return h(
+    'header',
+    {
+      style: { display: 'flex', flexDirection: 'column', gap: '4px' },
+    },
+    input.label !== undefined
+      ? h(
+          'label',
+          {
+            id: labelId,
+            htmlFor: input.inputId,
+            style: { fontSize: '13px', fontWeight: 600 },
+          },
+          input.label as React.ReactNode,
+        )
+      : null,
+    input.description !== undefined
+      ? h(
+          'p',
+          {
+            id: descriptionId,
+            style: {
+              margin: 0,
+              fontSize: '12px',
+              lineHeight: 1.5,
+              color: 'var(--stitch-color-on-surface-variant, #464553)',
+            },
+          },
+          input.description as React.ReactNode,
+        )
+      : null,
+    input.disabled === true
+      ? h(
+          'span',
+          {
+            className: 'facetheory-stitch-wizard-editable-token-input-state',
+            'data-state': 'disabled',
+            'aria-label': 'Disabled',
+            style: {
+              alignSelf: 'flex-start',
+              fontSize: '11px',
+              fontWeight: 600,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+              color: 'var(--stitch-color-on-surface-variant, #464553)',
+            },
+          },
+          'Disabled',
+        )
+      : input.readOnly === true
+        ? h(
+            'span',
+            {
+              className: 'facetheory-stitch-wizard-editable-token-input-state',
+              'data-state': 'readonly',
+              'aria-label': 'Read-only',
+              style: {
+                alignSelf: 'flex-start',
+                fontSize: '11px',
+                fontWeight: 600,
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase',
+                color: 'var(--stitch-color-on-surface-variant, #464553)',
+              },
+            },
+            'Read-only',
+          )
+        : null,
+  );
+}
+
+function renderChipRow(
+  input: WizardEditableTokenInput,
+  onChange: WizardEditableTokenInputPanelProps['onChange'],
+  readOnly: boolean,
+  tokenPrefix: string | undefined,
+): React.ReactElement {
+  if (input.value.length === 0) {
+    return h(
+      'div',
+      {
+        className: 'facetheory-stitch-wizard-editable-token-input-empty',
+        role: 'status',
+        style: {
+          fontSize: '12px',
+          color: 'var(--stitch-color-on-surface-variant, #464553)',
+        },
+      },
+      'No tokens yet.',
+    );
+  }
+  return h(
+    'ul',
+    {
+      className: 'facetheory-stitch-wizard-editable-token-input-chips',
+      role: 'list',
+      style: {
+        margin: 0,
+        padding: 0,
+        listStyle: 'none',
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '6px',
+      },
+    },
+    input.value.map((token, index) =>
+      renderChip(input, token, index, onChange, readOnly, tokenPrefix),
+    ),
+  );
+}
+
+function renderChip(
+  input: WizardEditableTokenInput,
+  token: string,
+  index: number,
+  onChange: WizardEditableTokenInputPanelProps['onChange'],
+  readOnly: boolean,
+  tokenPrefix: string | undefined,
+): React.ReactElement {
+  const meta = metadataForToken(input, token);
+  const tone: WizardEditableTokenInputTone = meta?.tone ?? 'neutral';
+  const palette = CHIP_PALETTE[tone];
+  const isRemovable =
+    !readOnly && meta?.removable !== false && meta?.disabled !== true;
+  const removeLabel = deriveRemoveLabel(input, token);
+
+  return h(
+    'li',
+    {
+      key: `${token}::${index}`,
+      className: `facetheory-stitch-wizard-editable-token-input-chip facetheory-stitch-wizard-editable-token-input-chip-tone-${tone}${meta?.disabled === true ? ' facetheory-stitch-wizard-editable-token-input-chip-disabled' : ''}`,
+      'data-token-value': token,
+      'data-token-index': String(index),
+      'data-token-tone': tone,
+      'data-token-removable': isRemovable ? 'true' : 'false',
+      style: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '4px 8px',
+        borderRadius: '9999px',
+        background: palette.background,
+        color: palette.color,
+        border: `1px solid ${palette.border}`,
+        fontSize: '12px',
+        lineHeight: 1.4,
+        fontFamily: 'var(--stitch-font-label, ui-monospace, SFMono-Regular, Menlo, monospace)',
+      },
+      title: meta?.title,
+    },
+    tokenPrefix !== undefined && tokenPrefix !== ''
+      ? h(
+          'span',
+          {
+            className: 'facetheory-stitch-wizard-editable-token-input-chip-prefix',
+            'aria-hidden': 'true',
+          },
+          tokenPrefix,
+        )
+      : null,
+    h(
+      'span',
+      {
+        className: 'facetheory-stitch-wizard-editable-token-input-chip-value',
+      },
+      token,
+    ),
+    isRemovable
+      ? h(
+          'button',
+          {
+            type: 'button',
+            className: 'facetheory-stitch-wizard-editable-token-input-chip-remove',
+            'aria-label': removeLabel,
+            'data-remove-token-index': String(index),
+            'data-remove-token-value': token,
+            disabled: meta?.disabled === true,
+            onClick: () => removeAt(input, index, onChange),
+            style: {
+              appearance: 'none',
+              background: 'transparent',
+              border: 'none',
+              color: 'inherit',
+              cursor: 'pointer',
+              fontSize: '14px',
+              lineHeight: 1,
+              padding: '0 2px',
+            },
+          },
+          '×',
+        )
+      : null,
+  );
+}
+
+function renderInputRow(
+  input: WizardEditableTokenInput,
+  onChange: WizardEditableTokenInputPanelProps['onChange'],
+  onDraftChange: WizardEditableTokenInputPanelProps['onDraftChange'],
+  ariaDescribedBy: string | undefined,
+  draftValue: string,
+  disabled: boolean,
+  labelId: string | undefined,
+): React.ReactElement {
+  return h(
+    'div',
+    {
+      className: 'facetheory-stitch-wizard-editable-token-input-input-row',
+      style: { display: 'flex', alignItems: 'center', gap: '8px' },
+    },
+    h('input', {
+      id: input.inputId,
+      type: 'text',
+      value: draftValue,
+      placeholder: input.placeholder,
+      disabled,
+      'aria-labelledby': labelId,
+      'aria-describedby': ariaDescribedBy,
+      'aria-invalid': false,
+      // Always wire an onChange so React does not treat the input as
+      // accidentally uncontrolled when the host omits `onDraftChange`.
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (onDraftChange !== undefined) {
+          onDraftChange(event.target.value);
+        }
+      },
+      onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter' || event.key === ',') {
+          event.preventDefault();
+          commitDraft(input, draftValue, onChange, onDraftChange);
+          return;
+        }
+        if (
+          event.key === 'Backspace' &&
+          draftValue === '' &&
+          input.value.length > 0
+        ) {
+          event.preventDefault();
+          removeAt(input, input.value.length - 1, onChange);
+        }
+      },
+      className: 'facetheory-stitch-wizard-editable-token-input-input',
+      style: {
+        flex: '1 1 auto',
+        minWidth: 0,
+        appearance: 'none',
+        background: 'var(--stitch-color-surface-container, #eaedff)',
+        border: '1px solid var(--stitch-color-outline-variant, #c6c5d0)',
+        borderRadius: 'var(--stitch-radius-sm, 8px)',
+        padding: '6px 10px',
+        fontSize: '13px',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+        fontFamily: 'inherit',
+      },
+    }),
+  );
+}
+
+function renderReadOnlyState(input: WizardEditableTokenInput): React.ReactElement {
+  return h(
+    'div',
+    {
+      className: 'facetheory-stitch-wizard-editable-token-input-readonly-state',
+      role: 'status',
+      'data-state': input.disabled === true ? 'disabled' : 'readonly',
+      style: {
+        fontSize: '12px',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+        fontStyle: 'italic',
+      },
+    },
+    input.disabled === true
+      ? 'Token entry is disabled.'
+      : 'Token entry is read-only.',
+  );
+}
+
+function renderFeedback(
+  feedback: FeedbackState,
+  feedbackId: string,
+): React.ReactElement {
+  const palette = FEEDBACK_PALETTE[feedback.tone];
+  return h(
+    'p',
+    {
+      id: feedbackId,
+      className: `facetheory-stitch-wizard-editable-token-input-feedback facetheory-stitch-wizard-editable-token-input-feedback-${feedback.tone}`,
+      role: 'alert',
+      'aria-live': 'polite',
+      'data-feedback-source': feedback.source,
+      'data-feedback-tone': feedback.tone,
+      style: {
+        margin: 0,
+        padding: '6px 10px',
+        borderRadius: 'var(--stitch-radius-sm, 8px)',
+        background: palette.background,
+        color: palette.color,
+        border: `1px solid ${palette.border}`,
+        fontSize: '12px',
+        lineHeight: 1.5,
+      },
+    },
+    feedback.message,
+  );
+}
+
+function renderSafetyFootnote(policy: WizardSafetyPolicy): React.ReactElement {
+  return h(
+    'p',
+    {
+      className: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+      style: {
+        margin: 0,
+        fontSize: '11px',
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+      },
+    },
+    `Safety policy: ${policy}`,
+  );
+}

--- a/ts/src/stitch-admin/index.ts
+++ b/ts/src/stitch-admin/index.ts
@@ -57,6 +57,19 @@ export type {
 } from './wizard-authority-context-strip-types.js';
 
 export type {
+  WizardChipList,
+  WizardChipListFeedbackTone,
+  WizardChipListItem,
+  WizardChipListTone,
+  WizardChipListValidationResult,
+  WizardEditableTokenInput,
+  WizardEditableTokenInputFeedbackTone,
+  WizardEditableTokenInputItem,
+  WizardEditableTokenInputTone,
+  WizardEditableTokenInputValidationResult,
+} from './wizard-editable-token-input-types.js';
+
+export type {
   AuthorityState,
   ConfidenceLevel,
   ConfidenceMetadata,

--- a/ts/src/stitch-admin/wizard-editable-token-input-types.ts
+++ b/ts/src/stitch-admin/wizard-editable-token-input-types.ts
@@ -1,0 +1,142 @@
+/**
+ * Framework-neutral types for the FaceTheory wizard editable token input
+ * (also exported as the alias `WizardChipList*`).
+ *
+ * This is the controlled chip/token entry primitive the TheoryMCP Agent
+ * Import & Completion Wizard uses for steps like "Allowed senders" or
+ * "Allowed domains". The contract is presentational and host-driven:
+ *
+ *   - FaceTheory renders only caller-supplied state.
+ *   - FaceTheory does NOT own hidden token authority state. Hosts pass the
+ *     current token list and (optionally) the current draft; FaceTheory
+ *     proposes the next state via callbacks, but the host owns acceptance.
+ *   - FaceTheory does NOT claim a token is safe to write. Any client-side
+ *     validation surfaced here is UX only. TheoryMCP must still
+ *     server-validate allowed senders/domains before writing
+ *     `AgentEmailBinding` policy.
+ *   - FaceTheory never resolves mailbox authority, tenant, namespace,
+ *     agent, partner, provider credentials, or email policy state.
+ *
+ * Adapters narrow `label`, `description`, and per-token `value` rendering
+ * to their native node type. The shape here is shared so Vue or Svelte
+ * adapters can wrap the same data without re-shaping it.
+ */
+
+import type { WizardSafetyPolicy } from './wizard-types.js';
+
+/** Tone hint for a single chip/token. Adapter chooses concrete tokens. */
+export type WizardEditableTokenInputTone =
+  | 'neutral'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger';
+
+/**
+ * Optional per-token metadata. Hosts supply this for tokens that need
+ * non-default presentation (e.g. a different tone, a tooltip, a
+ * non-removable system-defined entry). Tokens without an entry render
+ * with default `neutral` tone and remain removable unless the wider input
+ * is disabled or read-only.
+ */
+export interface WizardEditableTokenInputItem {
+  /** Stable token string. Matches an entry in `value`. */
+  value: string;
+  /** Tone hint for the chip. Defaults to `neutral`. */
+  tone?: WizardEditableTokenInputTone;
+  /** Optional tooltip rendered via the `title` attribute. */
+  title?: string;
+  /** When true, the chip's Remove button is disabled. */
+  disabled?: boolean;
+  /** When false, no Remove button is rendered for this token. Default true. */
+  removable?: boolean;
+}
+
+/**
+ * Result of a caller-supplied token validator. The primitive renders the
+ * message (when invalid) below the input and uses `normalized` as the
+ * payload it proposes via `onChange` when the user commits the draft.
+ */
+export interface WizardEditableTokenInputValidationResult {
+  valid: boolean;
+  message?: string;
+  normalized?: string;
+}
+
+/**
+ * Caller-supplied feedback severity tone. The primitive uses this only for
+ * styling; it does NOT change the announced role.
+ */
+export type WizardEditableTokenInputFeedbackTone =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger';
+
+/** Controlled input envelope. */
+export interface WizardEditableTokenInput {
+  /** Required, stable HTML id used to wire `<label htmlFor>` and aria-describedby. */
+  inputId: string;
+  /** Controlled token list. */
+  value: string[];
+  /** Optional per-token metadata. */
+  items?: WizardEditableTokenInputItem[];
+  /** Optional caller-supplied label. */
+  label?: unknown;
+  /** Optional descriptive copy below the label. */
+  description?: unknown;
+  /** Optional placeholder text for the draft input. */
+  placeholder?: string;
+  /** Controlled draft value (the text currently being typed). */
+  draftValue?: string;
+  /**
+   * Optional caller-supplied feedback message. When present, the primitive
+   * renders this verbatim with `role="alert"` regardless of validator/
+   * duplicate/maxTokens state. Hosts use this to surface server-side
+   * messages alongside the wizard.
+   */
+  feedbackMessage?: string;
+  /** Optional tone hint for caller-supplied feedback. Defaults to `info`. */
+  feedbackTone?: WizardEditableTokenInputFeedbackTone;
+  /**
+   * Optional maximum number of tokens. When `value.length >= maxTokens`,
+   * the primitive renders a "Maximum reached" feedback line. The host is
+   * still responsible for enforcing the cap on `onChange`.
+   */
+  maxTokens?: number;
+  /** Whether duplicate tokens are allowed. Default `false`. */
+  allowDuplicates?: boolean;
+  /**
+   * Optional prefix string rendered on every chip (e.g. `"@"` for email
+   * handles, `"*."` for wildcard domains). Decorative — adapter renders
+   * with `aria-hidden` so screen-readers do not double-read it.
+   */
+  tokenPrefix?: string;
+  /** Disabled state — input is non-interactive; Remove buttons disabled. */
+  disabled?: boolean;
+  /** Read-only state — input is non-interactive; chips are not removable. */
+  readOnly?: boolean;
+  /**
+   * Optional caller-supplied token validator. Called during render for the
+   * current `draftValue` only. Must be a pure function so SSR and hydrated
+   * DOM agree byte-for-byte.
+   */
+  validateToken?: (
+    token: string,
+  ) => WizardEditableTokenInputValidationResult;
+  /**
+   * Optional accessible "kind" string used in Remove button aria-labels
+   * (e.g. `"sender"` produces `"Remove sender qa@example.com"`). Default
+   * `"token"`.
+   */
+  removeLabelKind?: string;
+  /** Explicit safety policy assertion rendered into the DOM. */
+  safetyPolicy: WizardSafetyPolicy;
+}
+
+/** Stable alias matching the "ChipList" naming preference. */
+export type WizardChipList = WizardEditableTokenInput;
+export type WizardChipListItem = WizardEditableTokenInputItem;
+export type WizardChipListTone = WizardEditableTokenInputTone;
+export type WizardChipListValidationResult = WizardEditableTokenInputValidationResult;
+export type WizardChipListFeedbackTone = WizardEditableTokenInputFeedbackTone;

--- a/ts/src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte
+++ b/ts/src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte
@@ -1,0 +1,337 @@
+<script lang="ts">
+  import type {
+    WizardEditableTokenInput,
+    WizardEditableTokenInputFeedbackTone,
+    WizardEditableTokenInputItem,
+    WizardEditableTokenInputTone,
+  } from './types.js';
+
+  export let input: WizardEditableTokenInput;
+  export let onChange: (next: string[]) => void;
+  export let onDraftChange: ((next: string) => void) | undefined = undefined;
+
+  const chipPalette: Record<WizardEditableTokenInputTone, { background: string; color: string; border: string }> = {
+    neutral: {
+      background: 'var(--stitch-color-surface-container-high, #e2e7ff)',
+      color: 'var(--stitch-color-on-surface, #131b2e)',
+      border: 'var(--stitch-color-outline-variant, #c6c5d0)',
+    },
+    info: {
+      background: 'var(--stitch-color-primary-container, #e0e0ff)',
+      color: 'var(--stitch-color-on-primary-container, #000066)',
+      border: 'var(--stitch-color-primary-container, #e0e0ff)',
+    },
+    success: {
+      background: 'var(--stitch-color-tertiary-container, #004c45)',
+      color: 'var(--stitch-color-on-tertiary-container, #52c1b4)',
+      border: 'var(--stitch-color-tertiary-container, #004c45)',
+    },
+    warning: {
+      background: 'var(--stitch-color-secondary-container, #ffecc0)',
+      color: 'var(--stitch-color-on-secondary-container, #3f2e00)',
+      border: 'var(--stitch-color-secondary-container, #ffecc0)',
+    },
+    danger: {
+      background: 'var(--stitch-color-error-container, #ffdad6)',
+      color: 'var(--stitch-color-on-error-container, #93000a)',
+      border: 'var(--stitch-color-error-container, #ffdad6)',
+    },
+  };
+
+  const feedbackPalette: Record<WizardEditableTokenInputFeedbackTone, { background: string; color: string; border: string }> = {
+    info: chipPalette.info,
+    success: chipPalette.success,
+    warning: chipPalette.warning,
+    danger: chipPalette.danger,
+  };
+
+  type FeedbackSource = 'caller' | 'validator' | 'duplicate' | 'max-tokens' | 'none';
+  interface FeedbackState {
+    message: string | undefined;
+    tone: WizardEditableTokenInputFeedbackTone;
+    source: FeedbackSource;
+  }
+
+  function resolveFeedback(current: WizardEditableTokenInput): FeedbackState {
+    if (current.feedbackMessage !== undefined && current.feedbackMessage !== '') {
+      return {
+        message: current.feedbackMessage,
+        tone: current.feedbackTone ?? 'info',
+        source: 'caller',
+      };
+    }
+    const draft = current.draftValue ?? '';
+    if (draft !== '' && current.validateToken !== undefined) {
+      const result = current.validateToken(draft);
+      if (!result.valid) {
+        return {
+          message: result.message ?? 'Token is not valid.',
+          tone: 'danger',
+          source: 'validator',
+        };
+      }
+    }
+    if (
+      draft !== '' &&
+      current.allowDuplicates !== true &&
+      current.value.includes(draft)
+    ) {
+      return {
+        message: `"${draft}" is already in the list.`,
+        tone: 'warning',
+        source: 'duplicate',
+      };
+    }
+    if (
+      current.maxTokens !== undefined &&
+      current.value.length >= current.maxTokens
+    ) {
+      return {
+        message: `Maximum ${current.maxTokens} tokens reached.`,
+        tone: 'warning',
+        source: 'max-tokens',
+      };
+    }
+    return { message: undefined, tone: 'info', source: 'none' };
+  }
+
+  function metadataForToken(
+    current: WizardEditableTokenInput,
+    token: string,
+  ): WizardEditableTokenInputItem | undefined {
+    if (current.items === undefined) return undefined;
+    return current.items.find((entry) => entry.value === token);
+  }
+
+  function deriveRemoveLabel(current: WizardEditableTokenInput, token: string): string {
+    const kind = current.removeLabelKind ?? 'token';
+    return `Remove ${kind} ${token}`;
+  }
+
+  function commitDraft(
+    current: WizardEditableTokenInput,
+    raw: string,
+    change: (next: string[]) => void,
+    draftChange: ((next: string) => void) | undefined,
+  ): void {
+    const trimmed = raw.trim();
+    if (trimmed === '') {
+      if (draftChange !== undefined) draftChange('');
+      return;
+    }
+    let next = trimmed;
+    if (current.validateToken !== undefined) {
+      const result = current.validateToken(trimmed);
+      if (!result.valid) return;
+      if (result.normalized !== undefined) next = result.normalized;
+    }
+    if (current.allowDuplicates !== true && current.value.includes(next)) return;
+    if (
+      current.maxTokens !== undefined &&
+      current.value.length >= current.maxTokens
+    ) {
+      return;
+    }
+    change([...current.value, next]);
+    if (draftChange !== undefined) draftChange('');
+  }
+
+  function removeAt(
+    current: WizardEditableTokenInput,
+    index: number,
+    change: (next: string[]) => void,
+  ): void {
+    if (index < 0 || index >= current.value.length) return;
+    change(current.value.slice(0, index).concat(current.value.slice(index + 1)));
+  }
+
+  function chipStyle(tone: WizardEditableTokenInputTone): string {
+    const palette = chipPalette[tone];
+    return `display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:9999px;background:${palette.background};color:${palette.color};border:1px solid ${palette.border};font-size:12px;line-height:1.4;font-family:var(--stitch-font-label, ui-monospace, SFMono-Regular, Menlo, monospace);`;
+  }
+
+  function feedbackStyle(tone: WizardEditableTokenInputFeedbackTone): string {
+    const palette = feedbackPalette[tone];
+    return `margin:0;padding:6px 10px;border-radius:var(--stitch-radius-sm, 8px);background:${palette.background};color:${palette.color};border:1px solid ${palette.border};font-size:12px;line-height:1.5;`;
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      commitDraft(input, draftValue, onChange, onDraftChange);
+      return;
+    }
+    if (
+      event.key === 'Backspace' &&
+      draftValue === '' &&
+      input.value.length > 0
+    ) {
+      event.preventDefault();
+      removeAt(input, input.value.length - 1, onChange);
+    }
+  }
+
+  function handleInput(event: Event): void {
+    if (onDraftChange !== undefined) {
+      onDraftChange((event.target as HTMLInputElement).value);
+    }
+  }
+
+  $: readOnly = input.readOnly === true || input.disabled === true;
+  $: disabled = input.disabled === true;
+  $: feedback = resolveFeedback(input);
+  $: feedbackId = `${input.inputId}-feedback`;
+  $: descriptionId =
+    input.description !== undefined ? `${input.inputId}-description` : undefined;
+  $: labelId = input.label !== undefined ? `${input.inputId}-label` : undefined;
+  $: draftValue = input.draftValue ?? '';
+  $: tokenPrefix = input.tokenPrefix;
+  $: ariaDescribedBy =
+    [descriptionId, feedback.message !== undefined ? feedbackId : undefined]
+      .filter((id): id is string => typeof id === 'string')
+      .join(' ') || undefined;
+</script>
+
+<section
+  class={`facetheory-stitch-wizard-editable-token-input facetheory-stitch-wizard-editable-token-input-${readOnly ? 'readonly' : 'editable'}${disabled ? ' facetheory-stitch-wizard-editable-token-input-disabled' : ''}`}
+  data-safety-policy={input.safetyPolicy}
+  data-input-id={input.inputId}
+  data-token-count={String(input.value.length)}
+  data-allow-duplicates={input.allowDuplicates === true ? 'true' : 'false'}
+  data-max-tokens={input.maxTokens !== undefined ? String(input.maxTokens) : undefined}
+  data-disabled={disabled ? 'true' : 'false'}
+  data-read-only={input.readOnly === true ? 'true' : 'false'}
+  data-feedback-source={feedback.source}
+  style="display:flex;flex-direction:column;gap:8px;padding:12px;border-radius:var(--stitch-radius-lg, 12px);background:var(--stitch-color-surface-container-low, #f2f3ff);color:var(--stitch-color-on-surface, #131b2e);"
+>
+  {#if input.label !== undefined || input.description !== undefined}
+    <header style="display:flex;flex-direction:column;gap:4px;">
+      {#if input.label !== undefined}
+        <label id={labelId} for={input.inputId} style="font-size:13px;font-weight:600;">
+          {input.label}
+        </label>
+      {/if}
+      {#if input.description !== undefined}
+        <p
+          id={descriptionId}
+          style="margin:0;font-size:12px;line-height:1.5;color:var(--stitch-color-on-surface-variant, #464553);"
+        >
+          {input.description}
+        </p>
+      {/if}
+      {#if input.disabled === true}
+        <span
+          class="facetheory-stitch-wizard-editable-token-input-state"
+          data-state="disabled"
+          aria-label="Disabled"
+          style="align-self:flex-start;font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:var(--stitch-color-on-surface-variant, #464553);"
+        >Disabled</span>
+      {:else if input.readOnly === true}
+        <span
+          class="facetheory-stitch-wizard-editable-token-input-state"
+          data-state="readonly"
+          aria-label="Read-only"
+          style="align-self:flex-start;font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:var(--stitch-color-on-surface-variant, #464553);"
+        >Read-only</span>
+      {/if}
+    </header>
+  {/if}
+
+  {#if input.value.length === 0}
+    <div
+      class="facetheory-stitch-wizard-editable-token-input-empty"
+      role="status"
+      style="font-size:12px;color:var(--stitch-color-on-surface-variant, #464553);"
+    >No tokens yet.</div>
+  {:else}
+    <ul
+      class="facetheory-stitch-wizard-editable-token-input-chips"
+      role="list"
+      style="margin:0;padding:0;list-style:none;display:flex;flex-wrap:wrap;gap:6px;"
+    >
+      {#each input.value as token, index (token + '::' + index)}
+        {@const meta = metadataForToken(input, token)}
+        {@const tone = meta?.tone ?? 'neutral'}
+        {@const removable = !readOnly && meta?.removable !== false && meta?.disabled !== true}
+        <li
+          class={`facetheory-stitch-wizard-editable-token-input-chip facetheory-stitch-wizard-editable-token-input-chip-tone-${tone}${meta?.disabled === true ? ' facetheory-stitch-wizard-editable-token-input-chip-disabled' : ''}`}
+          data-token-value={token}
+          data-token-index={String(index)}
+          data-token-tone={tone}
+          data-token-removable={removable ? 'true' : 'false'}
+          title={meta?.title}
+          style={chipStyle(tone)}
+        >
+          {#if tokenPrefix !== undefined && tokenPrefix !== ''}
+            <span
+              class="facetheory-stitch-wizard-editable-token-input-chip-prefix"
+              aria-hidden="true"
+            >{tokenPrefix}</span>
+          {/if}
+          <span class="facetheory-stitch-wizard-editable-token-input-chip-value">{token}</span>
+          {#if removable}
+            <button
+              type="button"
+              class="facetheory-stitch-wizard-editable-token-input-chip-remove"
+              aria-label={deriveRemoveLabel(input, token)}
+              data-remove-token-index={String(index)}
+              data-remove-token-value={token}
+              disabled={meta?.disabled === true}
+              on:click={() => removeAt(input, index, onChange)}
+              style="appearance:none;background:transparent;border:none;color:inherit;cursor:pointer;font-size:14px;line-height:1;padding:0 2px;"
+            >×</button>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  {#if !readOnly}
+    <div
+      class="facetheory-stitch-wizard-editable-token-input-input-row"
+      style="display:flex;align-items:center;gap:8px;"
+    >
+      <input
+        id={input.inputId}
+        type="text"
+        value={draftValue}
+        placeholder={input.placeholder}
+        {disabled}
+        aria-labelledby={labelId}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid="false"
+        on:input={handleInput}
+        on:keydown={handleKeydown}
+        class="facetheory-stitch-wizard-editable-token-input-input"
+        style="flex:1 1 auto;min-width:0;appearance:none;background:var(--stitch-color-surface-container, #eaedff);border:1px solid var(--stitch-color-outline-variant, #c6c5d0);border-radius:var(--stitch-radius-sm, 8px);padding:6px 10px;font-size:13px;color:var(--stitch-color-on-surface, #131b2e);font-family:inherit;"
+      />
+    </div>
+  {:else}
+    <div
+      class="facetheory-stitch-wizard-editable-token-input-readonly-state"
+      role="status"
+      data-state={input.disabled === true ? 'disabled' : 'readonly'}
+      style="font-size:12px;color:var(--stitch-color-on-surface-variant, #464553);font-style:italic;"
+    >
+      {input.disabled === true ? 'Token entry is disabled.' : 'Token entry is read-only.'}
+    </div>
+  {/if}
+
+  {#if feedback.message !== undefined}
+    <p
+      id={feedbackId}
+      class={`facetheory-stitch-wizard-editable-token-input-feedback facetheory-stitch-wizard-editable-token-input-feedback-${feedback.tone}`}
+      role="alert"
+      aria-live="polite"
+      data-feedback-source={feedback.source}
+      data-feedback-tone={feedback.tone}
+      style={feedbackStyle(feedback.tone)}
+    >{feedback.message}</p>
+  {/if}
+
+  <p
+    class="facetheory-stitch-wizard-safety-footnote"
+    data-safety-policy={input.safetyPolicy}
+    style="margin:0;font-size:11px;letter-spacing:0.04em;text-transform:uppercase;color:var(--stitch-color-on-surface-variant, #464553);"
+  >Safety policy: {input.safetyPolicy}</p>
+</section>

--- a/ts/src/svelte/stitch-admin/index.d.ts
+++ b/ts/src/svelte/stitch-admin/index.d.ts
@@ -250,3 +250,19 @@ export declare const MetadataBadge: Component<MetadataBadgeProps>;
 export declare const MetadataBadgeGroup: Component<MetadataBadgeGroupProps>;
 export declare const NonAuthoritativeBanner: Component<NonAuthoritativeBannerProps>;
 export declare const OperatorEmptyState: Component<OperatorEmptyStateProps>;
+
+export interface WizardEditableTokenInputPanelProps {
+  input: import('../../stitch-admin/wizard-editable-token-input-types.js').WizardEditableTokenInput;
+  onChange: (next: string[]) => void;
+  onDraftChange?: (next: string) => void;
+}
+export type WizardChipListPanelProps = WizardEditableTokenInputPanelProps;
+export declare const WizardEditableTokenInputPanel: Component<WizardEditableTokenInputPanelProps>;
+export declare const WizardChipListPanel: Component<WizardChipListPanelProps>;
+export type {
+  WizardEditableTokenInput,
+  WizardEditableTokenInputFeedbackTone,
+  WizardEditableTokenInputItem,
+  WizardEditableTokenInputTone,
+  WizardEditableTokenInputValidationResult,
+} from '../../stitch-admin/wizard-editable-token-input-types.js';

--- a/ts/src/svelte/stitch-admin/index.ts
+++ b/ts/src/svelte/stitch-admin/index.ts
@@ -22,6 +22,18 @@ export { default as MetadataBadge } from './MetadataBadge.svelte';
 export { default as MetadataBadgeGroup } from './MetadataBadgeGroup.svelte';
 export { default as NonAuthoritativeBanner } from './NonAuthoritativeBanner.svelte';
 export { default as OperatorEmptyState } from './OperatorEmptyState.svelte';
+export { default as WizardEditableTokenInputPanel } from './WizardEditableTokenInputPanel.svelte';
+export { default as WizardChipListPanel } from './WizardEditableTokenInputPanel.svelte';
+
+export type {
+  WizardEditableTokenInput,
+  WizardEditableTokenInputFeedbackTone,
+  WizardEditableTokenInputItem,
+  WizardEditableTokenInputTone,
+  WizardEditableTokenInputValidationResult,
+  WizardEditableTokenInputPanelProps,
+  WizardChipListPanelProps,
+} from './types.js';
 
 export type {
   DataTableToolbarSlots,

--- a/ts/src/svelte/stitch-admin/types.ts
+++ b/ts/src/svelte/stitch-admin/types.ts
@@ -136,3 +136,19 @@ export interface OperatorEmptyStateProps {
   config: import('../../stitch-admin/operator-visibility-types.js').OperatorEmptyStateConfig;
   action?: unknown;
 }
+
+export type {
+  WizardEditableTokenInput,
+  WizardEditableTokenInputFeedbackTone,
+  WizardEditableTokenInputItem,
+  WizardEditableTokenInputTone,
+  WizardEditableTokenInputValidationResult,
+} from '../../stitch-admin/wizard-editable-token-input-types.js';
+
+export interface WizardEditableTokenInputPanelProps {
+  input: import('../../stitch-admin/wizard-editable-token-input-types.js').WizardEditableTokenInput;
+  onChange: (next: string[]) => void;
+  onDraftChange?: (next: string) => void;
+}
+
+export type WizardChipListPanelProps = WizardEditableTokenInputPanelProps;

--- a/ts/src/vue/stitch-admin/index.ts
+++ b/ts/src/vue/stitch-admin/index.ts
@@ -78,3 +78,14 @@ export {
   type OperatorGuardState,
   type OperatorGuardStatus,
 } from './operator-guard.js';
+
+export {
+  WizardEditableTokenInputPanel,
+  WizardChipListPanel,
+  type WizardEditableTokenInputPanelProps,
+  type WizardChipListPanelProps,
+  type WizardEditableTokenInput,
+  type WizardEditableTokenInputFeedbackTone,
+  type WizardEditableTokenInputItem,
+  type WizardEditableTokenInputTone,
+} from './wizard-editable-token-input.js';

--- a/ts/src/vue/stitch-admin/wizard-editable-token-input.ts
+++ b/ts/src/vue/stitch-admin/wizard-editable-token-input.ts
@@ -1,0 +1,599 @@
+import { defineComponent, h } from 'vue';
+import type { PropType, VNodeChild } from 'vue';
+
+import type {
+  WizardEditableTokenInput,
+  WizardEditableTokenInputFeedbackTone,
+  WizardEditableTokenInputItem,
+  WizardEditableTokenInputTone,
+} from '../../stitch-admin/wizard-editable-token-input-types.js';
+import { renderPropContent } from '../stitch-common.js';
+
+const REDACTED_MARKER = '[redacted]';
+
+interface ChipPalette {
+  background: string;
+  color: string;
+  border: string;
+}
+
+const chipPalette: Record<WizardEditableTokenInputTone, ChipPalette> = {
+  neutral: {
+    background: 'var(--stitch-color-surface-container-high, #e2e7ff)',
+    color: 'var(--stitch-color-on-surface, #131b2e)',
+    border: 'var(--stitch-color-outline-variant, #c6c5d0)',
+  },
+  info: {
+    background: 'var(--stitch-color-primary-container, #e0e0ff)',
+    color: 'var(--stitch-color-on-primary-container, #000066)',
+    border: 'var(--stitch-color-primary-container, #e0e0ff)',
+  },
+  success: {
+    background: 'var(--stitch-color-tertiary-container, #004c45)',
+    color: 'var(--stitch-color-on-tertiary-container, #52c1b4)',
+    border: 'var(--stitch-color-tertiary-container, #004c45)',
+  },
+  warning: {
+    background: 'var(--stitch-color-secondary-container, #ffecc0)',
+    color: 'var(--stitch-color-on-secondary-container, #3f2e00)',
+    border: 'var(--stitch-color-secondary-container, #ffecc0)',
+  },
+  danger: {
+    background: 'var(--stitch-color-error-container, #ffdad6)',
+    color: 'var(--stitch-color-on-error-container, #93000a)',
+    border: 'var(--stitch-color-error-container, #ffdad6)',
+  },
+};
+
+const feedbackPalette: Record<WizardEditableTokenInputFeedbackTone, ChipPalette> = {
+  info: chipPalette.info,
+  success: chipPalette.success,
+  warning: chipPalette.warning,
+  danger: chipPalette.danger,
+};
+
+interface FeedbackState {
+  message: string | undefined;
+  tone: WizardEditableTokenInputFeedbackTone;
+  source: 'caller' | 'validator' | 'duplicate' | 'max-tokens' | 'none';
+}
+
+function resolveFeedback(input: WizardEditableTokenInput): FeedbackState {
+  if (input.feedbackMessage !== undefined && input.feedbackMessage !== '') {
+    return {
+      message: input.feedbackMessage,
+      tone: input.feedbackTone ?? 'info',
+      source: 'caller',
+    };
+  }
+  const draft = input.draftValue ?? '';
+  if (draft !== '' && input.validateToken !== undefined) {
+    const result = input.validateToken(draft);
+    if (!result.valid) {
+      return {
+        message: result.message ?? 'Token is not valid.',
+        tone: 'danger',
+        source: 'validator',
+      };
+    }
+  }
+  if (
+    draft !== '' &&
+    input.allowDuplicates !== true &&
+    input.value.includes(draft)
+  ) {
+    return {
+      message: `"${draft}" is already in the list.`,
+      tone: 'warning',
+      source: 'duplicate',
+    };
+  }
+  if (
+    input.maxTokens !== undefined &&
+    input.value.length >= input.maxTokens
+  ) {
+    return {
+      message: `Maximum ${input.maxTokens} tokens reached.`,
+      tone: 'warning',
+      source: 'max-tokens',
+    };
+  }
+  return { message: undefined, tone: 'info', source: 'none' };
+}
+
+function metadataForToken(
+  input: WizardEditableTokenInput,
+  token: string,
+): WizardEditableTokenInputItem | undefined {
+  if (input.items === undefined) return undefined;
+  return input.items.find((entry) => entry.value === token);
+}
+
+function deriveRemoveLabel(
+  input: WizardEditableTokenInput,
+  token: string,
+): string {
+  const kind = input.removeLabelKind ?? 'token';
+  return `Remove ${kind} ${token}`;
+}
+
+function commitDraft(
+  input: WizardEditableTokenInput,
+  raw: string,
+  onChange: (next: string[]) => void,
+  onDraftChange: ((next: string) => void) | undefined,
+): void {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    if (onDraftChange !== undefined) onDraftChange('');
+    return;
+  }
+  let next = trimmed;
+  if (input.validateToken !== undefined) {
+    const result = input.validateToken(trimmed);
+    if (!result.valid) return;
+    if (result.normalized !== undefined) next = result.normalized;
+  }
+  if (input.allowDuplicates !== true && input.value.includes(next)) return;
+  if (input.maxTokens !== undefined && input.value.length >= input.maxTokens) {
+    return;
+  }
+  onChange([...input.value, next]);
+  if (onDraftChange !== undefined) onDraftChange('');
+}
+
+function removeAt(
+  input: WizardEditableTokenInput,
+  index: number,
+  onChange: (next: string[]) => void,
+): void {
+  if (index < 0 || index >= input.value.length) return;
+  onChange(input.value.slice(0, index).concat(input.value.slice(index + 1)));
+}
+
+export interface WizardEditableTokenInputPanelProps {
+  input: WizardEditableTokenInput;
+  onChange: (next: string[]) => void;
+  onDraftChange?: (next: string) => void;
+}
+
+/**
+ * Vue parity for the React `WizardEditableTokenInputPanel`. Renders the same
+ * DOM, classes, data-* attributes, and ARIA wiring so consumers see a
+ * matching primitive across adapters. Controlled — no hidden state, no
+ * `Math.random()`, no `Date.now()`, no `window` reads, no server validation
+ * at render time.
+ */
+export const WizardEditableTokenInputPanel = defineComponent({
+  name: 'FaceTheoryVueWizardEditableTokenInputPanel',
+  props: {
+    input: {
+      type: Object as PropType<WizardEditableTokenInput>,
+      required: true,
+    },
+    onChange: {
+      type: Function as PropType<(next: string[]) => void>,
+      required: true,
+    },
+    onDraftChange: {
+      type: Function as PropType<(next: string) => void>,
+      required: false,
+    },
+  },
+  setup(props) {
+    return () => {
+      const input = props.input;
+      const onChange = props.onChange;
+      const onDraftChange = props.onDraftChange;
+      const readOnly = input.readOnly === true || input.disabled === true;
+      const disabled = input.disabled === true;
+      const feedback = resolveFeedback(input);
+      const feedbackId = `${input.inputId}-feedback`;
+      const descriptionId =
+        input.description !== undefined
+          ? `${input.inputId}-description`
+          : undefined;
+      const labelId =
+        input.label !== undefined ? `${input.inputId}-label` : undefined;
+      const draftValue = input.draftValue ?? '';
+      const tokenPrefix = input.tokenPrefix;
+      const ariaDescribedBy =
+        [descriptionId, feedback.message !== undefined ? feedbackId : undefined]
+          .filter((id): id is string => typeof id === 'string')
+          .join(' ') || undefined;
+
+      return h(
+        'section',
+        {
+          class: `facetheory-stitch-wizard-editable-token-input facetheory-stitch-wizard-editable-token-input-${readOnly ? 'readonly' : 'editable'}${disabled ? ' facetheory-stitch-wizard-editable-token-input-disabled' : ''}`,
+          'data-safety-policy': input.safetyPolicy,
+          'data-input-id': input.inputId,
+          'data-token-count': String(input.value.length),
+          'data-allow-duplicates': input.allowDuplicates === true ? 'true' : 'false',
+          'data-max-tokens':
+            input.maxTokens !== undefined ? String(input.maxTokens) : undefined,
+          'data-disabled': disabled ? 'true' : 'false',
+          'data-read-only': input.readOnly === true ? 'true' : 'false',
+          'data-feedback-source': feedback.source,
+          style: {
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '8px',
+            padding: '12px',
+            borderRadius: 'var(--stitch-radius-lg, 12px)',
+            background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+            color: 'var(--stitch-color-on-surface, #131b2e)',
+          },
+        },
+        [
+          renderHeader(input, labelId, descriptionId),
+          renderChipRow(input, onChange, readOnly, tokenPrefix),
+          !readOnly
+            ? renderInputRow(
+                input,
+                onChange,
+                onDraftChange,
+                ariaDescribedBy,
+                draftValue,
+                disabled,
+                labelId,
+              )
+            : renderReadOnlyState(input),
+          feedback.message !== undefined
+            ? renderFeedback(feedback, feedbackId)
+            : null,
+          renderSafetyFootnote(input.safetyPolicy),
+        ],
+      );
+    };
+  },
+});
+
+/** ChipList alias matching the React adapter's alternate naming. */
+export const WizardChipListPanel = WizardEditableTokenInputPanel;
+export type WizardChipListPanelProps = WizardEditableTokenInputPanelProps;
+
+function renderHeader(
+  input: WizardEditableTokenInput,
+  labelId: string | undefined,
+  descriptionId: string | undefined,
+): VNodeChild {
+  if (input.label === undefined && input.description === undefined) return null;
+  return h(
+    'header',
+    {
+      style: { display: 'flex', flexDirection: 'column', gap: '4px' },
+    },
+    [
+      input.label !== undefined
+        ? h(
+            'label',
+            {
+              id: labelId,
+              for: input.inputId,
+              style: { fontSize: '13px', fontWeight: 600 },
+            },
+            renderPropContent(input.label as VNodeChild),
+          )
+        : null,
+      input.description !== undefined
+        ? h(
+            'p',
+            {
+              id: descriptionId,
+              style: {
+                margin: 0,
+                fontSize: '12px',
+                lineHeight: 1.5,
+                color: 'var(--stitch-color-on-surface-variant, #464553)',
+              },
+            },
+            renderPropContent(input.description as VNodeChild),
+          )
+        : null,
+      input.disabled === true
+        ? h(
+            'span',
+            {
+              class: 'facetheory-stitch-wizard-editable-token-input-state',
+              'data-state': 'disabled',
+              'aria-label': 'Disabled',
+              style: {
+                alignSelf: 'flex-start',
+                fontSize: '11px',
+                fontWeight: 600,
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase',
+                color: 'var(--stitch-color-on-surface-variant, #464553)',
+              },
+            },
+            'Disabled',
+          )
+        : input.readOnly === true
+          ? h(
+              'span',
+              {
+                class: 'facetheory-stitch-wizard-editable-token-input-state',
+                'data-state': 'readonly',
+                'aria-label': 'Read-only',
+                style: {
+                  alignSelf: 'flex-start',
+                  fontSize: '11px',
+                  fontWeight: 600,
+                  letterSpacing: '0.06em',
+                  textTransform: 'uppercase',
+                  color: 'var(--stitch-color-on-surface-variant, #464553)',
+                },
+              },
+              'Read-only',
+            )
+          : null,
+    ],
+  );
+}
+
+function renderChipRow(
+  input: WizardEditableTokenInput,
+  onChange: (next: string[]) => void,
+  readOnly: boolean,
+  tokenPrefix: string | undefined,
+): VNodeChild {
+  if (input.value.length === 0) {
+    return h(
+      'div',
+      {
+        class: 'facetheory-stitch-wizard-editable-token-input-empty',
+        role: 'status',
+        style: {
+          fontSize: '12px',
+          color: 'var(--stitch-color-on-surface-variant, #464553)',
+        },
+      },
+      'No tokens yet.',
+    );
+  }
+  return h(
+    'ul',
+    {
+      class: 'facetheory-stitch-wizard-editable-token-input-chips',
+      role: 'list',
+      style: {
+        margin: 0,
+        padding: 0,
+        listStyle: 'none',
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '6px',
+      },
+    },
+    input.value.map((token, index) =>
+      renderChip(input, token, index, onChange, readOnly, tokenPrefix),
+    ),
+  );
+}
+
+function renderChip(
+  input: WizardEditableTokenInput,
+  token: string,
+  index: number,
+  onChange: (next: string[]) => void,
+  readOnly: boolean,
+  tokenPrefix: string | undefined,
+): VNodeChild {
+  const meta = metadataForToken(input, token);
+  const tone: WizardEditableTokenInputTone = meta?.tone ?? 'neutral';
+  const palette = chipPalette[tone];
+  const isRemovable =
+    !readOnly && meta?.removable !== false && meta?.disabled !== true;
+  const removeLabel = deriveRemoveLabel(input, token);
+  return h(
+    'li',
+    {
+      key: `${token}::${index}`,
+      class: `facetheory-stitch-wizard-editable-token-input-chip facetheory-stitch-wizard-editable-token-input-chip-tone-${tone}${meta?.disabled === true ? ' facetheory-stitch-wizard-editable-token-input-chip-disabled' : ''}`,
+      'data-token-value': token,
+      'data-token-index': String(index),
+      'data-token-tone': tone,
+      'data-token-removable': isRemovable ? 'true' : 'false',
+      title: meta?.title,
+      style: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '4px 8px',
+        borderRadius: '9999px',
+        background: palette.background,
+        color: palette.color,
+        border: `1px solid ${palette.border}`,
+        fontSize: '12px',
+        lineHeight: 1.4,
+        fontFamily:
+          'var(--stitch-font-label, ui-monospace, SFMono-Regular, Menlo, monospace)',
+      },
+    },
+    [
+      tokenPrefix !== undefined && tokenPrefix !== ''
+        ? h(
+            'span',
+            {
+              class: 'facetheory-stitch-wizard-editable-token-input-chip-prefix',
+              'aria-hidden': 'true',
+            },
+            tokenPrefix,
+          )
+        : null,
+      h(
+        'span',
+        {
+          class: 'facetheory-stitch-wizard-editable-token-input-chip-value',
+        },
+        token,
+      ),
+      isRemovable
+        ? h(
+            'button',
+            {
+              type: 'button',
+              class: 'facetheory-stitch-wizard-editable-token-input-chip-remove',
+              'aria-label': removeLabel,
+              'data-remove-token-index': String(index),
+              'data-remove-token-value': token,
+              disabled: meta?.disabled === true,
+              onClick: () => removeAt(input, index, onChange),
+              style: {
+                appearance: 'none',
+                background: 'transparent',
+                border: 'none',
+                color: 'inherit',
+                cursor: 'pointer',
+                fontSize: '14px',
+                lineHeight: 1,
+                padding: '0 2px',
+              },
+            },
+            '×',
+          )
+        : null,
+    ],
+  );
+}
+
+function renderInputRow(
+  input: WizardEditableTokenInput,
+  onChange: (next: string[]) => void,
+  onDraftChange: ((next: string) => void) | undefined,
+  ariaDescribedBy: string | undefined,
+  draftValue: string,
+  disabled: boolean,
+  labelId: string | undefined,
+): VNodeChild {
+  return h(
+    'div',
+    {
+      class: 'facetheory-stitch-wizard-editable-token-input-input-row',
+      style: { display: 'flex', alignItems: 'center', gap: '8px' },
+    },
+    h('input', {
+      id: input.inputId,
+      type: 'text',
+      value: draftValue,
+      placeholder: input.placeholder,
+      disabled,
+      'aria-labelledby': labelId,
+      'aria-describedby': ariaDescribedBy,
+      'aria-invalid': 'false',
+      onInput: (event: Event) => {
+        if (onDraftChange !== undefined) {
+          onDraftChange((event.target as HTMLInputElement).value);
+        }
+      },
+      onKeydown: (event: KeyboardEvent) => {
+        if (event.key === 'Enter' || event.key === ',') {
+          event.preventDefault();
+          commitDraft(input, draftValue, onChange, onDraftChange);
+          return;
+        }
+        if (
+          event.key === 'Backspace' &&
+          draftValue === '' &&
+          input.value.length > 0
+        ) {
+          event.preventDefault();
+          removeAt(input, input.value.length - 1, onChange);
+        }
+      },
+      class: 'facetheory-stitch-wizard-editable-token-input-input',
+      style: {
+        flex: '1 1 auto',
+        minWidth: 0,
+        appearance: 'none',
+        background: 'var(--stitch-color-surface-container, #eaedff)',
+        border: '1px solid var(--stitch-color-outline-variant, #c6c5d0)',
+        borderRadius: 'var(--stitch-radius-sm, 8px)',
+        padding: '6px 10px',
+        fontSize: '13px',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+        fontFamily: 'inherit',
+      },
+    }),
+  );
+}
+
+function renderReadOnlyState(input: WizardEditableTokenInput): VNodeChild {
+  return h(
+    'div',
+    {
+      class: 'facetheory-stitch-wizard-editable-token-input-readonly-state',
+      role: 'status',
+      'data-state': input.disabled === true ? 'disabled' : 'readonly',
+      style: {
+        fontSize: '12px',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+        fontStyle: 'italic',
+      },
+    },
+    input.disabled === true
+      ? 'Token entry is disabled.'
+      : 'Token entry is read-only.',
+  );
+}
+
+function renderFeedback(
+  feedback: FeedbackState,
+  feedbackId: string,
+): VNodeChild {
+  const palette = feedbackPalette[feedback.tone];
+  return h(
+    'p',
+    {
+      id: feedbackId,
+      class: `facetheory-stitch-wizard-editable-token-input-feedback facetheory-stitch-wizard-editable-token-input-feedback-${feedback.tone}`,
+      role: 'alert',
+      'aria-live': 'polite',
+      'data-feedback-source': feedback.source,
+      'data-feedback-tone': feedback.tone,
+      style: {
+        margin: 0,
+        padding: '6px 10px',
+        borderRadius: 'var(--stitch-radius-sm, 8px)',
+        background: palette.background,
+        color: palette.color,
+        border: `1px solid ${palette.border}`,
+        fontSize: '12px',
+        lineHeight: 1.5,
+      },
+    },
+    feedback.message,
+  );
+}
+
+function renderSafetyFootnote(policy: string): VNodeChild {
+  return h(
+    'p',
+    {
+      class: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+      style: {
+        margin: 0,
+        fontSize: '11px',
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+      },
+    },
+    `Safety policy: ${policy}`,
+  );
+}
+
+// Re-export shared types for vue consumers (mirrors react adapter shape).
+export type {
+  WizardEditableTokenInput,
+  WizardEditableTokenInputFeedbackTone,
+  WizardEditableTokenInputItem,
+  WizardEditableTokenInputTone,
+} from '../../stitch-admin/wizard-editable-token-input-types.js';
+
+// Note: `REDACTED_MARKER` reserved for future redaction wiring; the editable
+// token input is value-only and does not surface secret-like data, but the
+// constant is kept aligned with the React/Svelte adapters.
+void REDACTED_MARKER;

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -22,6 +22,7 @@ await import('./unit/stitch-admin.test.js');
 await import('./unit/stitch-admin-wizard.test.js');
 await import('./unit/stitch-admin-wizard-reconciliation-plan.test.js');
 await import('./unit/stitch-admin-wizard-authority-context-strip.test.js');
+await import('./unit/stitch-admin-wizard-editable-token-input.test.js');
 await import('./unit/portal-fixtures.test.js');
 await import('./unit/antd-coverage.test.js');
 await import('./unit/portal-reference.test.js');

--- a/ts/test/unit/stitch-admin-wizard-editable-token-input.test.ts
+++ b/ts/test/unit/stitch-admin-wizard-editable-token-input.test.ts
@@ -1,0 +1,381 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as React from 'react';
+
+import { createFaceApp } from '../../src/app.js';
+import { createReactFace } from '../../src/adapters/react.js';
+import { createAntdIntegration } from '../../src/react/antd.js';
+import type { WizardEditableTokenInput } from '../../src/stitch-admin/index.js';
+import {
+  WizardChipListPanel,
+  WizardEditableTokenInputPanel,
+} from '../../src/react/stitch-admin/index.js';
+
+const h = React.createElement;
+
+async function renderSSR(element: React.ReactElement): Promise<string> {
+  const app = createFaceApp({
+    faces: [
+      createReactFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => element,
+        renderOptions: {
+          integrations: [createAntdIntegration({ hashed: false })],
+        },
+      }),
+    ],
+  });
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  return new TextDecoder().decode(resp.body as Uint8Array);
+}
+
+function countMatches(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+const NOOP_CHANGE = (): void => {};
+
+const BASE_INPUT: WizardEditableTokenInput = {
+  inputId: 'allowed-senders',
+  value: ['qa@example.com', 'ops@example.com'],
+  label: 'Allowed senders',
+  description: 'Server validation remains authoritative.',
+  placeholder: 'Add another address…',
+  removeLabelKind: 'sender',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+/* -------------------------------------------------------------------------- */
+/* Caller-supplied state passthrough                                          */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel renders caller-supplied tokens in order with stable data attributes', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, { input: BASE_INPUT, onChange: NOOP_CHANGE }),
+  );
+
+  assert.ok(body.includes('facetheory-stitch-wizard-editable-token-input'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(body.includes('data-input-id="allowed-senders"'));
+  assert.ok(body.includes('data-token-count="2"'));
+  assert.ok(body.includes('data-disabled="false"'));
+  assert.ok(body.includes('data-read-only="false"'));
+
+  // Tokens render in order.
+  const qaIdx = body.indexOf('data-token-value="qa@example.com"');
+  const opsIdx = body.indexOf('data-token-value="ops@example.com"');
+  assert.ok(qaIdx > -1 && opsIdx > qaIdx);
+
+  // Label + description rendered.
+  assert.ok(body.includes('Allowed senders'));
+  assert.ok(body.includes('Server validation remains authoritative.'));
+
+  // Label wired via htmlFor + matching input id.
+  assert.ok(body.includes('for="allowed-senders"'));
+  assert.ok(body.includes('id="allowed-senders"'));
+
+  // Description carries a stable id used in aria-describedby.
+  assert.ok(body.includes('id="allowed-senders-description"'));
+  assert.ok(body.includes('aria-describedby="allowed-senders-description"'));
+
+  // Placeholder rendered.
+  assert.ok(body.includes('placeholder="Add another address…"'));
+
+  // Section is the editable variant in the default state.
+  assert.ok(body.includes('facetheory-stitch-wizard-editable-token-input-editable'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Accessible Remove button                                                   */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel renders accessible Remove button for each token', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, { input: BASE_INPUT, onChange: NOOP_CHANGE }),
+  );
+
+  // Real <button type="button"> per token.
+  assert.equal(countMatches(body, 'aria-label="Remove sender qa@example.com"'), 1);
+  assert.equal(countMatches(body, 'aria-label="Remove sender ops@example.com"'), 1);
+  assert.equal(countMatches(body, '<button type="button"'), 2);
+  assert.ok(body.includes('data-remove-token-value="qa@example.com"'));
+  assert.ok(body.includes('data-remove-token-index="0"'));
+  assert.ok(body.includes('data-remove-token-value="ops@example.com"'));
+  assert.ok(body.includes('data-remove-token-index="1"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Per-token metadata: tone, title, disabled, removable                       */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel honours per-token metadata for tone, removability, and disabled', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: {
+        ...BASE_INPUT,
+        value: ['qa@example.com', 'system@example.com', 'frozen@example.com'],
+        items: [
+          { value: 'qa@example.com', tone: 'success' },
+          { value: 'system@example.com', removable: false, title: 'System-managed' },
+          { value: 'frozen@example.com', disabled: true },
+        ],
+      },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+
+  // Tone applied to the first chip.
+  assert.ok(body.includes('data-token-value="qa@example.com"'));
+  assert.ok(body.includes('data-token-tone="success"'));
+
+  // Non-removable token has no Remove button and is marked accordingly.
+  assert.ok(body.includes('data-token-value="system@example.com"'));
+  const systemIdx = body.indexOf('data-token-value="system@example.com"');
+  const systemSnippet = body.slice(systemIdx, systemIdx + 1200);
+  assert.ok(!systemSnippet.includes('data-remove-token-value="system@example.com"'));
+  assert.ok(systemSnippet.includes('data-token-removable="false"'));
+  // Title attribute carried over.
+  assert.ok(systemSnippet.includes('title="System-managed"'));
+
+  // Disabled token: chip class marker is rendered.
+  assert.ok(body.includes('facetheory-stitch-wizard-editable-token-input-chip-disabled'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* tokenPrefix and draftValue                                                 */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel renders tokenPrefix and draftValue', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: {
+        ...BASE_INPUT,
+        tokenPrefix: '@',
+        draftValue: 'newuser',
+      },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+
+  // Prefix rendered with aria-hidden on every chip.
+  assert.equal(countMatches(body, 'aria-hidden="true">@<'), 2);
+  // Draft value flows through to the input element.
+  assert.ok(body.includes('value="newuser"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Validator-driven feedback                                                  */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel renders validateToken-driven feedback with role="alert"', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: {
+        ...BASE_INPUT,
+        draftValue: 'not-an-email',
+        validateToken: (token: string) =>
+          token.includes('@')
+            ? { valid: true }
+            : { valid: false, message: 'Address must contain @' },
+      },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+
+  assert.ok(body.includes('role="alert"'));
+  assert.ok(body.includes('Address must contain @'));
+  assert.ok(body.includes('data-feedback-source="validator"'));
+  assert.ok(body.includes('data-feedback-tone="danger"'));
+  // The input is wired via aria-describedby to the feedback element.
+  assert.ok(body.includes('aria-describedby="allowed-senders-description allowed-senders-feedback"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Duplicate feedback                                                         */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel surfaces duplicate feedback when allowDuplicates !== true', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: {
+        ...BASE_INPUT,
+        draftValue: 'qa@example.com',
+      },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+
+  assert.ok(body.includes('data-feedback-source="duplicate"'));
+  assert.ok(body.includes('is already in the list'));
+});
+
+test('WizardEditableTokenInputPanel does not surface duplicate feedback when allowDuplicates is true', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: {
+        ...BASE_INPUT,
+        draftValue: 'qa@example.com',
+        allowDuplicates: true,
+      },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+  assert.ok(!body.includes('data-feedback-source="duplicate"'));
+  assert.ok(!body.includes('is already in the list'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* maxTokens feedback                                                         */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel surfaces maxTokens feedback when at capacity', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: {
+        ...BASE_INPUT,
+        maxTokens: 2,
+      },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('data-feedback-source="max-tokens"'));
+  assert.ok(body.includes('Maximum 2 tokens reached.'));
+  assert.ok(body.includes('data-max-tokens="2"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Caller-supplied feedback wins                                              */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel prefers caller-supplied feedbackMessage over computed feedback', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: {
+        ...BASE_INPUT,
+        draftValue: 'qa@example.com', // would normally trigger duplicate
+        feedbackMessage: 'Server says: address pending review',
+        feedbackTone: 'warning',
+      },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+
+  assert.ok(body.includes('Server says: address pending review'));
+  assert.ok(body.includes('data-feedback-source="caller"'));
+  assert.ok(body.includes('data-feedback-tone="warning"'));
+  assert.ok(!body.includes('is already in the list'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Disabled / read-only text labeling                                         */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel labels disabled state as text and disables the input', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: { ...BASE_INPUT, disabled: true },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('data-disabled="true"'));
+  // Text label in the header.
+  assert.ok(body.includes('aria-label="Disabled"'));
+  assert.ok(body.includes('data-state="disabled"'));
+  // No editable input element rendered in the read-only/disabled state.
+  assert.ok(!body.includes('type="text"'));
+  assert.ok(!body.includes('facetheory-stitch-wizard-editable-token-input-input"'));
+  // Read-only / disabled state announced as status.
+  assert.ok(body.includes('Token entry is disabled.'));
+  // Remove buttons not rendered in disabled state.
+  assert.ok(!body.includes('data-remove-token-value="qa@example.com"'));
+});
+
+test('WizardEditableTokenInputPanel labels read-only state as text and disables Remove buttons', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: { ...BASE_INPUT, readOnly: true },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('data-read-only="true"'));
+  assert.ok(body.includes('aria-label="Read-only"'));
+  assert.ok(body.includes('Token entry is read-only.'));
+  // No editable input element rendered.
+  assert.ok(!body.includes('type="text"'));
+  assert.ok(!body.includes('facetheory-stitch-wizard-editable-token-input-input"'));
+  // Remove buttons are not present (chips render but without remove control).
+  assert.ok(!body.includes('data-remove-token-value="qa@example.com"'));
+  assert.ok(body.includes('data-token-removable="false"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Empty state                                                                */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel renders empty-tokens placeholder when value is empty', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, {
+      input: { ...BASE_INPUT, value: [] },
+      onChange: NOOP_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('facetheory-stitch-wizard-editable-token-input-empty'));
+  assert.ok(body.includes('No tokens yet.'));
+  assert.ok(body.includes('data-token-count="0"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Determinism                                                                */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel produces byte-identical SSR output for the same props', async () => {
+  const first = await renderSSR(
+    h(WizardEditableTokenInputPanel, { input: BASE_INPUT, onChange: NOOP_CHANGE }),
+  );
+  const second = await renderSSR(
+    h(WizardEditableTokenInputPanel, { input: BASE_INPUT, onChange: NOOP_CHANGE }),
+  );
+  assert.equal(first, second, 'editable token input must be deterministic');
+});
+
+/* -------------------------------------------------------------------------- */
+/* ChipList alias                                                             */
+/* -------------------------------------------------------------------------- */
+
+test('WizardChipListPanel alias renders the same DOM as WizardEditableTokenInputPanel', async () => {
+  const canonical = await renderSSR(
+    h(WizardEditableTokenInputPanel, { input: BASE_INPUT, onChange: NOOP_CHANGE }),
+  );
+  const alias = await renderSSR(
+    h(WizardChipListPanel, { input: BASE_INPUT, onChange: NOOP_CHANGE }),
+  );
+  assert.equal(canonical, alias, 'ChipList alias must render identically');
+});
+
+/* -------------------------------------------------------------------------- */
+/* Safety policy footnote + fixture guard                                     */
+/* -------------------------------------------------------------------------- */
+
+test('WizardEditableTokenInputPanel renders the safety-policy footnote into the DOM', async () => {
+  const body = await renderSSR(
+    h(WizardEditableTokenInputPanel, { input: BASE_INPUT, onChange: NOOP_CHANGE }),
+  );
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+  assert.ok(body.includes('facetheory-stitch-wizard-safety-footnote'));
+});
+
+test('WizardEditableTokenInputPanel fixture contains no obvious production-like or secret values', () => {
+  const serialized = JSON.stringify(BASE_INPUT);
+  const forbidden = [
+    'AKIA',
+    'aws_secret',
+    'BEGIN PRIVATE KEY',
+    'Authorization:',
+    'api_key=',
+  ];
+  for (const needle of forbidden) {
+    assert.equal(serialized.includes(needle), false, `fixture must not include "${needle}"`);
+  }
+});

--- a/ts/test/unit/svelte-stitch-admin.test.ts
+++ b/ts/test/unit/svelte-stitch-admin.test.ts
@@ -458,3 +458,94 @@ test('svelte stitch-admin: VisibilityMatrix renders explicit empty matrix cells'
   assert.ok(body.includes('No imported visibility record'));
   assert.ok(body.includes('data-cell-state="unknown"'));
 });
+
+test('svelte stitch-admin: WizardEditableTokenInputPanel renders parity DOM with React adapter', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    {
+      input: {
+        inputId: 'svelte-allowed-senders',
+        value: ['qa@example.com', 'ops@example.com'],
+        label: 'Allowed senders',
+        description: 'Server validation remains authoritative.',
+        placeholder: 'Add another address…',
+        removeLabelKind: 'sender',
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+      onChange: (): void => {},
+    },
+  );
+  assert.ok(body.includes('facetheory-stitch-wizard-editable-token-input'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(body.includes('data-input-id="svelte-allowed-senders"'));
+  assert.ok(body.includes('data-token-count="2"'));
+  assert.ok(body.includes('data-token-value="qa@example.com"'));
+  assert.ok(body.includes('data-token-value="ops@example.com"'));
+  assert.ok(body.includes('aria-label="Remove sender qa@example.com"'));
+  assert.ok(body.includes('aria-label="Remove sender ops@example.com"'));
+  assert.ok(body.includes('for="svelte-allowed-senders"'));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+test('svelte stitch-admin: WizardEditableTokenInputPanel surfaces invalid + duplicate feedback with role=alert', async () => {
+  const invalidBody = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    {
+      input: {
+        inputId: 'svelte-allowed-senders-invalid',
+        value: ['qa@example.com'],
+        label: 'Allowed senders',
+        draftValue: 'not-an-email',
+        removeLabelKind: 'sender',
+        validateToken: (token: string) =>
+          token.includes('@')
+            ? { valid: true }
+            : { valid: false, message: 'Address must contain @' },
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+      onChange: (): void => {},
+    },
+  );
+  assert.ok(invalidBody.includes('role="alert"'));
+  assert.ok(invalidBody.includes('data-feedback-source="validator"'));
+  assert.ok(invalidBody.includes('Address must contain @'));
+
+  const duplicateBody = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    {
+      input: {
+        inputId: 'svelte-allowed-senders-duplicate',
+        value: ['qa@example.com'],
+        label: 'Allowed senders',
+        draftValue: 'qa@example.com',
+        removeLabelKind: 'sender',
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+      onChange: (): void => {},
+    },
+  );
+  assert.ok(duplicateBody.includes('data-feedback-source="duplicate"'));
+  assert.ok(duplicateBody.includes('is already in the list'));
+});
+
+test('svelte stitch-admin: WizardEditableTokenInputPanel is byte-identical across repeated SSR renders', async () => {
+  const props = {
+    input: {
+      inputId: 'svelte-allowed-senders-determinism',
+      value: ['qa@example.com', 'ops@example.com'],
+      label: 'Allowed senders',
+      removeLabelKind: 'sender',
+      safetyPolicy: 'no-secret-or-production-like-data',
+    },
+    onChange: (): void => {},
+  };
+  const first = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    props,
+  );
+  const second = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    props,
+  );
+  assert.equal(first, second);
+});

--- a/ts/test/unit/vue-stitch-admin.test.ts
+++ b/ts/test/unit/vue-stitch-admin.test.ts
@@ -641,3 +641,99 @@ test('vue stitch-admin: tabs, chips, key-value rows, copy code, logs, and policy
   assert.ok(body.includes('Deny'));
   assert.ok(body.includes('Warning'));
 });
+
+import { WizardEditableTokenInputPanel as VueWizardEditableTokenInputPanel, WizardChipListPanel as VueWizardChipListPanel } from '../../src/vue/stitch-admin/index.js';
+import type { WizardEditableTokenInput as VueWizardInput } from '../../src/stitch-admin/index.js';
+
+const VUE_NOOP_CHANGE = (): void => {};
+
+const VUE_BASE_INPUT: VueWizardInput = {
+  inputId: 'vue-allowed-senders',
+  value: ['qa@example.com', 'ops@example.com'],
+  label: 'Allowed senders',
+  description: 'Server validation remains authoritative.',
+  placeholder: 'Add another address…',
+  removeLabelKind: 'sender',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+test('vue stitch-admin: WizardEditableTokenInputPanel renders parity DOM with React adapter', async () => {
+  const body = await renderSSR(
+    h(VueWizardEditableTokenInputPanel, {
+      input: VUE_BASE_INPUT,
+      onChange: VUE_NOOP_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('facetheory-stitch-wizard-editable-token-input'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(body.includes('data-input-id="vue-allowed-senders"'));
+  assert.ok(body.includes('data-token-count="2"'));
+  assert.ok(body.includes('data-token-value="qa@example.com"'));
+  assert.ok(body.includes('data-token-value="ops@example.com"'));
+  // Accessible remove buttons with kind-aware aria-label.
+  assert.ok(body.includes('aria-label="Remove sender qa@example.com"'));
+  assert.ok(body.includes('aria-label="Remove sender ops@example.com"'));
+  // Label wired to input id and safety-policy footnote rendered.
+  assert.ok(body.includes('for="vue-allowed-senders"'));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+test('vue stitch-admin: WizardEditableTokenInputPanel surfaces invalid+duplicate feedback with role=alert', async () => {
+  const invalidBody = await renderSSR(
+    h(VueWizardEditableTokenInputPanel, {
+      input: {
+        ...VUE_BASE_INPUT,
+        draftValue: 'not-an-email',
+        validateToken: (token: string) =>
+          token.includes('@')
+            ? { valid: true }
+            : { valid: false, message: 'Address must contain @' },
+      },
+      onChange: VUE_NOOP_CHANGE,
+    }),
+  );
+  assert.ok(invalidBody.includes('role="alert"'));
+  assert.ok(invalidBody.includes('data-feedback-source="validator"'));
+  assert.ok(invalidBody.includes('Address must contain @'));
+
+  const duplicateBody = await renderSSR(
+    h(VueWizardEditableTokenInputPanel, {
+      input: { ...VUE_BASE_INPUT, draftValue: 'qa@example.com' },
+      onChange: VUE_NOOP_CHANGE,
+    }),
+  );
+  assert.ok(duplicateBody.includes('data-feedback-source="duplicate"'));
+  assert.ok(duplicateBody.includes('is already in the list'));
+});
+
+test('vue stitch-admin: WizardEditableTokenInputPanel is byte-identical across repeated SSR renders', async () => {
+  const first = await renderSSR(
+    h(VueWizardEditableTokenInputPanel, {
+      input: VUE_BASE_INPUT,
+      onChange: VUE_NOOP_CHANGE,
+    }),
+  );
+  const second = await renderSSR(
+    h(VueWizardEditableTokenInputPanel, {
+      input: VUE_BASE_INPUT,
+      onChange: VUE_NOOP_CHANGE,
+    }),
+  );
+  assert.equal(first, second);
+});
+
+test('vue stitch-admin: WizardChipListPanel alias renders the same DOM as the canonical panel', async () => {
+  const canonical = await renderSSR(
+    h(VueWizardEditableTokenInputPanel, {
+      input: VUE_BASE_INPUT,
+      onChange: VUE_NOOP_CHANGE,
+    }),
+  );
+  const alias = await renderSSR(
+    h(VueWizardChipListPanel, {
+      input: VUE_BASE_INPUT,
+      onChange: VUE_NOOP_CHANGE,
+    }),
+  );
+  assert.equal(canonical, alias);
+});


### PR DESCRIPTION
## Milestone

Factory assignment **THE-1450 / APW-FT4** (EditableTokenInput / ChipList) for the TheoryMCP Agent Import & Completion Wizard project.

- Linear issue: THE-1450 — APW-FT4 — Request FaceTheory EditableTokenInput / ChipList
- PR target: `project/theorymcp-agent-import-completion-wizard-20260521` (NOT `staging`)
- Project branch base: `project/theorymcp-agent-import-completion-wizard-20260521` @ `80619ae17fd770ebce2d19bec9158abeed5859fe` (THE-1449 / PR #217 merge)
- Milestone branch: `facetheory/agent-import-wizard-editable-token-input`
- Head commit: `b90ccc78051bfd02f090e1b8224b2a970c672340` (signed)
  - `9837526` — `feat(stitch-admin): add wizard editable token input (chip list) primitive` (React + shared types + docs + tests)
  - `8f8567b` — `feat(stitch-admin): add Vue + Svelte parity for wizard editable token input` (parity expansion)
  - `b90ccc7` — `docs(wizard): reflect THE-1450 React+Vue+Svelte parity and THE-1459 backfill` (docs-claim correction)

## What changed

A controlled chip / token entry primitive for wizard surfaces (e.g. "Allowed senders", "Allowed domains"), with **full React + Vue + Svelte parity** across the stitch-admin adapters. Pure presentation, no hidden state — SSR and hydrated DOM are byte-identical for the same props.

### Trust boundary (load-bearing)

- Client validation surfaced by these primitives is **UX only**. FaceTheory never claims a token is safe to write.
- TheoryMCP **must** still server-validate allowed senders / domains before writing `AgentEmailBinding` policy.
- FaceTheory does not resolve mailbox, tenant, namespace, agent, partner, provider credentials, or email policy state.
- No raw secrets, credentials, live receipts, private keys, provider tokens, raw package bodies, customer data, or production-like confidential values in fixtures, tests, or docs (a dedicated React test guards this).

### Framework-neutral types (`ts/src/stitch-admin/wizard-editable-token-input-types.ts`)

- `WizardEditableTokenInput` with controlled `value: string[]`, optional controlled `draftValue`, `label?`, `description?`, `placeholder?`, `validateToken?(token): { valid, message?, normalized? }`, `maxTokens?`, `allowDuplicates?`, `tokenPrefix?`, `disabled?`, `readOnly?`, `removeLabelKind?`, optional per-token metadata, optional `feedbackMessage` + `feedbackTone`, required deterministic `inputId`, and the required `WizardSafetyPolicy` literal.
- `WizardChipList*` alias type set for the "ChipList" naming preference.

### React adapter (`ts/src/react/stitch-admin/wizard-editable-token-input.ts`)

`WizardEditableTokenInputPanel` (alias `WizardChipListPanel`). Pure controlled. Chips with optional `tokenPrefix` (aria-hidden), value, real `<button type="button">` Remove with `aria-label="Remove <kind> <value>"`. Controlled `<input id={inputId}>` driven by `draftValue` / `onDraftChange`. Enter/comma commit, Backspace on empty draft removes last. Feedback below with `role="alert"` + `aria-live="polite"` + `aria-describedby`. Priority: caller `feedbackMessage` > `validateToken` > duplicate (when `allowDuplicates !== true`) > `maxTokens`. Disabled / read-only text-labeled with `aria-label`, suppress input + chip Remove buttons.

### Vue adapter (`ts/src/vue/stitch-admin/wizard-editable-token-input.ts`)

`WizardEditableTokenInputPanel` (alias `WizardChipListPanel`) via `defineComponent + h`. Same DOM, classes, data-* attributes, ARIA wiring, key handling, and feedback priority as React. Re-exported from `ts/src/vue/stitch-admin/index.ts`.

### Svelte adapter (`ts/src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte`)

Repo-convention `.svelte` file with `<script lang="ts">` props (`input`, `onChange`, `onDraftChange`). Same DOM contract via Svelte SSR. Re-exported as `WizardEditableTokenInputPanel` and `WizardChipListPanel` from `ts/src/svelte/stitch-admin/index.ts`, with matching types in `index.d.ts` and `types.ts`.

### Docs (`docs/wizard-primitives.md`) — corrected by commit `b90ccc7`

- Top "Status" line restated to call out THE-1450's React + Vue + Svelte parity for `WizardEditableTokenInputPanel` / `WizardChipListPanel` and to acknowledge that the earlier wizard families (`WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel`, `WizardAuthorityContextStripPanel`, `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`) currently ship React-only with Vue + Svelte parity tracked by **THE-1459** as a corrective backfill milestone.
- "Where the primitives live" table now lists explicit Vue and Svelte adapter rows for the editable token input panel and its alias.
- The stale "Vue and Svelte adapter parity is intentionally deferred for this milestone" paragraph has been removed and replaced with an "Adapter parity status" subsection distinguishing the THE-1450 (shipped-now-with-parity) surface from the THE-1459 (corrective-backfill) surface.
- Future component-request milestones land with React + Vue + Svelte parity from the start; the React-only paths are corrective scope, not the forward shape.

### Tests

- `ts/test/unit/stitch-admin-wizard-editable-token-input.test.ts` (React) — 16 tests including byte-identical SSR determinism, accessible Remove buttons, per-token metadata, validator + duplicate + maxTokens feedback flows, ChipList alias parity, and a fixture safety guard.
- `ts/test/unit/vue-stitch-admin.test.ts` — +4 Vue parity tests (SSR DOM parity with React, validator + duplicate `role="alert"` feedback, byte-identical SSR determinism, ChipList alias parity).
- `ts/test/unit/svelte-stitch-admin.test.ts` — +3 Svelte parity tests (same SSR DOM parity, validator + duplicate feedback, byte-identical SSR determinism).
- `npm test` reports **374 tests / 373 pass / 1 skip** (was 351 / 350 / 1 skip on the project branch baseline; +16 React + +4 Vue + +3 Svelte = +23 from this milestone). Unchanged by the docs-only commit.

## Validation

Run from the repo root against PR head `b90ccc78051bfd02f090e1b8224b2a970c672340`.

- `git diff --check origin/project/theorymcp-agent-import-completion-wizard-20260521...HEAD` — clean
- `scripts/verify-version-alignment.sh` → `version-alignment: PASS (3.2.1)`
- `cd ts && npm ci` — clean
- `cd ts && npm run typecheck` — pass
- `cd ts && npm run lint` — pass
- `cd ts && npm test` → **`tests 374 / pass 373 / fail 0 / skipped 1`**
- `cd ts && npm run build` — pass
- `scripts/pack-dev-archive.sh --output-dir /tmp/theorycloud-facetheory-dev-archives` — archive + `.sha256` sidecar; success message prints the cd-form verify command.
- `( cd /tmp/theorycloud-facetheory-dev-archives && sha256sum --check theory-cloud-facetheory-3.2.1-dev-b90ccc78051b.tgz.sha256 )` → `theory-cloud-facetheory-3.2.1-dev-b90ccc78051b.tgz: OK`
- `make rubric` — passes `version-alignment` + `ts-pack`; fails ONLY on the pre-existing `npm-audit: brace-expansion (severity=moderate)` finding present on the project base branch. `ts/package-lock.json` unchanged in this PR.

## Temporary local archive handoff

- Command: `scripts/pack-dev-archive.sh --output-dir /tmp/theorycloud-facetheory-dev-archives`
- Archive basename (from PR head `b90ccc7`): `theory-cloud-facetheory-3.2.1-dev-b90ccc78051b.tgz`
- sha256: `f663864ef3afd00d1d8da8785ba3e40504e369fa019d46016b2ef207e2bc718c`
- Verify: `( cd /tmp/theorycloud-facetheory-dev-archives && sha256sum --check theory-cloud-facetheory-3.2.1-dev-b90ccc78051b.tgz.sha256 )` → OK
- The content sha is unchanged from the prior `8f8567b` pack — `b90ccc7` is docs-only and is not bundled into `dist/`, so any TheoryMCP vendoring of the prior archive remains valid; the rename just records the new source commit.

## Safety / scope confirmation

- No release, npm publish, Release Please PR, version bump, tag creation, or release-asset publication.
- No AWS/cloud/account/DNS/cert/IAM/runner/action-lease mutation. No deploy. No smoke/canary.
- No live/customer-data fixtures. No secrets. No live receipts.
- No TheoryMCP, KnowledgeTheory, framework parent, or sibling repo edits.
- No git worktrees; normal checkout only.
- No PR to staging.
- The temporary archive is a pre-lab dev handoff and is explicitly **not** a release artifact.
- THE-1459 (parity backfill for THE-1458 / THE-1448 / THE-1449) is not mixed into this PR.

## Residual risks / blockers

- `make rubric` blocked on the pre-existing `brace-expansion` npm-audit moderate finding present on the project base branch; `ts/package-lock.json` unchanged in this PR.
- No other open blockers.

## Files

- `ts/src/stitch-admin/wizard-editable-token-input-types.ts` (new)
- `ts/src/stitch-admin/index.ts` (re-export new types)
- `ts/src/react/stitch-admin/wizard-editable-token-input.ts` (new)
- `ts/src/react/stitch-admin/index.ts` (re-export new component + alias)
- `ts/src/vue/stitch-admin/wizard-editable-token-input.ts` (new — Vue parity)
- `ts/src/vue/stitch-admin/index.ts` (re-export new component + alias)
- `ts/src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte` (new — Svelte parity)
- `ts/src/svelte/stitch-admin/index.ts` (re-export new component + alias)
- `ts/src/svelte/stitch-admin/index.d.ts` (Component type declarations)
- `ts/src/svelte/stitch-admin/types.ts` (shared type re-exports + panel-props)
- `ts/test/unit/stitch-admin-wizard-editable-token-input.test.ts` (new, 16 React tests)
- `ts/test/unit/vue-stitch-admin.test.ts` (+4 Vue parity tests)
- `ts/test/unit/svelte-stitch-admin.test.ts` (+3 Svelte parity tests)
- `ts/test/run-unit.ts` (register the new React test file)
- `docs/wizard-primitives.md` (EditableTokenInput section; commit `b90ccc7` restates top status, adds Vue + Svelte rows to the primitives table, and adds an explicit "Adapter parity status" subsection distinguishing THE-1450 parity from the THE-1459 corrective backfill)

Refs: THE-1450 (APW-FT4). THE-1459 backfill tracked separately; not in this PR.