### PR TITLE
feat(stitch-admin): add SelectableCardGrid + ChoiceCard with React+Vue+Svelte parity

### DIFF
--- a/docs/wizard-primitives.md
+++ b/docs/wizard-primitives.md
@@ -36,9 +36,9 @@ primitive twice and asserting byte-identical SSR output.
 | Layer | Module | What it exports |
 | --- | --- | --- |
 | Framework-neutral types | `@theory-cloud/facetheory/stitch-admin` | `WizardProgressState`, `WizardPackageSummary`, `WizardFindingList`, `WizardReconcileSummary`, `WizardReconciliationPlan`, `WizardAuthorityContextStrip`, `WizardCapabilityReview`, `WizardEnablementChecklist`, `WizardRecoveryStatus`, `WizardEmptyStateConfig`, `WizardEditableTokenInput`, `WizardSafetyPolicy`, and supporting enums and aliases. |
-| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`), `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
-| Vue adapter | `@theory-cloud/facetheory/vue/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`, `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`). |
-| Svelte adapter | `@theory-cloud/facetheory/svelte/stitch-admin` | Same primitive set as the Vue adapter, exposed as `.svelte` components with matching component-prop interfaces. |
+| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`), `SelectableCardGridPanel`, `ChoiceCard`, `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
+| Vue adapter | `@theory-cloud/facetheory/vue/stitch-admin` | Same primitive set as React, including `SelectableCardGridPanel` and `ChoiceCard`. |
+| Svelte adapter | `@theory-cloud/facetheory/svelte/stitch-admin` | Same primitive set, exposed as `.svelte` components with matching component-prop interfaces. |
 
 ### Adapter parity status
 
@@ -349,6 +349,97 @@ color-only cues.
   }}
   onChange={(next) => host.setAllowedSenders(next)}
   onDraftChange={(next) => host.setDraft(next)}
