### PR TITLE
fix(deps): bump transitive brace-expansion to 5.0.6 in ts/

### DIFF
--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -11,10 +11,35 @@ This file records the currently pinned versions and the exact install strings we
 - AppTheory (CDK): `v1.7.0`
 - TableTheory (TypeScript): `v1.8.3`
 
-## Known Audit Exception
+## Known Audit Exceptions
 
-None currently. AppTheory CDK `v1.7.0` requires `aws-cdk-lib@2.254.0`, and the infra example lockfiles now resolve
-the previous nested `fast-uri` audit finding to the patched AWS CDK dependency set.
+FaceTheory does not repackage AWS dependencies. The `infra/apptheory-ssr-site` and
+`infra/apptheory-ssg-isr-site` workspaces are reference / example deployment shapes that
+consumer applications reproduce themselves; the `aws-cdk-lib` tarball bundles its own
+`node_modules/` for some transitives, and FaceTheory cannot ship a patched version of those
+without forking AWS CDK. The exceptions below are narrowly scoped to one specific package
+name, one nested path inside `aws-cdk-lib/node_modules/`, one set of advisory URLs, and
+the `infra/apptheory-*` workspaces only. Anything outside those gates is still treated as
+`FAIL` by `scripts/verify-npm-audit.sh`.
+
+### Active exceptions
+
+- **`brace-expansion`** — [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)
+  ("Large numeric range defeats documented `max` DoS protection"), moderate severity.
+  Present transitively at `node_modules/aws-cdk-lib/node_modules/brace-expansion` in the
+  `infra/apptheory-*` workspaces because the `aws-cdk-lib` tarball bundles its own copy.
+  The FaceTheory package surface (`ts/`) was cleared in THE-1460 / PR #220 (transitive
+  `brace-expansion` upgraded `5.0.5` → `5.0.6` in `ts/package-lock.json`). The bundled
+  copy under `aws-cdk-lib` is upstream AWS's to ship; the exception will be removed once an
+  `aws-cdk-lib` release vendors a patched `brace-expansion` (≥ `5.0.6`).
+
+### Recently cleared
+
+- **`fast-uri`** — AppTheory CDK `v1.7.0` requires `aws-cdk-lib@2.254.0`, and the infra example
+  lockfiles now resolve the previous nested `fast-uri` audit finding to the patched AWS CDK
+  dependency set. The `fast-uri` allowlist in `scripts/verify-npm-audit.sh` is kept as a
+  belt-and-suspenders guard against future regressions; remove it when `aws-cdk-lib` no
+  longer bundles `fast-uri` at all.
 
 ## Infra Lockfile Note
 

--- a/scripts/verify-npm-audit.sh
+++ b/scripts/verify-npm-audit.sh
@@ -36,17 +36,47 @@ const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
 const vulnerabilities = report.vulnerabilities || {};
 const entries = Object.entries(vulnerabilities);
 
+// Known-allowed audit exceptions for upstream AWS CDK bundled transitives.
+//
+// FaceTheory does not repackage AWS dependencies. The `infra/apptheory-*`
+// workspaces are reference / example deployment shapes that consumer
+// applications reproduce themselves; the `aws-cdk-lib` tarball bundles its
+// own `node_modules/` for some transitives, and FaceTheory cannot ship a
+// patched version of those without forking AWS CDK. Each exception below
+// is narrowly scoped to (a) one specific package name, (b) one nested path
+// inside `aws-cdk-lib/node_modules/`, (c) one set of advisory URLs that
+// upstream has classified as scoped to that bundled copy, and (d) the
+// `infra/apptheory-*` workspaces only. Anything outside those gates is
+// still treated as `FAIL`.
+//
+// Cross-reference: `docs/UPSTREAM_RELEASE_PINS.md` — "Known Audit
+// Exception" section documents the same boundary in product terms.
+
 const allowedFastUriAdvisories = new Set([
   'https://github.com/advisories/GHSA-q3j6-qgpj-74h6',
   'https://github.com/advisories/GHSA-v39h-62p7-jpjc',
 ]);
 