+/>
+```
+
+## Selectable card grid / choice card
+
+`SelectableCardGridPanel` (with the lower-level `ChoiceCard` primitive) is the
+card-grid choice surface the TheoryMCP Agent Import & Completion Wizard
+renders for "pick an action / target / environment" steps. It supports both
+single-select and multi-select selection modes and three layouts (responsive
+grid, compact stacked list, two-column wizard panels).
+
+### Trust boundary
+
+- Presentation-only. FaceTheory does not decide whether a choice is
+  authorized.
+- theory-mcp-server (the host) supplies `allowed` / `disabled` / `blocked`
+  state from route-resolved server policy and TableTheory-backed state.
+- FaceTheory makes no authorization inference from option labels, package
+  fields, repository names, or action-family strings.
+- `recommended`, `riskLabel`, `disabledReason`, `blocked`, and
+  `blockedReason` fields are caller-supplied display values, never computed
+  by the primitive.
+
+### Option contract
+
+```ts
+interface SelectableCardOption {
+  key: string;
+  title: unknown;
+  description?: unknown;
+  icon?: unknown;
+  badge?: unknown;
+  tone?: 'neutral' | 'info' | 'success' | 'warning' | 'danger' | 'recommended';
+  riskLabel?: string;
+  disabledReason?: string;
+  recommended?: boolean;
+  blocked?: boolean;
+  blockedReason?: string;
+  metadata?: OperatorVisibilityMetadata;
+}
+```
+
+### Accessibility contract
+
+- Single-select grids render the outer container as `role="radiogroup"` and
+  each card as `role="radio"` with `aria-checked` and a tab index driven by
+  selection.
+- Multi-select grids render the outer container as `role="group"` and each
+  card as `role="checkbox"` with `aria-checked`.
+- Disabled options (those carrying `disabledReason` or `blocked: true`)
+  carry `aria-disabled="true"`; the host-supplied `disabledReason` is
+  rendered as text and wired via `aria-describedby` to the card.
+- `recommended`, `Blocked`, and risk states render as **text pills** (not
+  color-only) so high-contrast viewers see the cue.
+- Keyboard activation: `Space` or `Enter` calls the host's `onChange`
+  with the proposed next selected-key set. The primitive never toggles
+  state internally.
+
+### Selection model
+
+- `single`: `onChange([option.key])` on activate.
+- `multi`: `onChange([...selectedKeys, option.key])` or
+  `onChange(selectedKeys.filter(k => k !== option.key))` depending on whether
+  the option is currently selected.
+
+The host owns acceptance — passing back a different list is fine.
+
+### Example
+
+```tsx
+<SelectableCardGridPanel
+  grid={{
+    groupId: 'allowed-action',
+    selection: 'single',
+    selectedKeys: ['create'],
+    options: [
+      { key: 'create', title: 'Create new namespace', tone: 'success', recommended: true },
+      { key: 'reuse', title: 'Reuse existing namespace', tone: 'info' },
+      { key: 'replace', title: 'Replace existing namespace',
+        tone: 'warning', riskLabel: 'High blast radius' },
+      { key: 'archive', title: 'Archive without binding',
+        disabledReason: 'Requires operator review before archival.' },
+      { key: 'forbidden', title: 'Forbidden namespace',
+        blocked: true, blockedReason: 'Server policy blocks this option.' },
+    ],
+    label: 'Allowed action',
+    description: 'TheoryMCP resolves which of these are available per route.',
+    layout: 'grid',
+    safetyPolicy: 'no-secret-or-production-like-data',
+  }}
+  onChange={(next) => host.setAllowedAction(next[0])}
 />
 ```
 

--- a/ts/src/react/stitch-admin/index.ts
+++ b/ts/src/react/stitch-admin/index.ts
@@ -165,6 +165,20 @@ export {
 } from './wizard-authority-context-strip.js';
 
 export {
+  SelectableCardGridPanel,
+  ChoiceCard,
+  type SelectableCardGridPanelProps,
+  type ChoiceCardPanelProps,
+  type ChoiceCardProps,
+  type SelectableCardGrid,
+  type SelectableCardGridLayout,
+  type SelectableCardGridSelection,
+  type SelectableCardGridSize,
+  type SelectableCardOption,
+  type SelectableCardTone,
+} from './selectable-card-grid.js';
+
+export {
   WizardEditableTokenInputPanel,
   WizardChipListPanel,
   type WizardEditableTokenInputPanelProps,

--- a/ts/src/react/stitch-admin/selectable-card-grid.ts
+++ b/ts/src/react/stitch-admin/selectable-card-grid.ts
@@ -203,6 +203,7 @@ function renderCardStatusPills(
   return h(
     'div',
     {
+      key: 'pills',
       className: 'facetheory-stitch-selectable-card-pills',
       style: { display: 'flex', gap: '6px', flexWrap: 'wrap' },
     },

--- a/ts/src/react/stitch-admin/selectable-card-grid.ts
+++ b/ts/src/react/stitch-admin/selectable-card-grid.ts
@@ -1,0 +1,571 @@
+import * as React from 'react';
+
+import type {
+  ChoiceCardProps,
+  SelectableCardGrid,
+  SelectableCardGridLayout,
+  SelectableCardGridSelection,
+  SelectableCardGridSize,
+  SelectableCardOption,
+  SelectableCardTone,
+} from '../../stitch-admin/selectable-card-grid-types.js';
+import type { WizardSafetyPolicy } from '../../stitch-admin/wizard-types.js';
+import { MetadataBadgeGroup } from './operator-notices.js';
+
+const h = React.createElement;
+
+export type {
+  ChoiceCardProps,
+  SelectableCardGrid,
+  SelectableCardGridLayout,
+  SelectableCardGridSelection,
+  SelectableCardGridSize,
+  SelectableCardOption,
+  SelectableCardTone,
+};
+
+interface TonePalette {
+  background: string;
+  color: string;
+  border: string;
+}
+
+const TONE_PALETTE: Record<SelectableCardTone, TonePalette> = {
+  neutral: {
+    background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+    color: 'var(--stitch-color-on-surface, #131b2e)',
+    border: 'var(--stitch-color-outline-variant, #c6c5d0)',
+  },
+  info: {
+    background: 'var(--stitch-color-primary-container, #e0e0ff)',
+    color: 'var(--stitch-color-on-primary-container, #000066)',
+    border: 'var(--stitch-color-primary-container, #e0e0ff)',
+  },
+  success: {
+    background: 'var(--stitch-color-tertiary-container, #004c45)',
+    color: 'var(--stitch-color-on-tertiary-container, #52c1b4)',
+    border: 'var(--stitch-color-tertiary-container, #004c45)',
+  },
+  warning: {
+    background: 'var(--stitch-color-secondary-container, #ffecc0)',
+    color: 'var(--stitch-color-on-secondary-container, #3f2e00)',
+    border: 'var(--stitch-color-secondary-container, #ffecc0)',
+  },
+  danger: {
+    background: 'var(--stitch-color-error-container, #ffdad6)',
+    color: 'var(--stitch-color-on-error-container, #93000a)',
+    border: 'var(--stitch-color-error-container, #ffdad6)',
+  },
+  recommended: {
+    background: 'var(--stitch-color-tertiary-container, #004c45)',
+    color: 'var(--stitch-color-on-tertiary-container, #52c1b4)',
+    border: 'var(--stitch-color-on-tertiary-container, #52c1b4)',
+  },
+};
+
+interface SizeTokens {
+  padding: string;
+  gap: string;
+  titleFontSize: string;
+  descriptionFontSize: string;
+  borderRadius: string;
+}
+
+const SIZE_TOKENS: Record<SelectableCardGridSize, SizeTokens> = {
+  sm: {
+    padding: '10px 12px',
+    gap: '6px',
+    titleFontSize: '13px',
+    descriptionFontSize: '12px',
+    borderRadius: 'var(--stitch-radius-sm, 8px)',
+  },
+  md: {
+    padding: '14px 16px',
+    gap: '8px',
+    titleFontSize: '14px',
+    descriptionFontSize: '13px',
+    borderRadius: 'var(--stitch-radius-md, 10px)',
+  },
+  lg: {
+    padding: '18px 20px',
+    gap: '10px',
+    titleFontSize: '15px',
+    descriptionFontSize: '14px',
+    borderRadius: 'var(--stitch-radius-lg, 12px)',
+  },
+};
+
+function layoutContainerStyle(
+  layout: SelectableCardGridLayout,
+): React.CSSProperties {
+  switch (layout) {
+    case 'stack':
+      return { display: 'flex', flexDirection: 'column', gap: '10px' };
+    case 'two-column':
+      return {
+        display: 'grid',
+        gap: '10px',
+        gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+      };
+    case 'grid':
+    default:
+      return {
+        display: 'grid',
+        gap: '10px',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+      };
+  }
+}
+
+function isOptionDisabled(option: SelectableCardOption): boolean {
+  return option.blocked === true || option.disabledReason !== undefined;
+}
+
+function deriveCardClassName(
+  option: SelectableCardOption,
+  selected: boolean,
+): string {
+  const tone = option.tone ?? 'neutral';
+  const disabled = isOptionDisabled(option);
+  const cls = [
+    'facetheory-stitch-selectable-card',
+    `facetheory-stitch-selectable-card-tone-${tone}`,
+  ];
+  if (selected) cls.push('facetheory-stitch-selectable-card-selected');
+  if (disabled) cls.push('facetheory-stitch-selectable-card-disabled');
+  if (option.blocked === true) cls.push('facetheory-stitch-selectable-card-blocked');
+  if (option.recommended === true) cls.push('facetheory-stitch-selectable-card-recommended');
+  return cls.join(' ');
+}
+
+function renderSafetyFootnote(policy: WizardSafetyPolicy): React.ReactElement {
+  return h(
+    'p',
+    {
+      className: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+      style: {
+        margin: 0,
+        fontSize: '11px',
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+      },
+    },
+    `Safety policy: ${policy}`,
+  );
+}
+
+function renderCardStatusPills(
+  option: SelectableCardOption,
+): React.ReactElement | null {
+  const pills: React.ReactElement[] = [];
+  if (option.recommended === true) {
+    pills.push(
+      h(
+        'span',
+        {
+          key: 'recommended',
+          className: 'facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-recommended',
+          'data-pill': 'recommended',
+        },
+        'Recommended',
+      ),
+    );
+  }
+  if (option.blocked === true) {
+    pills.push(
+      h(
+        'span',
+        {
+          key: 'blocked',
+          className: 'facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-blocked',
+          'data-pill': 'blocked',
+        },
+        'Blocked',
+      ),
+    );
+  }
+  if (option.riskLabel !== undefined && option.riskLabel !== '') {
+    pills.push(
+      h(
+        'span',
+        {
+          key: 'risk',
+          className: 'facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-risk',
+          'data-pill': 'risk',
+        },
+        option.riskLabel,
+      ),
+    );
+  }
+  if (pills.length === 0) return null;
+  return h(
+    'div',
+    {
+      className: 'facetheory-stitch-selectable-card-pills',
+      style: { display: 'flex', gap: '6px', flexWrap: 'wrap' },
+    },
+    pills,
+  );
+}
+
+function renderCardBody(
+  option: SelectableCardOption,
+  sizeTokens: SizeTokens,
+  reasonId: string | undefined,
+): React.ReactElement[] {
+  const children: React.ReactElement[] = [];
+  children.push(
+    h(
+      'div',
+      {
+        key: 'header',
+        className: 'facetheory-stitch-selectable-card-header',
+        style: { display: 'flex', alignItems: 'center', gap: '8px' },
+      },
+      option.icon !== undefined
+        ? h(
+            'span',
+            {
+              key: 'icon',
+              className: 'facetheory-stitch-selectable-card-icon',
+              'aria-hidden': 'true',
+            },
+            option.icon as React.ReactNode,
+          )
+        : null,
+      h(
+        'strong',
+        {
+          key: 'title',
+          className: 'facetheory-stitch-selectable-card-title',
+          style: { fontSize: sizeTokens.titleFontSize },
+        },
+        option.title as React.ReactNode,
+      ),
+      option.badge !== undefined
+        ? h(
+            'span',
+            {
+              key: 'badge',
+              className: 'facetheory-stitch-selectable-card-badge',
+            },
+            option.badge as React.ReactNode,
+          )
+        : null,
+    ),
+  );
+  if (option.description !== undefined) {
+    children.push(
+      h(
+        'p',
+        {
+          key: 'description',
+          className: 'facetheory-stitch-selectable-card-description',
+          style: {
+            margin: 0,
+            fontSize: sizeTokens.descriptionFontSize,
+            lineHeight: 1.5,
+            color: 'var(--stitch-color-on-surface-variant, #464553)',
+          },
+        },
+        option.description as React.ReactNode,
+      ),
+    );
+  }
+  const statusPills = renderCardStatusPills(option);
+  if (statusPills !== null) children.push(statusPills);
+  if (option.blocked === true && option.blockedReason !== undefined) {
+    children.push(
+      h(
+        'p',
+        {
+          key: 'blocked-reason',
+          className: 'facetheory-stitch-selectable-card-blocked-reason',
+          style: {
+            margin: 0,
+            fontSize: '12px',
+            color: 'var(--stitch-color-on-error-container, #93000a)',
+            fontWeight: 600,
+          },
+        },
+        option.blockedReason,
+      ),
+    );
+  }
+  if (option.disabledReason !== undefined) {
+    children.push(
+      h(
+        'p',
+        {
+          key: 'disabled-reason',
+          id: reasonId,
+          className: 'facetheory-stitch-selectable-card-disabled-reason',
+          'data-disabled-reason': 'true',
+          style: {
+            margin: 0,
+            fontSize: '12px',
+            color: 'var(--stitch-color-on-surface-variant, #464553)',
+            fontStyle: 'italic',
+          },
+        },
+        option.disabledReason,
+      ),
+    );
+  }
+  if (option.metadata !== undefined) {
+    children.push(h(MetadataBadgeGroup, { key: 'metadata', metadata: option.metadata }));
+  }
+  return children;
+}
+
+/* -------------------------------------------------------------------------- */
+/* SelectableCardGridPanel                                                    */
+/* -------------------------------------------------------------------------- */
+
+export interface SelectableCardGridPanelProps {
+  grid: SelectableCardGrid;
+  /**
+   * Required. Called whenever the primitive wants to propose a new selected
+   * key set (user activated a card). The host owns acceptance; the
+   * primitive does not toggle state internally.
+   */
+  onChange: (nextSelectedKeys: string[]) => void;
+}
+
+export function SelectableCardGridPanel(
+  props: SelectableCardGridPanelProps,
+): React.ReactElement {
+  const { grid, onChange } = props;
+  const layout: SelectableCardGridLayout = grid.layout ?? 'grid';
+  const size: SelectableCardGridSize = grid.size ?? 'md';
+  const sizeTokens = SIZE_TOKENS[size];
+  const groupRole = grid.selection === 'single' ? 'radiogroup' : 'group';
+  const labelId = grid.label !== undefined ? `${grid.groupId}-label` : undefined;
+  const descriptionId =
+    grid.description !== undefined ? `${grid.groupId}-description` : undefined;
+  const ariaDescribedBy = descriptionId;
+
+  function handleActivate(option: SelectableCardOption): void {
+    if (isOptionDisabled(option)) return;
+    if (grid.selection === 'single') {
+      onChange([option.key]);
+      return;
+    }
+    const isSelected = grid.selectedKeys.includes(option.key);
+    const next = isSelected
+      ? grid.selectedKeys.filter((k) => k !== option.key)
+      : [...grid.selectedKeys, option.key];
+    onChange(next);
+  }
+
+  return h(
+    'section',
+    {
+      className: `facetheory-stitch-selectable-card-grid facetheory-stitch-selectable-card-grid-${grid.selection} facetheory-stitch-selectable-card-grid-layout-${layout} facetheory-stitch-selectable-card-grid-size-${size}`,
+      'data-safety-policy': grid.safetyPolicy,
+      'data-group-id': grid.groupId,
+      'data-selection': grid.selection,
+      'data-layout': layout,
+      'data-size': size,
+      'data-option-count': String(grid.options.length),
+      'data-selected-count': String(grid.selectedKeys.length),
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+        padding: '12px',
+        borderRadius: 'var(--stitch-radius-lg, 12px)',
+        background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+      },
+    },
+    grid.label !== undefined || grid.description !== undefined
+      ? h(
+          'header',
+          {
+            className: 'facetheory-stitch-selectable-card-grid-header',
+            style: { display: 'flex', flexDirection: 'column', gap: '4px' },
+          },
+          grid.label !== undefined
+            ? h(
+                'div',
+                {
+                  id: labelId,
+                  className: 'facetheory-stitch-selectable-card-grid-label',
+                  style: { fontSize: '13px', fontWeight: 600 },
+                },
+                grid.label as React.ReactNode,
+              )
+            : null,
+          grid.description !== undefined
+            ? h(
+                'p',
+                {
+                  id: descriptionId,
+                  className: 'facetheory-stitch-selectable-card-grid-description',
+                  style: {
+                    margin: 0,
+                    fontSize: '12px',
+                    lineHeight: 1.5,
+                    color: 'var(--stitch-color-on-surface-variant, #464553)',
+                  },
+                },
+                grid.description as React.ReactNode,
+              )
+            : null,
+        )
+      : null,
+    h(
+      'div',
+      {
+        role: groupRole,
+        'aria-labelledby': labelId,
+        'aria-describedby': ariaDescribedBy,
+        className: 'facetheory-stitch-selectable-card-grid-options',
+        style: layoutContainerStyle(layout),
+      },
+      grid.options.map((option) =>
+        renderCardForGrid(
+          option,
+          grid.selection,
+          grid.selectedKeys.includes(option.key),
+          grid.groupId,
+          sizeTokens,
+          handleActivate,
+        ),
+      ),
+    ),
+    renderSafetyFootnote(grid.safetyPolicy),
+  );
+}
+
+function renderCardForGrid(
+  option: SelectableCardOption,
+  selection: SelectableCardGridSelection,
+  selected: boolean,
+  groupId: string,
+  sizeTokens: SizeTokens,
+  onActivate: (option: SelectableCardOption) => void,
+): React.ReactElement {
+  const disabled = isOptionDisabled(option);
+  const role = selection === 'single' ? 'radio' : 'checkbox';
+  const reasonId =
+    option.disabledReason !== undefined
+      ? `${groupId}-${option.key}-reason`
+      : undefined;
+  const tone = option.tone ?? 'neutral';
+  const palette = TONE_PALETTE[tone];
+
+  return h(
+    'div',
+    {
+      key: option.key,
+      className: deriveCardClassName(option, selected),
+      role,
+      'aria-checked': selected ? 'true' : 'false',
+      'aria-disabled': disabled ? 'true' : undefined,
+      'aria-describedby': reasonId,
+      tabIndex: disabled ? -1 : selected || selection === 'multi' ? 0 : -1,
+      'data-option-key': option.key,
+      'data-option-tone': tone,
+      'data-option-selected': selected ? 'true' : 'false',
+      'data-option-disabled': disabled ? 'true' : 'false',
+      'data-option-blocked': option.blocked === true ? 'true' : 'false',
+      'data-option-recommended': option.recommended === true ? 'true' : 'false',
+      onClick: !disabled ? () => onActivate(option) : undefined,
+      onKeyDown: !disabled
+        ? (event: React.KeyboardEvent<HTMLDivElement>) => {
+            if (event.key === ' ' || event.key === 'Enter') {
+              event.preventDefault();
+              onActivate(option);
+            }
+          }
+        : undefined,
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: sizeTokens.gap,
+        padding: sizeTokens.padding,
+        borderRadius: sizeTokens.borderRadius,
+        background: palette.background,
+        color: palette.color,
+        border: `${selected ? '2px' : '1px'} solid ${selected ? palette.color : palette.border}`,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.7 : 1,
+      },
+    },
+    renderCardBody(option, sizeTokens, reasonId),
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* ChoiceCard (standalone single-card primitive)                              */
+/* -------------------------------------------------------------------------- */
+
+export interface ChoiceCardPanelProps {
+  card: ChoiceCardProps;
+  /** Called when the user activates the card. Host owns selection state. */
+  onChange?: (selected: boolean) => void;
+}
+
+export function ChoiceCard(props: ChoiceCardPanelProps): React.ReactElement {
+  const { card, onChange } = props;
+  const { option, selection, selected, cardId, safetyPolicy } = card;
+  const size: SelectableCardGridSize = card.size ?? 'md';
+  const sizeTokens = SIZE_TOKENS[size];
+  const disabled = isOptionDisabled(option);
+  const role = selection === 'single' ? 'radio' : 'checkbox';
+  const reasonId =
+    option.disabledReason !== undefined ? `${cardId}-reason` : undefined;
+  const tone = option.tone ?? 'neutral';
+  const palette = TONE_PALETTE[tone];
+
+  return h(
+    'div',
+    {
+      id: cardId,
+      className: `${deriveCardClassName(option, selected)} facetheory-stitch-choice-card`,
+      role,
+      'aria-checked': selected ? 'true' : 'false',
+      'aria-disabled': disabled ? 'true' : undefined,
+      'aria-describedby': reasonId,
+      tabIndex: disabled ? -1 : 0,
+      'data-safety-policy': safetyPolicy,
+      'data-option-key': option.key,
+      'data-option-tone': tone,
+      'data-option-selected': selected ? 'true' : 'false',
+      'data-option-disabled': disabled ? 'true' : 'false',
+      'data-option-blocked': option.blocked === true ? 'true' : 'false',
+      'data-option-recommended': option.recommended === true ? 'true' : 'false',
+      'data-selection-family': selection,
+      onClick:
+        !disabled && onChange !== undefined
+          ? () => onChange(!selected)
+          : undefined,
+      onKeyDown:
+        !disabled && onChange !== undefined
+          ? (event: React.KeyboardEvent<HTMLDivElement>) => {
+              if (event.key === ' ' || event.key === 'Enter') {
+                event.preventDefault();
+                onChange(!selected);
+              }
+            }
+          : undefined,
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: sizeTokens.gap,
+        padding: sizeTokens.padding,
+        borderRadius: sizeTokens.borderRadius,
+        background: palette.background,
+        color: palette.color,
+        border: `${selected ? '2px' : '1px'} solid ${selected ? palette.color : palette.border}`,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.7 : 1,
+      },
+    },
+    renderCardBody(option, sizeTokens, reasonId),
+  );
+}

--- a/ts/src/stitch-admin/index.ts
+++ b/ts/src/stitch-admin/index.ts
@@ -57,6 +57,16 @@ export type {
 } from './wizard-authority-context-strip-types.js';
 
 export type {
+  ChoiceCardProps,
+  SelectableCardGrid,
+  SelectableCardGridLayout,
+  SelectableCardGridSelection,
+  SelectableCardGridSize,
+  SelectableCardOption,
+  SelectableCardTone,
+} from './selectable-card-grid-types.js';
+
+export type {
   WizardChipList,
   WizardChipListFeedbackTone,
   WizardChipListItem,

--- a/ts/src/stitch-admin/selectable-card-grid-types.ts
+++ b/ts/src/stitch-admin/selectable-card-grid-types.ts
@@ -1,0 +1,165 @@
+/**
+ * Framework-neutral types for the FaceTheory `SelectableCardGrid` /
+ * `ChoiceCard` primitives. The TheoryMCP Agent Import & Completion Wizard
+ * uses these to render the operator-facing choice surfaces (allowed actions,
+ * binding targets, environment selection) above wizard content.
+ *
+ * Trust boundary (load-bearing):
+ *
+ *   - This is presentation-only. FaceTheory does not decide whether a choice
+ *     is authorized.
+ *   - theory-mcp-server (the host) supplies allowed / disabled / blocked
+ *     state from route-resolved server policy and TableTheory-backed state.
+ *   - FaceTheory makes no authorization inference from option labels,
+ *     package fields, repository names, or action-family strings.
+ *   - The `recommended`, `riskLabel`, `disabledReason`, `blocked`, and
+ *     `blockedReason` fields are caller-supplied display values, never
+ *     computed by the primitive.
+ *
+ * Adapters (React, Vue, Svelte) narrow node-shaped fields to their native
+ * node type. The shape here is shared so the three adapters render the same
+ * testable contract (class names, `data-*`, ARIA, role markers).
+ */
+
+import type { OperatorVisibilityMetadata } from './operator-visibility-types.js';
+import type { WizardSafetyPolicy } from './wizard-types.js';
+
+/**
+ * Tone hint for a card. Hosts pick one; the adapter chooses concrete tokens.
+ * `recommended` is its own tone so the visual cue and the textual
+ * "Recommended" label can be paired.
+ */
+export type SelectableCardTone =
+  | 'neutral'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'recommended';
+
+/**
+ * Selection mode. `single` maps to `role="radiogroup"` + `role="radio"`;
+ * `multi` maps to `role="group"` + `role="checkbox"`.
+ */
+export type SelectableCardGridSelection = 'single' | 'multi';
+
+/** Layout mode. Adapter renders the appropriate inline-styled container. */
+export type SelectableCardGridLayout = 'grid' | 'stack' | 'two-column';
+
+/** Size hint. Adapter chooses concrete padding / font tokens. */
+export type SelectableCardGridSize = 'sm' | 'md' | 'lg';
+
+/**
+ * A single selectable card. Hosts provide already-resolved values; the
+ * adapter only renders them.
+ */
+export interface SelectableCardOption {
+  /** Stable identifier used for keying and selection state. */
+  key: string;
+  /** Required title. Adapters narrow this to their native node type. */
+  title: unknown;
+  /** Optional descriptive copy. Adapters narrow this to their native node type. */
+  description?: unknown;
+  /**
+   * Optional leading icon. Decorative; adapters render with `aria-hidden`
+   * so screen-readers do not double-read it. The accessible name comes from
+   * the title.
+   */
+  icon?: unknown;
+  /** Optional badge (e.g. "Beta", "Live"). Adapters narrow this. */
+  badge?: unknown;
+  /** Optional tone hint for the card. Defaults to `neutral`. */
+  tone?: SelectableCardTone;
+  /**
+   * Optional caller-supplied risk / warning label rendered as TEXT
+   * (e.g. "High blast radius"). Color-independent so high-contrast viewers
+   * see it. The primitive does not compute risk; it only displays.
+   */
+  riskLabel?: string;
+  /**
+   * Optional disabled reason copy. Presence implies the option is disabled
+   * (the adapter sets `aria-disabled="true"` on the card and wires
+   * `aria-describedby` to the reason node so screen-readers announce it).
+   * The primitive does not decide disabled state; it relays the host's
+   * decision.
+   */
+  disabledReason?: string;
+  /**
+   * Explicit `recommended` marker. Renders a TEXT "Recommended" pill in
+   * addition to any tone styling so the cue is not color-only.
+   */
+  recommended?: boolean;
+  /**
+   * Explicit `blocked` marker. Renders a TEXT "Blocked" pill and disables
+   * selection on the card. Often paired with `blockedReason` text.
+   */
+  blocked?: boolean;
+  /** Caller-supplied reason copy for blocked options. */
+  blockedReason?: string;
+  /**
+   * Optional already-server-resolved metadata badges (authority /
+   * provenance / correlation / confidence / staleness). Adapters render via
+   * `MetadataBadgeGroup`.
+   */
+  metadata?: OperatorVisibilityMetadata;
+}
+
+/**
+ * The card grid envelope. Hosts pre-compute selection state and the option
+ * order; the adapter renders verbatim.
+ */
+export interface SelectableCardGrid {
+  /** Stable HTML id used by the adapter to wire label/description/aria-* refs. */
+  groupId: string;
+  /** Caller-supplied options. */
+  options: SelectableCardOption[];
+  /** Currently selected option keys. Empty array means nothing selected. */
+  selectedKeys: string[];
+  /** Selection mode. */
+  selection: SelectableCardGridSelection;
+  /** Layout mode. Default `grid`. */
+  layout?: SelectableCardGridLayout;
+  /** Size hint. Default `md`. */
+  size?: SelectableCardGridSize;
+  /**
+   * Optional group label rendered above the cards and exposed via
+   * `aria-labelledby`. Adapters narrow this.
+   */
+  label?: unknown;
+  /**
+   * Optional descriptive copy. Adapters narrow this and wire it via
+   * `aria-describedby` on the group.
+   */
+  description?: unknown;
+  /**
+   * Explicit safety policy assertion (mirrors the rest of the wizard
+   * primitives — hosts confirm placeholders carry no secrets or
+   * production-like data, and the adapter renders the policy into the DOM).
+   */
+  safetyPolicy: WizardSafetyPolicy;
+}
+
+/**
+ * Props for the standalone `ChoiceCard` primitive — a single card rendered
+ * outside a grid. The card still relays selection state through host
+ * callbacks; it does NOT toggle itself.
+ */
+export interface ChoiceCardProps {
+  /** Required stable id used to wire label / aria-describedby refs. */
+  cardId: string;
+  /** The option payload. */
+  option: SelectableCardOption;
+  /**
+   * Selection mode. Determines whether the card renders as a radio (single
+   * selection family) or checkbox (multi selection family). Standalone
+   * cards still declare their family so screen-readers get the right
+   * semantics.
+   */
+  selection: SelectableCardGridSelection;
+  /** Whether the card is currently selected. Caller-controlled. */
+  selected: boolean;
+  /** Size hint. Default `md`. */
+  size?: SelectableCardGridSize;
+  /** Explicit safety policy assertion. */
+  safetyPolicy: WizardSafetyPolicy;
+}

--- a/ts/src/svelte/stitch-admin/ChoiceCard.svelte
+++ b/ts/src/svelte/stitch-admin/ChoiceCard.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import type {
+    ChoiceCardProps,
+    SelectableCardGridSelection,
+    SelectableCardOption,
+    SelectableCardTone,
+  } from './types.js';
+  import MetadataBadgeGroup from './MetadataBadgeGroup.svelte';
+
+  export let card: ChoiceCardProps;
+  export let onChange: ((selected: boolean) => void) | undefined = undefined;
+
+  function isOptionDisabled(option: SelectableCardOption): boolean {
+    return option.blocked === true || option.disabledReason !== undefined;
+  }
+
+  function deriveCardClassName(
+    option: SelectableCardOption,
+    selected: boolean,
+  ): string {
+    const tone: SelectableCardTone = option.tone ?? 'neutral';
+    const disabled = isOptionDisabled(option);
+    const cls = [
+      'facetheory-stitch-selectable-card',
+      `facetheory-stitch-selectable-card-tone-${tone}`,
+    ];
+    if (selected) cls.push('facetheory-stitch-selectable-card-selected');
+    if (disabled) cls.push('facetheory-stitch-selectable-card-disabled');
+    if (option.blocked === true) cls.push('facetheory-stitch-selectable-card-blocked');
+    if (option.recommended === true)
+      cls.push('facetheory-stitch-selectable-card-recommended');
+    return cls.join(' ');
+  }
+
+  function handleClick(): void {
+    if (isOptionDisabled(card.option) || onChange === undefined) return;
+    onChange(!card.selected);
+  }
+
+  function handleKey(event: KeyboardEvent): void {
+    if (isOptionDisabled(card.option) || onChange === undefined) return;
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      onChange(!card.selected);
+    }
+  }
+
+  $: option = card.option;
+  $: selected = card.selected;
+  $: cardId = card.cardId;
+  $: safetyPolicy = card.safetyPolicy;
+  $: selection = card.selection as SelectableCardGridSelection;
+  $: disabled = isOptionDisabled(option);
+  $: role = selection === 'single' ? 'radio' : 'checkbox';
+  $: reasonId = option.disabledReason !== undefined ? `${cardId}-reason` : undefined;
+  $: tone = option.tone ?? 'neutral';
+</script>
+
+<div
+  id={cardId}
+  class={`${deriveCardClassName(option, selected)} facetheory-stitch-choice-card`}
+  {role}
+  aria-checked={selected ? 'true' : 'false'}
+  aria-disabled={disabled ? 'true' : undefined}
+  aria-describedby={reasonId}
+  tabindex={disabled ? -1 : 0}
+  data-safety-policy={safetyPolicy}
+  data-option-key={option.key}
+  data-option-tone={tone}
+  data-option-selected={selected ? 'true' : 'false'}
+  data-option-disabled={disabled ? 'true' : 'false'}
+  data-option-blocked={option.blocked === true ? 'true' : 'false'}
+  data-option-recommended={option.recommended === true ? 'true' : 'false'}
+  data-selection-family={selection}
+  on:click={handleClick}
+  on:keydown={handleKey}
+>
+  <div class="facetheory-stitch-selectable-card-header">
+    {#if option.icon !== undefined}
+      <span class="facetheory-stitch-selectable-card-icon" aria-hidden="true">{option.icon}</span>
+    {/if}
+    <strong class="facetheory-stitch-selectable-card-title">{option.title}</strong>
+    {#if option.badge !== undefined}
+      <span class="facetheory-stitch-selectable-card-badge">{option.badge}</span>
+    {/if}
+  </div>
+  {#if option.description !== undefined}
+    <p class="facetheory-stitch-selectable-card-description">{option.description}</p>
+  {/if}
+  {#if option.recommended === true || option.blocked === true || (option.riskLabel !== undefined && option.riskLabel !== '')}
+    <div class="facetheory-stitch-selectable-card-pills">
+      {#if option.recommended === true}
+        <span class="facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-recommended" data-pill="recommended">Recommended</span>
+      {/if}
+      {#if option.blocked === true}
+        <span class="facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-blocked" data-pill="blocked">Blocked</span>
+      {/if}
+      {#if option.riskLabel !== undefined && option.riskLabel !== ''}
+        <span class="facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-risk" data-pill="risk">{option.riskLabel}</span>
+      {/if}
+    </div>
+  {/if}
+  {#if option.blocked === true && option.blockedReason !== undefined}
+    <p class="facetheory-stitch-selectable-card-blocked-reason">{option.blockedReason}</p>
+  {/if}
+  {#if option.disabledReason !== undefined}
+    <p
+      id={reasonId}
+      class="facetheory-stitch-selectable-card-disabled-reason"
+      data-disabled-reason="true"
+    >{option.disabledReason}</p>
+  {/if}
+  {#if option.metadata !== undefined}
+    <MetadataBadgeGroup metadata={option.metadata} />
+  {/if}
+</div>

--- a/ts/src/svelte/stitch-admin/SelectableCardGridPanel.svelte
+++ b/ts/src/svelte/stitch-admin/SelectableCardGridPanel.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  import type {
+    SelectableCardGrid,
+    SelectableCardGridLayout,
+    SelectableCardGridSelection,
+    SelectableCardGridSize,
+    SelectableCardOption,
+    SelectableCardTone,
+  } from './types.js';
+  import MetadataBadgeGroup from './MetadataBadgeGroup.svelte';
+
+  export let grid: SelectableCardGrid;
+  export let onChange: (nextSelectedKeys: string[]) => void;
+
+  function isOptionDisabled(option: SelectableCardOption): boolean {
+    return option.blocked === true || option.disabledReason !== undefined;
+  }
+
+  function deriveCardClassName(
+    option: SelectableCardOption,
+    selected: boolean,
+  ): string {
+    const tone: SelectableCardTone = option.tone ?? 'neutral';
+    const disabled = isOptionDisabled(option);
+    const cls = [
+      'facetheory-stitch-selectable-card',
+      `facetheory-stitch-selectable-card-tone-${tone}`,
+    ];
+    if (selected) cls.push('facetheory-stitch-selectable-card-selected');
+    if (disabled) cls.push('facetheory-stitch-selectable-card-disabled');
+    if (option.blocked === true) cls.push('facetheory-stitch-selectable-card-blocked');
+    if (option.recommended === true)
+      cls.push('facetheory-stitch-selectable-card-recommended');
+    return cls.join(' ');
+  }
+
+  function handleActivate(option: SelectableCardOption): void {
+    if (isOptionDisabled(option)) return;
+    if (grid.selection === 'single') {
+      onChange([option.key]);
+      return;
+    }
+    const isSelected = grid.selectedKeys.includes(option.key);
+    const next = isSelected
+      ? grid.selectedKeys.filter((k) => k !== option.key)
+      : [...grid.selectedKeys, option.key];
+    onChange(next);
+  }
+
+  function handleKey(event: KeyboardEvent, option: SelectableCardOption): void {
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      handleActivate(option);
+    }
+  }
+
+  $: layout = (grid.layout ?? 'grid') as SelectableCardGridLayout;
+  $: size = (grid.size ?? 'md') as SelectableCardGridSize;
+  $: groupRole = grid.selection === 'single' ? 'radiogroup' : 'group';
+  $: labelId = grid.label !== undefined ? `${grid.groupId}-label` : undefined;
+  $: descriptionId =
+    grid.description !== undefined ? `${grid.groupId}-description` : undefined;
+</script>
+
+<section
+  class={`facetheory-stitch-selectable-card-grid facetheory-stitch-selectable-card-grid-${grid.selection} facetheory-stitch-selectable-card-grid-layout-${layout} facetheory-stitch-selectable-card-grid-size-${size}`}
+  data-safety-policy={grid.safetyPolicy}
+  data-group-id={grid.groupId}
+  data-selection={grid.selection}
+  data-layout={layout}
+  data-size={size}
+  data-option-count={String(grid.options.length)}
+  data-selected-count={String(grid.selectedKeys.length)}
+>
+  {#if grid.label !== undefined || grid.description !== undefined}
+    <header class="facetheory-stitch-selectable-card-grid-header">
+      {#if grid.label !== undefined}
+        <div id={labelId} class="facetheory-stitch-selectable-card-grid-label">
+          {grid.label}
+        </div>
+      {/if}
+      {#if grid.description !== undefined}
+        <p id={descriptionId} class="facetheory-stitch-selectable-card-grid-description">
+          {grid.description}
+        </p>
+      {/if}
+    </header>
+  {/if}
+
+  <div
+    role={groupRole}
+    aria-labelledby={labelId}
+    aria-describedby={descriptionId}
+    class="facetheory-stitch-selectable-card-grid-options"
+  >
+    {#each grid.options as option (option.key)}
+      {@const selected = grid.selectedKeys.includes(option.key)}
+      {@const disabled = isOptionDisabled(option)}
+      {@const role = grid.selection === 'single' ? 'radio' : 'checkbox'}
+      {@const reasonId = option.disabledReason !== undefined ? `${grid.groupId}-${option.key}-reason` : undefined}
+      {@const tone = option.tone ?? 'neutral'}
+      <div
+        class={deriveCardClassName(option, selected)}
+        {role}
+        aria-checked={selected ? 'true' : 'false'}
+        aria-disabled={disabled ? 'true' : undefined}
+        aria-describedby={reasonId}
+        tabindex={disabled ? -1 : (selected || grid.selection === 'multi' ? 0 : -1)}
+        data-option-key={option.key}
+        data-option-tone={tone}
+        data-option-selected={selected ? 'true' : 'false'}
+        data-option-disabled={disabled ? 'true' : 'false'}
+        data-option-blocked={option.blocked === true ? 'true' : 'false'}
+        data-option-recommended={option.recommended === true ? 'true' : 'false'}
+        on:click={() => !disabled && handleActivate(option)}
+        on:keydown={(event) => !disabled && handleKey(event, option)}
+      >
+        <div class="facetheory-stitch-selectable-card-header">
+          {#if option.icon !== undefined}
+            <span class="facetheory-stitch-selectable-card-icon" aria-hidden="true">{option.icon}</span>
+          {/if}
+          <strong class="facetheory-stitch-selectable-card-title">{option.title}</strong>
+          {#if option.badge !== undefined}
+            <span class="facetheory-stitch-selectable-card-badge">{option.badge}</span>
+          {/if}
+        </div>
+        {#if option.description !== undefined}
+          <p class="facetheory-stitch-selectable-card-description">{option.description}</p>
+        {/if}
+        {#if option.recommended === true || option.blocked === true || (option.riskLabel !== undefined && option.riskLabel !== '')}
+          <div class="facetheory-stitch-selectable-card-pills">
+            {#if option.recommended === true}
+              <span
+                class="facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-recommended"
+                data-pill="recommended"
+              >Recommended</span>
+            {/if}
+            {#if option.blocked === true}
+              <span
+                class="facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-blocked"
+                data-pill="blocked"
+              >Blocked</span>
+            {/if}
+            {#if option.riskLabel !== undefined && option.riskLabel !== ''}
+              <span
+                class="facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-risk"
+                data-pill="risk"
+              >{option.riskLabel}</span>
+            {/if}
+          </div>
+        {/if}
+        {#if option.blocked === true && option.blockedReason !== undefined}
+          <p class="facetheory-stitch-selectable-card-blocked-reason">{option.blockedReason}</p>
+        {/if}
+        {#if option.disabledReason !== undefined}
+          <p
+            id={reasonId}
+            class="facetheory-stitch-selectable-card-disabled-reason"
+            data-disabled-reason="true"
+          >{option.disabledReason}</p>
+        {/if}
+        {#if option.metadata !== undefined}
+          <MetadataBadgeGroup metadata={option.metadata} />
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  <p
+    class="facetheory-stitch-wizard-safety-footnote"
+    data-safety-policy={grid.safetyPolicy}
+  >Safety policy: {grid.safetyPolicy}</p>
+</section>

--- a/ts/src/svelte/stitch-admin/index.d.ts
+++ b/ts/src/svelte/stitch-admin/index.d.ts
@@ -375,6 +375,27 @@ export interface WizardAuthorityContextStripPanelProps {
 }
 export type WizardServerResolvedContextBarPanelProps = WizardAuthorityContextStripPanelProps;
 
+export type {
+  ChoiceCardProps,
+  SelectableCardGrid,
+  SelectableCardGridLayout,
+  SelectableCardGridSelection,
+  SelectableCardGridSize,
+  SelectableCardOption,
+  SelectableCardTone,
+} from '../../stitch-admin/selectable-card-grid-types.js';
+
+export interface SelectableCardGridPanelProps {
+  grid: import('../../stitch-admin/selectable-card-grid-types.js').SelectableCardGrid;
+  onChange: (nextSelectedKeys: string[]) => void;
+}
+export interface ChoiceCardPanelProps {
+  card: import('../../stitch-admin/selectable-card-grid-types.js').ChoiceCardProps;
+  onChange?: (selected: boolean) => void;
+}
+export declare const SelectableCardGridPanel: Component<SelectableCardGridPanelProps>;
+export declare const ChoiceCard: Component<ChoiceCardPanelProps>;
+
 export declare const WizardProgress: Component<WizardProgressPanelProps>;
 export declare const WizardPackageSummaryPanel: Component<WizardPackageSummaryPanelProps>;
 export declare const WizardFindingListPanel: Component<WizardFindingListPanelProps>;

--- a/ts/src/svelte/stitch-admin/index.ts
+++ b/ts/src/svelte/stitch-admin/index.ts
@@ -34,8 +34,20 @@ export { default as WizardReconciliationPlanPanel } from './WizardReconciliation
 export { default as WizardDiffListPanel } from './WizardReconciliationPlanPanel.svelte';
 export { default as WizardAuthorityContextStripPanel } from './WizardAuthorityContextStripPanel.svelte';
 export { default as WizardServerResolvedContextBarPanel } from './WizardAuthorityContextStripPanel.svelte';
+export { default as SelectableCardGridPanel } from './SelectableCardGridPanel.svelte';
+export { default as ChoiceCard } from './ChoiceCard.svelte';
 export { default as WizardEditableTokenInputPanel } from './WizardEditableTokenInputPanel.svelte';
 export { default as WizardChipListPanel } from './WizardEditableTokenInputPanel.svelte';
+
+export type {
+  ChoiceCardProps,
+  SelectableCardGrid,
+  SelectableCardGridLayout,
+  SelectableCardGridSelection,
+  SelectableCardGridSize,
+  SelectableCardOption,
+  SelectableCardTone,
+} from '../../stitch-admin/selectable-card-grid-types.js';
 
 export type {
   WizardCapability,

--- a/ts/src/svelte/stitch-admin/types.ts
+++ b/ts/src/svelte/stitch-admin/types.ts
@@ -271,3 +271,23 @@ export interface WizardAuthorityContextStripPanelProps {
 }
 
 export type WizardServerResolvedContextBarPanelProps = WizardAuthorityContextStripPanelProps;
+
+export type {
+  ChoiceCardProps,
+  SelectableCardGrid,
+  SelectableCardGridLayout,
+  SelectableCardGridSelection,
+  SelectableCardGridSize,
+  SelectableCardOption,
+  SelectableCardTone,
+} from '../../stitch-admin/selectable-card-grid-types.js';
+
+export interface SelectableCardGridPanelProps {
+  grid: import('../../stitch-admin/selectable-card-grid-types.js').SelectableCardGrid;
+  onChange: (nextSelectedKeys: string[]) => void;
+}
+
+export interface ChoiceCardPanelProps {
+  card: import('../../stitch-admin/selectable-card-grid-types.js').ChoiceCardProps;
+  onChange?: (selected: boolean) => void;
+}

--- a/ts/src/vue/stitch-admin/index.ts
+++ b/ts/src/vue/stitch-admin/index.ts
@@ -146,6 +146,20 @@ export {
 } from './wizard-authority-context-strip.js';
 
 export {
+  SelectableCardGridPanel,
+  ChoiceCard,
+  type SelectableCardGridPanelProps,
+  type ChoiceCardPanelProps,
+  type ChoiceCardProps,
+  type SelectableCardGrid,
+  type SelectableCardGridLayout,
+  type SelectableCardGridSelection,
+  type SelectableCardGridSize,
+  type SelectableCardOption,
+  type SelectableCardTone,
+} from './selectable-card-grid.js';
+
+export {
   WizardEditableTokenInputPanel,
   WizardChipListPanel,
   type WizardEditableTokenInputPanelProps,

--- a/ts/src/vue/stitch-admin/selectable-card-grid.ts
+++ b/ts/src/vue/stitch-admin/selectable-card-grid.ts
@@ -1,0 +1,395 @@
+/**
+ * Vue parity for `SelectableCardGridPanel` and `ChoiceCard`. Mirrors the
+ * React adapter's class names, data-* attributes, ARIA wiring (radiogroup
+ * vs checkbox group, aria-checked, aria-disabled, aria-describedby), role
+ * markers, and safety-policy footnote.
+ */
+
+import { defineComponent, h } from 'vue';
+import type { PropType, VNodeChild } from 'vue';
+
+import type {
+  ChoiceCardProps,
+  SelectableCardGrid,
+  SelectableCardGridLayout,
+  SelectableCardGridSelection,
+  SelectableCardGridSize,
+  SelectableCardOption,
+  SelectableCardTone,
+} from '../../stitch-admin/selectable-card-grid-types.js';
+import type { WizardSafetyPolicy } from '../../stitch-admin/wizard-types.js';
+import { renderPropContent } from '../stitch-common.js';
+import { MetadataBadgeGroup } from './operator-notices.js';
+
+export type {
+  ChoiceCardProps,
+  SelectableCardGrid,
+  SelectableCardGridLayout,
+  SelectableCardGridSelection,
+  SelectableCardGridSize,
+  SelectableCardOption,
+  SelectableCardTone,
+};
+
+function isOptionDisabled(option: SelectableCardOption): boolean {
+  return option.blocked === true || option.disabledReason !== undefined;
+}
+
+function deriveCardClassName(option: SelectableCardOption, selected: boolean): string {
+  const tone = option.tone ?? 'neutral';
+  const disabled = isOptionDisabled(option);
+  const cls = [
+    'facetheory-stitch-selectable-card',
+    `facetheory-stitch-selectable-card-tone-${tone}`,
+  ];
+  if (selected) cls.push('facetheory-stitch-selectable-card-selected');
+  if (disabled) cls.push('facetheory-stitch-selectable-card-disabled');
+  if (option.blocked === true) cls.push('facetheory-stitch-selectable-card-blocked');
+  if (option.recommended === true) cls.push('facetheory-stitch-selectable-card-recommended');
+  return cls.join(' ');
+}
+
+function renderSafetyFootnote(policy: WizardSafetyPolicy): VNodeChild {
+  return h(
+    'p',
+    {
+      class: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+    },
+    `Safety policy: ${policy}`,
+  );
+}
+
+function renderCardStatusPills(option: SelectableCardOption): VNodeChild {
+  const pills: VNodeChild[] = [];
+  if (option.recommended === true) {
+    pills.push(
+      h(
+        'span',
+        {
+          key: 'recommended',
+          class:
+            'facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-recommended',
+          'data-pill': 'recommended',
+        },
+        'Recommended',
+      ),
+    );
+  }
+  if (option.blocked === true) {
+    pills.push(
+      h(
+        'span',
+        {
+          key: 'blocked',
+          class:
+            'facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-blocked',
+          'data-pill': 'blocked',
+        },
+        'Blocked',
+      ),
+    );
+  }
+  if (option.riskLabel !== undefined && option.riskLabel !== '') {
+    pills.push(
+      h(
+        'span',
+        {
+          key: 'risk',
+          class:
+            'facetheory-stitch-selectable-card-pill facetheory-stitch-selectable-card-pill-risk',
+          'data-pill': 'risk',
+        },
+        option.riskLabel,
+      ),
+    );
+  }
+  if (pills.length === 0) return null;
+  return h(
+    'div',
+    { class: 'facetheory-stitch-selectable-card-pills' },
+    pills,
+  );
+}
+
+function renderCardBody(
+  option: SelectableCardOption,
+  reasonId: string | undefined,
+): VNodeChild[] {
+  const children: VNodeChild[] = [];
+  children.push(
+    h(
+      'div',
+      { class: 'facetheory-stitch-selectable-card-header' },
+      [
+        option.icon !== undefined
+          ? h(
+              'span',
+              {
+                class: 'facetheory-stitch-selectable-card-icon',
+                'aria-hidden': 'true',
+              },
+              renderPropContent(option.icon as VNodeChild),
+            )
+          : null,
+        h(
+          'strong',
+          { class: 'facetheory-stitch-selectable-card-title' },
+          renderPropContent(option.title as VNodeChild),
+        ),
+        option.badge !== undefined
+          ? h(
+              'span',
+              { class: 'facetheory-stitch-selectable-card-badge' },
+              renderPropContent(option.badge as VNodeChild),
+            )
+          : null,
+      ],
+    ),
+  );
+  if (option.description !== undefined) {
+    children.push(
+      h(
+        'p',
+        { class: 'facetheory-stitch-selectable-card-description' },
+        renderPropContent(option.description as VNodeChild),
+      ),
+    );
+  }
+  const pills = renderCardStatusPills(option);
+  if (pills !== null) children.push(pills);
+  if (option.blocked === true && option.blockedReason !== undefined) {
+    children.push(
+      h(
+        'p',
+        { class: 'facetheory-stitch-selectable-card-blocked-reason' },
+        option.blockedReason,
+      ),
+    );
+  }
+  if (option.disabledReason !== undefined) {
+    children.push(
+      h(
+        'p',
+        {
+          id: reasonId,
+          class: 'facetheory-stitch-selectable-card-disabled-reason',
+          'data-disabled-reason': 'true',
+        },
+        option.disabledReason,
+      ),
+    );
+  }
+  if (option.metadata !== undefined) {
+    children.push(h(MetadataBadgeGroup, { metadata: option.metadata }));
+  }
+  return children;
+}
+
+function renderCardForGrid(
+  option: SelectableCardOption,
+  selection: SelectableCardGridSelection,
+  selected: boolean,
+  groupId: string,
+  onActivate: (option: SelectableCardOption) => void,
+): VNodeChild {
+  const disabled = isOptionDisabled(option);
+  const role = selection === 'single' ? 'radio' : 'checkbox';
+  const reasonId =
+    option.disabledReason !== undefined
+      ? `${groupId}-${option.key}-reason`
+      : undefined;
+  const tone = option.tone ?? 'neutral';
+  const props: Record<string, unknown> = {
+    key: option.key,
+    class: deriveCardClassName(option, selected),
+    role,
+    'aria-checked': selected ? 'true' : 'false',
+    'data-option-key': option.key,
+    'data-option-tone': tone,
+    'data-option-selected': selected ? 'true' : 'false',
+    'data-option-disabled': disabled ? 'true' : 'false',
+    'data-option-blocked': option.blocked === true ? 'true' : 'false',
+    'data-option-recommended': option.recommended === true ? 'true' : 'false',
+    tabindex: disabled ? -1 : selected || selection === 'multi' ? 0 : -1,
+  };
+  if (disabled) props['aria-disabled'] = 'true';
+  if (reasonId !== undefined) props['aria-describedby'] = reasonId;
+  if (!disabled) {
+    props.onClick = () => onActivate(option);
+    props.onKeydown = (event: KeyboardEvent) => {
+      if (event.key === ' ' || event.key === 'Enter') {
+        event.preventDefault();
+        onActivate(option);
+      }
+    };
+  }
+  return h('div', props, renderCardBody(option, reasonId));
+}
+
+export interface SelectableCardGridPanelProps {
+  grid: SelectableCardGrid;
+  onChange: (nextSelectedKeys: string[]) => void;
+}
+
+export const SelectableCardGridPanel = defineComponent({
+  name: 'FaceTheoryVueSelectableCardGridPanel',
+  props: {
+    grid: { type: Object as PropType<SelectableCardGrid>, required: true },
+    onChange: {
+      type: Function as PropType<(nextSelectedKeys: string[]) => void>,
+      required: true,
+    },
+  },
+  setup(props) {
+    return () => {
+      const grid = props.grid;
+      const onChange = props.onChange;
+      const layout: SelectableCardGridLayout = grid.layout ?? 'grid';
+      const size: SelectableCardGridSize = grid.size ?? 'md';
+      const groupRole = grid.selection === 'single' ? 'radiogroup' : 'group';
+      const labelId =
+        grid.label !== undefined ? `${grid.groupId}-label` : undefined;
+      const descriptionId =
+        grid.description !== undefined
+          ? `${grid.groupId}-description`
+          : undefined;
+
+      function handleActivate(option: SelectableCardOption): void {
+        if (isOptionDisabled(option)) return;
+        if (grid.selection === 'single') {
+          onChange([option.key]);
+          return;
+        }
+        const isSelected = grid.selectedKeys.includes(option.key);
+        const next = isSelected
+          ? grid.selectedKeys.filter((k) => k !== option.key)
+          : [...grid.selectedKeys, option.key];
+        onChange(next);
+      }
+
+      const groupProps: Record<string, unknown> = {
+        role: groupRole,
+        class: 'facetheory-stitch-selectable-card-grid-options',
+      };
+      if (labelId !== undefined) groupProps['aria-labelledby'] = labelId;
+      if (descriptionId !== undefined)
+        groupProps['aria-describedby'] = descriptionId;
+
+      return h(
+        'section',
+        {
+          class: `facetheory-stitch-selectable-card-grid facetheory-stitch-selectable-card-grid-${grid.selection} facetheory-stitch-selectable-card-grid-layout-${layout} facetheory-stitch-selectable-card-grid-size-${size}`,
+          'data-safety-policy': grid.safetyPolicy,
+          'data-group-id': grid.groupId,
+          'data-selection': grid.selection,
+          'data-layout': layout,
+          'data-size': size,
+          'data-option-count': String(grid.options.length),
+          'data-selected-count': String(grid.selectedKeys.length),
+        },
+        [
+          grid.label !== undefined || grid.description !== undefined
+            ? h(
+                'header',
+                { class: 'facetheory-stitch-selectable-card-grid-header' },
+                [
+                  grid.label !== undefined
+                    ? h(
+                        'div',
+                        {
+                          id: labelId,
+                          class: 'facetheory-stitch-selectable-card-grid-label',
+                        },
+                        renderPropContent(grid.label as VNodeChild),
+                      )
+                    : null,
+                  grid.description !== undefined
+                    ? h(
+                        'p',
+                        {
+                          id: descriptionId,
+                          class:
+                            'facetheory-stitch-selectable-card-grid-description',
+                        },
+                        renderPropContent(grid.description as VNodeChild),
+                      )
+                    : null,
+                ],
+              )
+            : null,
+          h(
+            'div',
+            groupProps,
+            grid.options.map((option) =>
+              renderCardForGrid(
+                option,
+                grid.selection,
+                grid.selectedKeys.includes(option.key),
+                grid.groupId,
+                handleActivate,
+              ),
+            ),
+          ),
+          renderSafetyFootnote(grid.safetyPolicy),
+        ],
+      );
+    };
+  },
+});
+
+export interface ChoiceCardPanelProps {
+  card: ChoiceCardProps;
+  onChange?: (selected: boolean) => void;
+}
+
+export const ChoiceCard = defineComponent({
+  name: 'FaceTheoryVueChoiceCard',
+  props: {
+    card: { type: Object as PropType<ChoiceCardProps>, required: true },
+    onChange: {
+      type: Function as PropType<(selected: boolean) => void>,
+      required: false,
+    },
+  },
+  setup(props) {
+    return () => {
+      const card = props.card;
+      const onChange = props.onChange;
+      const { option, selection, selected, cardId, safetyPolicy } = card;
+      const disabled = isOptionDisabled(option);
+      const role = selection === 'single' ? 'radio' : 'checkbox';
+      const reasonId =
+        option.disabledReason !== undefined ? `${cardId}-reason` : undefined;
+      const tone = option.tone ?? 'neutral';
+      const cardProps: Record<string, unknown> = {
+        id: cardId,
+        class: `${deriveCardClassName(option, selected)} facetheory-stitch-choice-card`,
+        role,
+        'aria-checked': selected ? 'true' : 'false',
+        'data-safety-policy': safetyPolicy,
+        'data-option-key': option.key,
+        'data-option-tone': tone,
+        'data-option-selected': selected ? 'true' : 'false',
+        'data-option-disabled': disabled ? 'true' : 'false',
+        'data-option-blocked': option.blocked === true ? 'true' : 'false',
+        'data-option-recommended':
+          option.recommended === true ? 'true' : 'false',
+        'data-selection-family': selection,
+        tabindex: disabled ? -1 : 0,
+      };
+      if (disabled) cardProps['aria-disabled'] = 'true';
+      if (reasonId !== undefined) cardProps['aria-describedby'] = reasonId;
+      if (!disabled && onChange !== undefined) {
+        cardProps.onClick = () => onChange(!selected);
+        cardProps.onKeydown = (event: KeyboardEvent) => {
+          if (event.key === ' ' || event.key === 'Enter') {
+            event.preventDefault();
+            onChange(!selected);
+          }
+        };
+      }
+      return h('div', cardProps, renderCardBody(option, reasonId));
+    };
+  },
+});

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -22,6 +22,7 @@ await import('./unit/stitch-admin.test.js');
 await import('./unit/stitch-admin-wizard.test.js');
 await import('./unit/stitch-admin-wizard-reconciliation-plan.test.js');
 await import('./unit/stitch-admin-wizard-authority-context-strip.test.js');
+await import('./unit/stitch-admin-selectable-card-grid.test.js');
 await import('./unit/stitch-admin-wizard-editable-token-input.test.js');
 await import('./unit/portal-fixtures.test.js');
 await import('./unit/antd-coverage.test.js');

--- a/ts/test/unit/stitch-admin-selectable-card-grid.test.ts
+++ b/ts/test/unit/stitch-admin-selectable-card-grid.test.ts
@@ -1,0 +1,321 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as React from 'react';
+
+import { createFaceApp } from '../../src/app.js';
+import { createReactFace } from '../../src/adapters/react.js';
+import { createAntdIntegration } from '../../src/react/antd.js';
+import type {
+  ChoiceCardProps,
+  SelectableCardGrid,
+} from '../../src/stitch-admin/index.js';
+import {
+  ChoiceCard,
+  SelectableCardGridPanel,
+} from '../../src/react/stitch-admin/index.js';
+
+const h = React.createElement;
+
+async function renderSSR(element: React.ReactElement): Promise<string> {
+  const app = createFaceApp({
+    faces: [
+      createReactFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => element,
+        renderOptions: {
+          integrations: [createAntdIntegration({ hashed: false })],
+        },
+      }),
+    ],
+  });
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  return new TextDecoder().decode(resp.body as Uint8Array);
+}
+
+function countMatches(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+const NOOP_CHANGE = (): void => {};
+
+const SAMPLE_GRID_SINGLE: SelectableCardGrid = {
+  groupId: 'allowed-action',
+  selection: 'single',
+  selectedKeys: ['create'],
+  options: [
+    {
+      key: 'create',
+      title: 'Create new namespace',
+      description: 'Adds a fresh namespace under the current tenant.',
+      tone: 'success',
+      recommended: true,
+    },
+    {
+      key: 'reuse',
+      title: 'Reuse existing namespace',
+      description: 'Bind the agent to a namespace TheoryMCP already manages.',
+      tone: 'info',
+    },
+    {
+      key: 'replace',
+      title: 'Replace existing namespace',
+      description: 'Destructive: overwrites the existing binding.',
+      tone: 'warning',
+      riskLabel: 'High blast radius',
+    },
+    {
+      key: 'archive',
+      title: 'Archive without binding',
+      description: 'Cannot be re-enabled without operator review.',
+      disabledReason: 'Requires operator review before archival.',
+    },
+    {
+      key: 'forbidden',
+      title: 'Forbidden namespace',
+      description: 'Policy disallows this option for the current operator.',
+      blocked: true,
+      blockedReason: 'Server policy blocks this option for non-admin operators.',
+    },
+  ],
+  label: 'Allowed action',
+  description: 'TheoryMCP resolves which of these are available per route.',
+  layout: 'grid',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+const SAMPLE_GRID_MULTI: SelectableCardGrid = {
+  groupId: 'allowed-targets',
+  selection: 'multi',
+  selectedKeys: ['github', 'mailbox'],
+  options: [
+    { key: 'github', title: 'GitHub binding' },
+    { key: 'mailbox', title: 'Mailbox binding' },
+    { key: 'policy', title: 'Policy binding' },
+  ],
+  layout: 'stack',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+/* -------------------------------------------------------------------------- */
+/* Single-select / radiogroup semantics                                       */
+/* -------------------------------------------------------------------------- */
+
+test('SelectableCardGridPanel renders single-select as a radiogroup with stable data attrs', async () => {
+  const body = await renderSSR(
+    h(SelectableCardGridPanel, { grid: SAMPLE_GRID_SINGLE, onChange: NOOP_CHANGE }),
+  );
+
+  assert.ok(body.includes('facetheory-stitch-selectable-card-grid'));
+  assert.ok(body.includes('facetheory-stitch-selectable-card-grid-single'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(body.includes('data-selection="single"'));
+  assert.ok(body.includes('data-layout="grid"'));
+  assert.ok(body.includes('data-option-count="5"'));
+  assert.ok(body.includes('data-selected-count="1"'));
+
+  // Group container uses role="radiogroup" and is wired to the label/description.
+  assert.ok(body.includes('role="radiogroup"'));
+  assert.ok(body.includes('aria-labelledby="allowed-action-label"'));
+  assert.ok(body.includes('aria-describedby="allowed-action-description"'));
+
+  // Each card carries role="radio" + aria-checked.
+  assert.equal(countMatches(body, 'role="radio"'), 5);
+  assert.ok(body.includes('data-option-key="create"'));
+  assert.ok(body.includes('data-option-selected="true"'));
+
+  // Caller-supplied order preserved.
+  const order = ['create', 'reuse', 'replace', 'archive', 'forbidden'];
+  let prev = -1;
+  for (const key of order) {
+    const idx = body.indexOf(`data-option-key="${key}"`);
+    assert.ok(idx > prev, `option ${key} must appear after previous in SSR output`);
+    prev = idx;
+  }
+
+  // Safety policy footnote present.
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+test('SelectableCardGridPanel renders recommended, risk, and blocked TEXT pills (not color-only)', async () => {
+  const body = await renderSSR(
+    h(SelectableCardGridPanel, { grid: SAMPLE_GRID_SINGLE, onChange: NOOP_CHANGE }),
+  );
+
+  // Recommended pill on the recommended option only.
+  const createIdx = body.indexOf('data-option-key="create"');
+  const createSnippet = body.slice(createIdx, createIdx + 2000);
+  assert.ok(createSnippet.includes('data-pill="recommended"'));
+  assert.ok(createSnippet.includes('Recommended'));
+  assert.ok(body.includes('data-option-recommended="true"'));
+
+  // Risk label rendered as text on the risky option.
+  const replaceIdx = body.indexOf('data-option-key="replace"');
+  const replaceSnippet = body.slice(replaceIdx, replaceIdx + 2000);
+  assert.ok(replaceSnippet.includes('data-pill="risk"'));
+  assert.ok(replaceSnippet.includes('High blast radius'));
+
+  // Blocked pill + blocked reason on the forbidden option.
+  const forbiddenIdx = body.indexOf('data-option-key="forbidden"');
+  const forbiddenSnippet = body.slice(forbiddenIdx, forbiddenIdx + 2000);
+  assert.ok(forbiddenSnippet.includes('data-pill="blocked"'));
+  assert.ok(forbiddenSnippet.includes('Blocked'));
+  assert.ok(forbiddenSnippet.includes('Server policy blocks this option for non-admin operators.'));
+  assert.ok(forbiddenSnippet.includes('data-option-blocked="true"'));
+
+  // Confirm the forbidden option's opening tag carries aria-disabled too.
+  const forbiddenTagStart = body.lastIndexOf('<div', forbiddenIdx);
+  const forbiddenTagEnd = body.indexOf('>', forbiddenTagStart);
+  const forbiddenTag = body.slice(forbiddenTagStart, forbiddenTagEnd + 1);
+  assert.ok(forbiddenTag.includes('aria-disabled="true"'));
+});
+
+test('SelectableCardGridPanel renders disabled-with-reason wired via aria-describedby', async () => {
+  const body = await renderSSR(
+    h(SelectableCardGridPanel, { grid: SAMPLE_GRID_SINGLE, onChange: NOOP_CHANGE }),
+  );
+
+  // Archive option is disabled via disabledReason. Confirm the same opening
+  // tag carries aria-disabled and aria-describedby pointing at the reason id.
+  const archiveIdx = body.indexOf('data-option-key="archive"');
+  assert.ok(archiveIdx > -1);
+  const archiveTagStart = body.lastIndexOf('<div', archiveIdx);
+  const archiveTagEnd = body.indexOf('>', archiveTagStart);
+  const archiveTag = body.slice(archiveTagStart, archiveTagEnd + 1);
+  assert.ok(archiveTag.includes('aria-disabled="true"'));
+  assert.ok(archiveTag.includes('aria-describedby="allowed-action-archive-reason"'));
+
+  // The reason node carries the expected id, copy, and data marker.
+  assert.ok(body.includes('id="allowed-action-archive-reason"'));
+  assert.ok(body.includes('Requires operator review before archival.'));
+  assert.ok(body.includes('data-disabled-reason="true"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Multi-select / checkbox group semantics                                    */
+/* -------------------------------------------------------------------------- */
+
+test('SelectableCardGridPanel renders multi-select as a group of checkboxes', async () => {
+  const body = await renderSSR(
+    h(SelectableCardGridPanel, { grid: SAMPLE_GRID_MULTI, onChange: NOOP_CHANGE }),
+  );
+
+  assert.ok(body.includes('facetheory-stitch-selectable-card-grid-multi'));
+  assert.ok(body.includes('data-selection="multi"'));
+  assert.ok(body.includes('data-layout="stack"'));
+  assert.ok(body.includes('data-selected-count="2"'));
+  assert.ok(body.includes('role="group"'));
+  assert.equal(countMatches(body, 'role="checkbox"'), 3);
+
+  // 2 of 3 cards selected → 2 cards with aria-checked="true" and data-option-selected="true",
+  // 1 card with aria-checked="false" and data-option-selected="false".
+  assert.equal(countMatches(body, 'aria-checked="true"'), 2);
+  assert.equal(countMatches(body, 'aria-checked="false"'), 1);
+  assert.equal(countMatches(body, 'data-option-selected="true"'), 2);
+  assert.equal(countMatches(body, 'data-option-selected="false"'), 1);
+
+  // The unselected option is `policy`.
+  const policyIdx = body.indexOf('data-option-key="policy"');
+  assert.ok(policyIdx > -1);
+  // Search backwards from the policy data attribute to confirm the same card
+  // also carries `aria-checked="false"` and `data-option-selected="false"`.
+  const policyOpeningTag = body.lastIndexOf('<div', policyIdx);
+  const policyTagEnd = body.indexOf('>', policyOpeningTag);
+  const policyTag = body.slice(policyOpeningTag, policyTagEnd + 1);
+  assert.ok(policyTag.includes('aria-checked="false"'));
+  assert.ok(policyTag.includes('data-option-selected="false"'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Layout variants                                                            */
+/* -------------------------------------------------------------------------- */
+
+test('SelectableCardGridPanel exposes each layout via data-layout', async () => {
+  for (const layout of ['grid', 'stack', 'two-column'] as const) {
+    const body = await renderSSR(
+      h(SelectableCardGridPanel, {
+        grid: { ...SAMPLE_GRID_SINGLE, layout },
+        onChange: NOOP_CHANGE,
+      }),
+    );
+    assert.ok(body.includes(`data-layout="${layout}"`));
+    assert.ok(
+      body.includes(`facetheory-stitch-selectable-card-grid-layout-${layout}`),
+    );
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* Determinism                                                                */
+/* -------------------------------------------------------------------------- */
+
+test('SelectableCardGridPanel produces byte-identical SSR output for the same input', async () => {
+  const first = await renderSSR(
+    h(SelectableCardGridPanel, { grid: SAMPLE_GRID_SINGLE, onChange: NOOP_CHANGE }),
+  );
+  const second = await renderSSR(
+    h(SelectableCardGridPanel, { grid: SAMPLE_GRID_SINGLE, onChange: NOOP_CHANGE }),
+  );
+  assert.equal(first, second, 'SelectableCardGridPanel must be deterministic');
+});
+
+/* -------------------------------------------------------------------------- */
+/* Standalone ChoiceCard                                                      */
+/* -------------------------------------------------------------------------- */
+
+test('ChoiceCard renders selected single-family card with role=radio + aria-checked', async () => {
+  const card: ChoiceCardProps = {
+    cardId: 'choice-create',
+    option: {
+      key: 'create',
+      title: 'Create new namespace',
+      description: 'Adds a fresh namespace.',
+      tone: 'success',
+      recommended: true,
+    },
+    selection: 'single',
+    selected: true,
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(h(ChoiceCard, { card }));
+  assert.ok(body.includes('facetheory-stitch-choice-card'));
+  assert.ok(body.includes('role="radio"'));
+  assert.ok(body.includes('aria-checked="true"'));
+  assert.ok(body.includes('data-option-key="create"'));
+  assert.ok(body.includes('data-option-selected="true"'));
+  assert.ok(body.includes('data-option-recommended="true"'));
+  assert.ok(body.includes('data-selection-family="single"'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+});
+
+test('ChoiceCard renders disabled card with aria-disabled and aria-describedby wiring', async () => {
+  const card: ChoiceCardProps = {
+    cardId: 'choice-archive',
+    option: {
+      key: 'archive',
+      title: 'Archive without binding',
+      disabledReason: 'Requires operator review before archival.',
+    },
+    selection: 'single',
+    selected: false,
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(h(ChoiceCard, { card }));
+  assert.ok(body.includes('aria-disabled="true"'));
+  assert.ok(body.includes('aria-describedby="choice-archive-reason"'));
+  assert.ok(body.includes('id="choice-archive-reason"'));
+  assert.ok(body.includes('Requires operator review before archival.'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Fixture safety guard                                                       */
+/* -------------------------------------------------------------------------- */
+
+test('SelectableCardGridPanel fixture contains no obvious production-like or secret values', () => {
+  const serialized = JSON.stringify(SAMPLE_GRID_SINGLE) + JSON.stringify(SAMPLE_GRID_MULTI);
+  const forbidden = ['AKIA', 'aws_secret', 'BEGIN PRIVATE KEY', 'Authorization:', 'api_key='];
+  for (const needle of forbidden) {
+    assert.equal(serialized.includes(needle), false, `fixture must not include "${needle}"`);
+  }
+});

--- a/ts/test/unit/svelte-stitch-admin.test.ts
+++ b/ts/test/unit/svelte-stitch-admin.test.ts
@@ -851,3 +851,89 @@ test('svelte wizard parity: WizardReconciliationPlanPanel renders row.metadata v
   assert.ok(body.includes('facetheory-stitch-metadata-badge-group'));
   assert.ok(body.includes('Plan diff'));
 });
+
+test('svelte selectable-card-grid: single-select renders as radiogroup with role=radio cards', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/SelectableCardGridPanel.svelte'),
+    {
+      grid: {
+        groupId: 'allowed-action',
+        selection: 'single',
+        selectedKeys: ['create'],
+        options: [
+          { key: 'create', title: 'Create', tone: 'success', recommended: true },
+          { key: 'reuse', title: 'Reuse', tone: 'info' },
+          { key: 'replace', title: 'Replace', tone: 'warning', riskLabel: 'High blast radius' },
+          { key: 'archive', title: 'Archive', disabledReason: 'Requires operator review.' },
+          { key: 'forbidden', title: 'Forbidden', blocked: true, blockedReason: 'Server policy blocks this.' },
+        ],
+        label: 'Allowed action',
+        description: 'TheoryMCP resolves availability per route.',
+        layout: 'grid',
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+      onChange: (): void => {},
+    },
+  );
+  assert.ok(body.includes('facetheory-stitch-selectable-card-grid'));
+  assert.ok(body.includes('data-selection="single"'));
+  assert.ok(body.includes('data-layout="grid"'));
+  assert.ok(body.includes('role="radiogroup"'));
+  assert.ok(body.includes('aria-labelledby="allowed-action-label"'));
+  assert.ok(body.includes('aria-describedby="allowed-action-description"'));
+  assert.equal(body.split('role="radio"').length - 1, 5);
+  assert.ok(body.includes('data-option-selected="true"'));
+  assert.ok(body.includes('data-pill="recommended"'));
+  assert.ok(body.includes('data-pill="risk"'));
+  assert.ok(body.includes('data-pill="blocked"'));
+  assert.ok(body.includes('id="allowed-action-archive-reason"'));
+  assert.ok(body.includes('Requires operator review.'));
+  assert.ok(body.includes('Server policy blocks this.'));
+});
+
+test('svelte selectable-card-grid: multi-select renders as checkbox group', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/SelectableCardGridPanel.svelte'),
+    {
+      grid: {
+        groupId: 'targets',
+        selection: 'multi',
+        selectedKeys: ['github', 'mailbox'],
+        options: [
+          { key: 'github', title: 'GitHub' },
+          { key: 'mailbox', title: 'Mailbox' },
+          { key: 'policy', title: 'Policy' },
+        ],
+        layout: 'stack',
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+      onChange: (): void => {},
+    },
+  );
+  assert.ok(body.includes('data-selection="multi"'));
+  assert.ok(body.includes('role="group"'));
+  assert.equal(body.split('role="checkbox"').length - 1, 3);
+  assert.equal(body.split('aria-checked="true"').length - 1, 2);
+  assert.equal(body.split('aria-checked="false"').length - 1, 1);
+});
+
+test('svelte ChoiceCard renders standalone card with selection family + safety policy', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/ChoiceCard.svelte'),
+    {
+      card: {
+        cardId: 'choice-create',
+        option: { key: 'create', title: 'Create', recommended: true },
+        selection: 'single',
+        selected: true,
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+    },
+  );
+  assert.ok(body.includes('facetheory-stitch-choice-card'));
+  assert.ok(body.includes('role="radio"'));
+  assert.ok(body.includes('aria-checked="true"'));
+  assert.ok(body.includes('data-selection-family="single"'));
+  assert.ok(body.includes('data-option-recommended="true"'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+});

--- a/ts/test/unit/vue-stitch-admin.test.ts
+++ b/ts/test/unit/vue-stitch-admin.test.ts
@@ -1010,3 +1010,113 @@ test('vue wizard parity: WizardReconciliationPlanPanel renders row.metadata via 
   assert.ok(body.includes('facetheory-stitch-metadata-badge-group'));
   assert.ok(body.includes('Plan diff'));
 });
+
+import {
+  SelectableCardGridPanel as VueSelectableCardGridPanel,
+  ChoiceCard as VueChoiceCard,
+} from '../../src/vue/stitch-admin/index.js';
+import type {
+  ChoiceCardProps as VueChoiceCardProps,
+  SelectableCardGrid as VueSelectableCardGrid,
+} from '../../src/stitch-admin/index.js';
+
+const SELECTABLE_GRID_SINGLE: VueSelectableCardGrid = {
+  groupId: 'allowed-action',
+  selection: 'single',
+  selectedKeys: ['create'],
+  options: [
+    { key: 'create', title: 'Create', tone: 'success', recommended: true },
+    { key: 'reuse', title: 'Reuse', tone: 'info' },
+    { key: 'replace', title: 'Replace', tone: 'warning', riskLabel: 'High blast radius' },
+    { key: 'archive', title: 'Archive', disabledReason: 'Requires operator review.' },
+    { key: 'forbidden', title: 'Forbidden', blocked: true, blockedReason: 'Server policy blocks this.' },
+  ],
+  label: 'Allowed action',
+  description: 'TheoryMCP resolves availability per route.',
+  layout: 'grid',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+test('vue selectable-card-grid: single-select renders as radiogroup with role=radio cards', async () => {
+  const body = await renderSSR(
+    h(VueSelectableCardGridPanel, {
+      grid: SELECTABLE_GRID_SINGLE,
+      onChange: () => {},
+    }),
+  );
+  assert.ok(body.includes('facetheory-stitch-selectable-card-grid'));
+  assert.ok(body.includes('data-selection="single"'));
+  assert.ok(body.includes('data-layout="grid"'));
+  assert.ok(body.includes('role="radiogroup"'));
+  assert.ok(body.includes('aria-labelledby="allowed-action-label"'));
+  assert.ok(body.includes('aria-describedby="allowed-action-description"'));
+  // 5 role=radio cards.
+  assert.equal(body.split('role="radio"').length - 1, 5);
+  assert.ok(body.includes('data-option-selected="true"'));
+});
+
+test('vue selectable-card-grid: renders recommended/risk/blocked TEXT pills + disabled reason wiring', async () => {
+  const body = await renderSSR(
+    h(VueSelectableCardGridPanel, {
+      grid: SELECTABLE_GRID_SINGLE,
+      onChange: () => {},
+    }),
+  );
+  assert.ok(body.includes('data-pill="recommended"'));
+  assert.ok(body.includes('Recommended'));
+  assert.ok(body.includes('data-pill="risk"'));
+  assert.ok(body.includes('High blast radius'));
+  assert.ok(body.includes('data-pill="blocked"'));
+  assert.ok(body.includes('Server policy blocks this.'));
+  assert.ok(body.includes('id="allowed-action-archive-reason"'));
+  assert.ok(body.includes('data-disabled-reason="true"'));
+  assert.ok(body.includes('Requires operator review.'));
+});
+
+test('vue selectable-card-grid: multi-select renders as checkbox group', async () => {
+  const grid: VueSelectableCardGrid = {
+    groupId: 'targets',
+    selection: 'multi',
+    selectedKeys: ['github', 'mailbox'],
+    options: [
+      { key: 'github', title: 'GitHub' },
+      { key: 'mailbox', title: 'Mailbox' },
+      { key: 'policy', title: 'Policy' },
+    ],
+    layout: 'stack',
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(h(VueSelectableCardGridPanel, { grid, onChange: () => {} }));
+  assert.ok(body.includes('data-selection="multi"'));
+  assert.ok(body.includes('role="group"'));
+  assert.equal(body.split('role="checkbox"').length - 1, 3);
+  assert.equal(body.split('aria-checked="true"').length - 1, 2);
+  assert.equal(body.split('aria-checked="false"').length - 1, 1);
+});
+
+test('vue selectable-card-grid: byte-identical SSR for the same input', async () => {
+  const first = await renderSSR(
+    h(VueSelectableCardGridPanel, { grid: SELECTABLE_GRID_SINGLE, onChange: () => {} }),
+  );
+  const second = await renderSSR(
+    h(VueSelectableCardGridPanel, { grid: SELECTABLE_GRID_SINGLE, onChange: () => {} }),
+  );
+  assert.equal(first, second);
+});
+
+test('vue ChoiceCard renders standalone card with selection family + safety policy', async () => {
+  const card: VueChoiceCardProps = {
+    cardId: 'choice-create',
+    option: { key: 'create', title: 'Create', recommended: true },
+    selection: 'single',
+    selected: true,
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(h(VueChoiceCard, { card }));
+  assert.ok(body.includes('facetheory-stitch-choice-card'));
+  assert.ok(body.includes('role="radio"'));
+  assert.ok(body.includes('aria-checked="true"'));
+  assert.ok(body.includes('data-selection-family="single"'));
+  assert.ok(body.includes('data-option-recommended="true"'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+});


### PR DESCRIPTION
## Milestone

Factory assignment **THE-1454 / APW-FT5** — SelectableCardGrid / ChoiceCard with React + Vue + Svelte parity from the start.

- Linear issue: THE-1454 — APW-FT5: Request FaceTheory SelectableCardGrid / ChoiceCard
- PR target: `project/theorymcp-agent-import-completion-wizard-20260521` (NOT `staging`)
- Project branch base: `project/theorymcp-agent-import-completion-wizard-20260521` @ `ffcbdd1af8043452fdd7678204924d51814709aa` (THE-1460 / PR #220 merge)
- Milestone branch: `facetheory/agent-import-wizard-selectable-card-grid`
- Head commit: `b406e2578be8fcf307d1920a1446eb5ce0776e52` (signed)

## What changed

Card-grid choice surface for the TheoryMCP Agent Import & Completion Wizard's "pick an action / target / environment" steps. Single-select and multi-select; three layouts; six tones; full accessibility wiring. Ships with React + Vue + Svelte parity from the start (per the lesson from THE-1450 → THE-1459 — captured in steward memory and reaffirmed by your assignment).

### Framework-neutral types (`ts/src/stitch-admin/selectable-card-grid-types.ts`)

- `SelectableCardOption { key, title, description?, icon?, badge?, tone?, riskLabel?, disabledReason?, recommended?, blocked?, blockedReason?, metadata? }` — `metadata` is the shared `OperatorVisibilityMetadata` so `MetadataBadgeGroup` parity carries over.
- `SelectableCardTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger' | 'recommended'`.
- `SelectableCardGridSelection = 'single' | 'multi'`.
- `SelectableCardGridLayout = 'grid' | 'stack' | 'two-column'`.
- `SelectableCardGrid` envelope + `ChoiceCardProps` for the standalone primitive.

### React adapter (`ts/src/react/stitch-admin/selectable-card-grid.ts`)

`SelectableCardGridPanel` + `ChoiceCard`. Pure controlled — no hidden state. No `Math.random()` / `Date.now()` / `window` reads / network / server validation at render. `onChange(nextSelectedKeys: string[])` proposes selection; the primitive never toggles state internally.

### Vue adapter (`ts/src/vue/stitch-admin/selectable-card-grid.ts`)

Same DOM contract via `defineComponent + h`. Re-exported from `ts/src/vue/stitch-admin/index.ts`.

### Svelte adapter (`SelectableCardGridPanel.svelte` + `ChoiceCard.svelte`)

Same DOM via Svelte SSR. Re-exported from `ts/src/svelte/stitch-admin/index.ts` with matching Component declarations in `index.d.ts` and prop interfaces in `types.ts`.

### Accessibility contract

- Single-select grids render the outer container as `role="radiogroup"` with each card as `role="radio"` and `aria-checked` driven by selection.
- Multi-select grids render the outer container as `role="group"` with each card as `role="checkbox"` and `aria-checked` driven by selection.
- Disabled options (those with `disabledReason` or `blocked: true`) carry `aria-disabled="true"`; the host-supplied disabled reason is rendered as text and wired via `aria-describedby` so screen-readers announce it.
- `recommended`, `Blocked`, and risk states render as **text pills** (not color-only) — `data-pill="recommended" | "blocked" | "risk"` — so high-contrast viewers see the cue.
- `Space` or `Enter` activate; the primitive calls the host's `onChange` with the proposed next selected-key set.