-function isAllowedFastUri(name, vulnerability) {
-  if (name !== 'fast-uri' || vulnerability?.name !== 'fast-uri') return false;
+// brace-expansion: Large numeric range defeats documented `max` DoS
+// protection (moderate). Present transitively in aws-cdk-lib's bundled
+// node_modules. AWS CDK has not yet shipped a fix; FaceTheory cannot
+// repackage. Exception will be removed when an aws-cdk-lib release
+// vendors a patched brace-expansion (>= 5.0.6).
+const allowedBraceExpansionAdvisories = new Set([
+  'https://github.com/advisories/GHSA-jxxr-4gwj-5jf2',
+]);
+
+function isAllowedAwsCdkBundled(
+  packageName,
+  vulnerability,
+  expectedNode,
+  allowedAdvisories,
+) {
+  if (vulnerability?.name !== packageName) return false;
   if (!project.startsWith('infra/apptheory-')) return false;
 
   const nodes = Array.isArray(vulnerability.nodes) ? vulnerability.nodes : [];
-  if (nodes.length !== 1 || nodes[0] !== 'node_modules/aws-cdk-lib/node_modules/fast-uri') {
+  if (nodes.length !== 1 || nodes[0] !== expectedNode) {
     return false;
   }
 
@@ -54,15 +84,37 @@ function isAllowedFastUri(name, vulnerability) {
   if (via.length === 0) return false;
   return via.every((entry) => {
     if (!entry || typeof entry !== 'object') return false;
-    return entry.name === 'fast-uri' && allowedFastUriAdvisories.has(entry.url);
+    return entry.name === packageName && allowedAdvisories.has(entry.url);
   });
+}
+
+function isAllowedFastUri(name, vulnerability) {
+  if (name !== 'fast-uri') return false;
+  return isAllowedAwsCdkBundled(
+    'fast-uri',
+    vulnerability,
+    'node_modules/aws-cdk-lib/node_modules/fast-uri',
+    allowedFastUriAdvisories,
+  );
+}
+
+function isAllowedBraceExpansion(name, vulnerability) {
+  if (name !== 'brace-expansion') return false;
+  return isAllowedAwsCdkBundled(
+    'brace-expansion',
+    vulnerability,
+    'node_modules/aws-cdk-lib/node_modules/brace-expansion',
+    allowedBraceExpansionAdvisories,
+  );
 }
 
 const unexpected = [];
 const allowed = [];
 for (const [name, vulnerability] of entries) {
   if (isAllowedFastUri(name, vulnerability)) {
-    allowed.push(name);
+    allowed.push({ name, reason: 'fast-uri' });
+  } else if (isAllowedBraceExpansion(name, vulnerability)) {
+    allowed.push({ name, reason: 'brace-expansion' });
   } else {
     unexpected.push({ name, vulnerability });
   }
@@ -77,9 +129,11 @@ if (unexpected.length > 0) {
 }
 
 if (allowed.length > 0) {
-  console.log(
-    `npm-audit: ALLOW (${project}) fast-uri via bundled aws-cdk-lib tarball; no custom CDK tarball is maintained`,
-  );
+  for (const { name } of allowed) {
+    console.log(
+      `npm-audit: ALLOW (${project}) ${name} via bundled aws-cdk-lib tarball; no custom CDK tarball is maintained`,
+    );
+  }
   process.exit(0);
 }
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -5076,9 +5076,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Milestone

Factory assignment **THE-1460** — APW-FT follow-up: clear FaceTheory brace-expansion audit advisory.

- Linear issue: THE-1460
- PR target: `project/theorymcp-agent-import-completion-wizard-20260521` (NOT `staging`)
- Project branch base: `c27d44c4b946c2985ebb54a9ee29f76485cd89f6` (THE-1459 / PR #219 merge)
- Milestone branch: `facetheory/agent-import-wizard-brace-expansion-audit-fix`
- Head commit: `389ef30bbf98919e7fb622459d0accfe5f8faf76` (signed)
  - `77ed459` — `fix(deps): bump transitive brace-expansion to 5.0.6 in ts/`
  - `389ef30` — `chore(audit): allowlist aws-cdk-lib bundled brace-expansion in infra audits` (principal-authorized scope expansion)

## What changed

Two coordinated changes, both grounded in the FaceTheory architectural posture: **FaceTheory does not repackage AWS dependencies**.

### 1. FaceTheory package surface (`ts/`) cleared

`npm --prefix ts audit fix` cleanly upgrades the transitive `node_modules/brace-expansion` from `5.0.5` to `5.0.6`. Three-line diff in `ts/package-lock.json`; `ts/package.json` unchanged.

```diff
 "node_modules/brace-expansion": {
-  "version": "5.0.5",
+  "version": "5.0.6",
```

### 2. Audit allowlist for upstream AWS CDK bundled `brace-expansion`

`scripts/verify-npm-audit.sh` already had a narrow allowlist for `fast-uri` under `aws-cdk-lib/node_modules/`. Extend the same pattern to `brace-expansion`:

- Refactor the existing `fast-uri`-specific gate into a shared `isAllowedAwsCdkBundled(packageName, vulnerability, expectedNode, allowedAdvisories)` helper.
- Derive both `isAllowedFastUri` and `isAllowedBraceExpansion` from it.
- Gates remain narrow: exactly one specific package name, exactly one nested node path inside `aws-cdk-lib/node_modules/`, every `via` entry must be the same package name with an advisory URL in the allowed set, only the `infra/apptheory-*` workspaces.
- Anything outside those gates is still treated as `FAIL`.
- Each accepted finding is logged with an explicit `npm-audit: ALLOW (...)` line.

Document the boundary in `docs/UPSTREAM_RELEASE_PINS.md` under "Known Audit Exceptions":

- The active `brace-expansion` exception (advisory URL, severity, expected node path, when it will be removed).
- The recently cleared `fast-uri` exception (kept as a belt-and-suspenders guard).
- The underlying rule that FaceTheory does not repackage AWS dependencies; consumer applications reproduce the deployment shape themselves.

### Scope expansion note

THE-1460's original allowed write scope was `ts/package-lock.json` only. After the first commit (`77ed459`) cleared the `ts/` surface, `make rubric` still exited non-zero because `scripts/verify-npm-audit.sh` also audits the `infra/apptheory-*` workspaces and surfaces the same advisory under AWS CDK's bundled `brace-expansion`. The principal (Aron) explicitly authorized expanding this PR's scope to include `scripts/verify-npm-audit.sh` and `docs/UPSTREAM_RELEASE_PINS.md` so the audit-exception boundary lands in one place rather than silently leaving `make rubric` non-zero on the project branch indefinitely. Factory is notified on the THE-1460 assignment thread.

## Validation

Run from the repo root against PR head `389ef30bbf98919e7fb622459d0accfe5f8faf76`.

- `git diff --check origin/project/theorymcp-agent-import-completion-wizard-20260521...HEAD` — clean
- `scripts/verify-version-alignment.sh` → `version-alignment: PASS (3.2.1)`
- `cd ts && npm ci` — clean; `npm audit` now reports `found 0 vulnerabilities`
- `cd ts && npm run typecheck` — pass
- `cd ts && npm run lint` — pass
- `cd ts && npm test` → **`tests 404 / pass 403 / fail 0 / skipped 1`**
- `cd ts && npm run build` — pass
- `scripts/verify-npm-audit.sh`:
  - `npm-audit: PASS (ts)`
  - `npm-audit: ALLOW (infra/apptheory-ssr-site) brace-expansion via bundled aws-cdk-lib tarball; no custom CDK tarball is maintained`
  - `npm-audit: ALLOW (infra/apptheory-ssg-isr-site) brace-expansion via bundled aws-cdk-lib tarball; no custom CDK tarball is maintained`
- `make rubric` → **exits 0 for the first time on the project branch.** Stages summary: `version-alignment: PASS (3.2.1)`, `ts-pack: PASS`, `npm-audit: PASS (ts)` + `ALLOW (infra/apptheory-ssr-site)` + `ALLOW (infra/apptheory-ssg-isr-site)`, `go-version-pin: PASS`, all `test-*` release-workflow scripts PASS.
- `scripts/pack-dev-archive.sh --skip-build --output-dir /tmp/theorycloud-facetheory-dev-archives` — archive + sidecar produced.
- `( cd /tmp/theorycloud-facetheory-dev-archives && sha256sum --check theory-cloud-facetheory-3.2.1-dev-389ef30bbf98.tgz.sha256 )` → `theory-cloud-facetheory-3.2.1-dev-389ef30bbf98.tgz: OK`

## Temporary local archive handoff

- Command: `scripts/pack-dev-archive.sh --output-dir /tmp/theorycloud-facetheory-dev-archives`
- Archive basename (from PR head `389ef30`): `theory-cloud-facetheory-3.2.1-dev-389ef30bbf98.tgz`
- sha256: `85ec7f6eaf2f71adb75c9c6c09f0708deeda3c454f183fd2a0f43f9e8a5023aa`
- Verify (works from any cwd):
  ```bash
  ( cd /tmp/theorycloud-facetheory-dev-archives \
      && sha256sum --check theory-cloud-facetheory-3.2.1-dev-389ef30bbf98.tgz.sha256 )
  ```
- Content sha is unchanged from the prior pack because neither the audit allowlist nor the doc edit is bundled into `dist/`.

## Safety / scope confirmation

- Three-file diff: `ts/package-lock.json`, `scripts/verify-npm-audit.sh`, `docs/UPSTREAM_RELEASE_PINS.md`. `ts/package.json` unchanged. FaceTheory package version remains `3.2.1`.
- No npm release / publish / GitHub Release / release-asset workflow / tag / version bump / staging-or-main promotion.
- No source / component / API changes.
- No AWS / cloud / IAM / DNS / cert / account / deploy / smoke / canary.
- No secrets, credentials, live receipts, raw package bodies, customer data, or production-like confidential fixtures.
- No sibling repo edits, parent Factory repo edits, or framework changes outside FaceTheory.
- No git worktrees; normal checkout only.
- No PR to staging.
- Will NOT start THE-1454 / THE-1455 / THE-1456 or any other FaceTheory component milestone until Factory resolves THE-1460.

## Files

- `ts/package-lock.json` — transitive `brace-expansion` upgraded `5.0.5` → `5.0.6` (3-line diff).
- `scripts/verify-npm-audit.sh` — extend the narrow allowlist pattern to also accept the `brace-expansion` advisory under `aws-cdk-lib/node_modules/` in the `infra/apptheory-*` workspaces; refactor `fast-uri` and `brace-expansion` gates through a shared helper.
- `docs/UPSTREAM_RELEASE_PINS.md` — document the active `brace-expansion` exception, the recently cleared `fast-uri` exception, and the rule that FaceTheory does not repackage AWS dependencies.

Refs: THE-1460 (APW-FT follow-up). Scope expanded by principal.