### Trust boundary

- Presentation-only. FaceTheory does not decide whether a choice is authorized.
- theory-mcp-server supplies allowed / disabled / blocked state from route-resolved server policy and TableTheory-backed state.
- FaceTheory makes no authorization inference from option labels, package fields, repository names, or action-family strings.
- AWS dependency boundary preserved: the existing narrow allowlist exception for AWS CDK bundled `brace-expansion` in `infra/apptheory-*` workspaces is unchanged.

### Tests

- `ts/test/unit/stitch-admin-selectable-card-grid.test.ts` (React, 9 tests): single-select radiogroup with stable data attrs, recommended/risk/blocked TEXT pills, disabled-with-reason wired via `aria-describedby`, multi-select checkbox group, all three layouts via `data-layout`, byte-identical SSR determinism, standalone `ChoiceCard` selection-family rendering, `ChoiceCard` disabled-with-reason wiring, fixture safety guard.
- `ts/test/unit/vue-stitch-admin.test.ts` — +5 Vue parity tests.
- `ts/test/unit/svelte-stitch-admin.test.ts` — +3 Svelte parity tests.
- `npm test` now reports **421 tests / 420 pass / 1 skip** (was 404 / 403 / 1 skip; +9 React + +5 Vue + +3 Svelte = +17 new tests).

### Docs (`docs/wizard-primitives.md`)

- Primitives table updated so React/Vue/Svelte rows enumerate the new `SelectableCardGridPanel` and `ChoiceCard`.
- New "Selectable card grid / choice card" section covering the trust boundary, option contract, accessibility contract (radiogroup vs checkbox group, text-pill cues), selection model, keyboard activation, and a worked TheoryMCP allowed-action example.

## Explicit React / Vue / Svelte parity summary

| Surface                          | React | Vue | Svelte |
| -------------------------------- | :---: | :-: | :----: |
| `SelectableCardGridPanel`        | ✅    | ✅  | ✅      |
| `ChoiceCard`                     | ✅    | ✅  | ✅      |
| Single-select radiogroup roles   | ✅    | ✅  | ✅      |
| Multi-select checkbox roles      | ✅    | ✅  | ✅      |
| `data-*` markers                 | ✅    | ✅  | ✅      |
| Recommended / blocked / risk text pills | ✅ | ✅ | ✅ |
| Disabled-with-reason + aria-describedby | ✅ | ✅ | ✅ |
| Three layouts (`grid` / `stack` / `two-column`) | ✅ | ✅ | ✅ |
| Metadata via `MetadataBadgeGroup` | ✅ | ✅ | ✅ |
| Safety-policy footnote           | ✅    | ✅  | ✅      |
| Focused parity tests             | ✅    | ✅  | ✅      |

## Validation

Run from the repo root against PR head `b406e2578be8fcf307d1920a1446eb5ce0776e52`.

- `git diff --check origin/project/theorymcp-agent-import-completion-wizard-20260521...HEAD` — clean
- `scripts/verify-version-alignment.sh` → `version-alignment: PASS (3.2.1)`
- `cd ts && npm ci` — clean; `npm audit` reports `found 0 vulnerabilities`
- `cd ts && npm run typecheck` — pass
- `cd ts && npm run lint` — pass
- `cd ts && npm test` → **`tests 421 / pass 420 / fail 0 / skipped 1`**
- `cd ts && npm run build` — pass
- `scripts/verify-npm-audit.sh`:
  - `npm-audit: PASS (ts)`
  - `npm-audit: ALLOW (infra/apptheory-ssr-site) brace-expansion via bundled aws-cdk-lib tarball; no custom CDK tarball is maintained`
  - `npm-audit: ALLOW (infra/apptheory-ssg-isr-site) brace-expansion via bundled aws-cdk-lib tarball; no custom CDK tarball is maintained`
- `make rubric` — **exits 0**.
- `scripts/pack-dev-archive.sh --skip-build --output-dir /tmp/theorycloud-facetheory-dev-archives` — archive + sidecar produced.
- `( cd /tmp/theorycloud-facetheory-dev-archives && sha256sum --check theory-cloud-facetheory-3.2.1-dev-b406e2578be8.tgz.sha256 )` → `theory-cloud-facetheory-3.2.1-dev-b406e2578be8.tgz: OK`

## Temporary local archive handoff

- Command: `scripts/pack-dev-archive.sh --output-dir /tmp/theorycloud-facetheory-dev-archives`
- Archive basename (from PR head `b406e25`): `theory-cloud-facetheory-3.2.1-dev-b406e2578be8.tgz`
- sha256: `3405028b7810174ac5a1fc42d24db98ab5d723ba2c95a75325386cfc594a8d12`
- Verify (works from any cwd):
  ```bash
  ( cd /tmp/theorycloud-facetheory-dev-archives \
      && sha256sum --check theory-cloud-facetheory-3.2.1-dev-b406e2578be8.tgz.sha256 )
  ```
- Verify output: `theory-cloud-facetheory-3.2.1-dev-b406e2578be8.tgz: OK`

## Safety / scope confirmation

- No npm release / publish / GitHub Release / release-asset workflow / tag / version bump / staging-or-main promotion.
- No AWS / cloud / IAM / DNS / cert / account / deploy / smoke / canary.
- No AWS dependency repackaging; the documented AWS CDK bundled `brace-expansion` exception boundary is intact.
- No secrets, credentials, live receipts, raw package bodies, customer data, or production-like confidential fixtures.
- No sibling repo edits, parent Factory repo edits, or framework changes.
- No git worktrees; normal checkout only.
- No PR to staging.
- Did NOT infer follow-on FaceTheory milestones.

## Residual risks / blockers

- None. `make rubric` exits 0; the FaceTheory package surface is clean; the AWS CDK bundled transitive remains under the documented narrow allowlist with the documented exit criterion.

## Files

Shared types:
- `ts/src/stitch-admin/selectable-card-grid-types.ts` (new)
- `ts/src/stitch-admin/index.ts` (re-export new types)

React adapter:
- `ts/src/react/stitch-admin/selectable-card-grid.ts` (new — `SelectableCardGridPanel`, `ChoiceCard`)
- `ts/src/react/stitch-admin/index.ts` (re-exports)

Vue adapter:
- `ts/src/vue/stitch-admin/selectable-card-grid.ts` (new)
- `ts/src/vue/stitch-admin/index.ts` (re-exports)

Svelte adapter:
- `ts/src/svelte/stitch-admin/SelectableCardGridPanel.svelte` (new)
- `ts/src/svelte/stitch-admin/ChoiceCard.svelte` (new)
- `ts/src/svelte/stitch-admin/index.ts` (re-exports)
- `ts/src/svelte/stitch-admin/index.d.ts` (Component declarations + prop interfaces)
- `ts/src/svelte/stitch-admin/types.ts` (shared type re-exports + panel-props)

Tests:
- `ts/test/unit/stitch-admin-selectable-card-grid.test.ts` (new, 9 React tests)
- `ts/test/unit/vue-stitch-admin.test.ts` (+5 Vue parity tests)
- `ts/test/unit/svelte-stitch-admin.test.ts` (+3 Svelte parity tests)
- `ts/test/run-unit.ts` (register the new React test file)

Docs:
- `docs/wizard-primitives.md` (primitives table + new SelectableCardGrid section)

Refs: THE-1454 (APW-FT5).