### PR TITLE
feat(stitch-admin): add PackageSourceInput + CodeDropzone with React+Vue+Svelte parity

### DIFF
--- a/docs/wizard-primitives.md
+++ b/docs/wizard-primitives.md
@@ -36,7 +36,7 @@ primitive twice and asserting byte-identical SSR output.
 | Layer | Module | What it exports |
 | --- | --- | --- |
 | Framework-neutral types | `@theory-cloud/facetheory/stitch-admin` | `WizardProgressState`, `WizardPackageSummary`, `WizardFindingList`, `WizardReconcileSummary`, `WizardReconciliationPlan`, `WizardAuthorityContextStrip`, `WizardCapabilityReview`, `WizardEnablementChecklist`, `WizardRecoveryStatus`, `WizardEmptyStateConfig`, `WizardEditableTokenInput`, `WizardSafetyPolicy`, and supporting enums and aliases. |
-| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`), `SelectableCardGridPanel`, `ChoiceCard`, `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
+| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`), `SelectableCardGridPanel`, `ChoiceCard`, `PackageSourceInputPanel`, `CodeDropzone`, `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
 | Vue adapter | `@theory-cloud/facetheory/vue/stitch-admin` | Same primitive set as React, including `SelectableCardGridPanel` and `ChoiceCard`. |
 | Svelte adapter | `@theory-cloud/facetheory/svelte/stitch-admin` | Same primitive set, exposed as `.svelte` components with matching component-prop interfaces. |
 
@@ -440,6 +440,85 @@ The host owns acceptance — passing back a different list is fine.
     safetyPolicy: 'no-secret-or-production-like-data',
   }}
   onChange={(next) => host.setAllowedAction(next[0])}
+/>
+```
+
+## Package source input / code dropzone
+
+`PackageSourceInputPanel` (with the lower-level `CodeDropzone` primitive) is
+the "where does the package come from" surface the TheoryMCP Agent Import &
+Completion Wizard uses. It supports any subset of three input modes —
+**paste** (textarea), **dropzone** (drag/drop affordance), and **upload**
+(file picker) — combined with a presentational state machine and a per-error
+display contract.
+
+### Trust boundary
+
+- Presentation-only. FaceTheory does **not** parse package bodies, validate
+  syntax, scan for secrets, check entitlements, or check GitHub / email
+  policy.
+- theory-mcp-server remains authoritative server-side before preview / apply.
+- Hosts may pass convenience parse/validation status; the primitive displays
+  it via `input.state` and `input.errors[]`.
+- For `kind: 'redacted'` errors the primitive **never renders** the host's
+  `evidence` field — only the human-readable `message`. The other error
+  kinds (`invalid-syntax`, `forbidden`, `unsafe`, `other`) render `evidence`
+  verbatim, on the explicit assumption that the host pre-redacted it.
+- The primitive never holds a real `File` object across renders.
+  `input.fileMeta` (and `dropzone.fileMeta`) is a caller-supplied SSR-safe
+  description (`name`, `sizeBytes?`, `mediaType?`, `sha256?`).
+
+### State machine
+
+`input.state` is authoritative and caller-supplied:
+
+| State        | Role marker     | Meaning                                          |
+| ------------ | --------------- | ------------------------------------------------ |
+| `idle`       | (none)          | Awaiting source.                                 |
+| `loading`    | `role="status"` | Source is being loaded (e.g. fetch in progress). |
+| `validating` | `role="status"` | Source is being validated server-side.           |
+| `ready`      | `role="status"` | Ready for server preview.                        |
+| `invalid`    | `role="alert"`  | Source failed validation.                        |
+| `forbidden`  | `role="alert"`  | Policy blocks this source.                       |
+| `redacted`   | `role="alert"`  | Source contains redacted content.                |
+
+### Accessibility
+
+- Real `<textarea>` for paste, real `<input type="file">` for upload, real
+  `<button type="button">` for Clear / Replace / Copy.
+- The dropzone is a `role="group"` `<div>` with a text `aria-label` based on
+  the current state and `aria-describedby` wired to the help text and any
+  errors. `tabindex="0"` keeps it keyboard-focusable.
+- Each error renders as a `<li>` with `role="alert"` and
+  `aria-live="polite"`.
+- The state announcement renders as a `<p>` with `role="status"` /
+  `role="alert"` per the table above.
+- `aria-invalid="true"` on the paste textarea whenever the state is an
+  alert state.
+
+### Example
+
+```tsx
+<PackageSourceInputPanel
+  input={{
+    groupId: 'pkg-src',
+    value: host.pasteValue,
+    state: 'validating',
+    errors: host.errors,
+    modes: ['paste', 'dropzone', 'upload'],
+    label: 'Package source',
+    description: 'TheoryMCP parses and validates server-side before preview.',
+    placeholder: 'Paste your agent manifest…',
+    fileAccept: '.yaml,.yml,.json',
+    fileMeta: host.attachedFile,
+    actions: { clear: true, replace: true, copy: true, copyValue: host.pasteValue },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  }}
+  onValueChange={(next) => host.setPasteValue(next)}
+  onFiles={(files) => host.handleFiles(files)}
+  onClear={() => host.clear()}
+  onReplace={() => host.openReplaceDialog()}
+  onCopy={(value) => host.copyToClipboard(value)}
 />
 ```
 

--- a/docs/wizard-primitives.md
+++ b/docs/wizard-primitives.md
@@ -460,10 +460,12 @@ display contract.
 - theory-mcp-server remains authoritative server-side before preview / apply.
 - Hosts may pass convenience parse/validation status; the primitive displays
   it via `input.state` and `input.errors[]`.
-- For `kind: 'redacted'` errors the primitive **never renders** the host's
-  `evidence` field — only the human-readable `message`. The other error
-  kinds (`invalid-syntax`, `forbidden`, `unsafe`, `other`) render `evidence`
-  verbatim, on the explicit assumption that the host pre-redacted it.
+- The primitive enforces a strict evidence-suppression rule: **only
+  `invalid-syntax` errors render `evidence`**. Every other kind
+  (`forbidden`, `redacted`, `unsafe`, `other`) renders only the
+  human-readable `message` and suppresses caller-supplied `evidence`. This
+  protects against hosts accidentally passing secret-like content in
+  `evidence` for any of the sensitive error kinds.
 - The primitive never holds a real `File` object across renders.
   `input.fileMeta` (and `dropzone.fileMeta`) is a caller-supplied SSR-safe
   description (`name`, `sizeBytes?`, `mediaType?`, `sha256?`).

--- a/ts/src/react/stitch-admin/index.ts
+++ b/ts/src/react/stitch-admin/index.ts
@@ -165,6 +165,21 @@ export {
 } from './wizard-authority-context-strip.js';
 
 export {
+  PackageSourceInputPanel,
+  CodeDropzone,
+  type PackageSourceInputPanelProps,
+  type CodeDropzonePanelProps,
+  type CodeDropzoneProps,
+  type PackageSourceInput,
+  type PackageSourceInputActions,
+  type PackageSourceInputError,
+  type PackageSourceInputErrorKind,
+  type PackageSourceInputFileMeta,
+  type PackageSourceInputMode,
+  type PackageSourceInputState,
+} from './package-source-input.js';
+
+export {
   SelectableCardGridPanel,
   ChoiceCard,
   type SelectableCardGridPanelProps,

--- a/ts/src/react/stitch-admin/package-source-input.ts
+++ b/ts/src/react/stitch-admin/package-source-input.ts
@@ -1,0 +1,659 @@
+import * as React from 'react';
+
+import type {
+  CodeDropzoneProps,
+  PackageSourceInput,
+  PackageSourceInputActions,
+  PackageSourceInputError,
+  PackageSourceInputErrorKind,
+  PackageSourceInputFileMeta,
+  PackageSourceInputMode,
+  PackageSourceInputState,
+} from '../../stitch-admin/package-source-input-types.js';
+import type { WizardSafetyPolicy } from '../../stitch-admin/wizard-types.js';
+
+const h = React.createElement;
+
+export type {
+  CodeDropzoneProps,
+  PackageSourceInput,
+  PackageSourceInputActions,
+  PackageSourceInputError,
+  PackageSourceInputErrorKind,
+  PackageSourceInputFileMeta,
+  PackageSourceInputMode,
+  PackageSourceInputState,
+};
+
+const STATE_LABEL_DEFAULTS: Record<PackageSourceInputState, string> = {
+  idle: 'Awaiting source',
+  loading: 'Loading source',
+  validating: 'Validating source',
+  ready: 'Ready for server preview',
+  invalid: 'Invalid source',
+  forbidden: 'Source not allowed',
+  redacted: 'Source contains redacted content',
+};
+
+const ERROR_KIND_LABEL: Record<PackageSourceInputErrorKind, string> = {
+  'invalid-syntax': 'Invalid syntax',
+  forbidden: 'Forbidden',
+  redacted: 'Redacted',
+  unsafe: 'Unsafe',
+  other: 'Error',
+};
+
+const ALERT_STATES: ReadonlySet<PackageSourceInputState> = new Set([
+  'invalid',
+  'forbidden',
+  'redacted',
+]);
+
+const STATUS_STATES: ReadonlySet<PackageSourceInputState> = new Set([
+  'loading',
+  'validating',
+  'ready',
+]);
+
+function isAlertState(state: PackageSourceInputState): boolean {
+  return ALERT_STATES.has(state);
+}
+
+function isStatusState(state: PackageSourceInputState): boolean {
+  return STATUS_STATES.has(state);
+}
+
+function stateLabel(
+  state: PackageSourceInputState,
+  overrides?: PackageSourceInput['stateLabels'],
+): string {
+  if (overrides !== undefined && overrides[state] !== undefined) {
+    return overrides[state] as string;
+  }
+  return STATE_LABEL_DEFAULTS[state];
+}
+
+function renderSafetyFootnote(policy: WizardSafetyPolicy): React.ReactElement {
+  return h(
+    'p',
+    {
+      className: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+      style: {
+        margin: 0,
+        fontSize: '11px',
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+      },
+    },
+    `Safety policy: ${policy}`,
+  );
+}
+
+function renderErrors(
+  errors: PackageSourceInputError[],
+  groupId: string,
+): React.ReactElement | null {
+  if (errors.length === 0) return null;
+  return h(
+    'ul',
+    {
+      key: 'errors',
+      className: 'facetheory-stitch-package-source-input-errors',
+      role: 'list',
+      'data-error-count': String(errors.length),
+      style: { margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: '6px' },
+    },
+    errors.map((error) =>
+      h(
+        'li',
+        {
+          key: error.id,
+          id: `${groupId}-error-${error.id}`,
+          className: `facetheory-stitch-package-source-input-error facetheory-stitch-package-source-input-error-${error.kind}`,
+          'data-error-kind': error.kind,
+          'data-error-id': error.id,
+          role: 'alert',
+          'aria-live': 'polite',
+          style: {
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '2px',
+            padding: '8px 10px',
+            borderRadius: 'var(--stitch-radius-sm, 8px)',
+            background:
+              error.kind === 'forbidden' || error.kind === 'redacted' || error.kind === 'unsafe'
+                ? 'var(--stitch-color-error-container, #ffdad6)'
+                : 'var(--stitch-color-secondary-container, #ffecc0)',
+            color:
+              error.kind === 'forbidden' || error.kind === 'redacted' || error.kind === 'unsafe'
+                ? 'var(--stitch-color-on-error-container, #93000a)'
+                : 'var(--stitch-color-on-secondary-container, #3f2e00)',
+            fontSize: '12px',
+            lineHeight: 1.5,
+          },
+        },
+        h(
+          'strong',
+          {
+            className: 'facetheory-stitch-package-source-input-error-kind',
+            'data-error-kind-label': error.kind,
+          },
+          ERROR_KIND_LABEL[error.kind],
+        ),
+        h('span', { className: 'facetheory-stitch-package-source-input-error-message' }, error.message as React.ReactNode),
+        error.evidence !== undefined && error.kind !== 'redacted'
+          ? h(
+              'code',
+              {
+                className: 'facetheory-stitch-package-source-input-error-evidence',
+                style: { fontSize: '11px', overflowWrap: 'anywhere' },
+              },
+              error.evidence,
+            )
+          : null,
+      ),
+    ),
+  );
+}
+
+function renderFileMeta(
+  fileMeta: PackageSourceInputFileMeta,
+): React.ReactElement {
+  return h(
+    'dl',
+    {
+      key: 'file-meta',
+      className: 'facetheory-stitch-package-source-input-file-meta',
+      'data-file-name': fileMeta.name,
+      style: { margin: 0, display: 'flex', flexWrap: 'wrap', gap: '6px 12px', fontSize: '12px' },
+    },
+    h('div', { key: 'name' }, [h('dt', null, 'File'), h('dd', null, fileMeta.name)]),
+    fileMeta.sizeBytes !== undefined
+      ? h('div', { key: 'size' }, [h('dt', null, 'Size'), h('dd', null, `${fileMeta.sizeBytes} B`)])
+      : null,
+    fileMeta.mediaType !== undefined
+      ? h('div', { key: 'media' }, [h('dt', null, 'Media type'), h('dd', null, fileMeta.mediaType)])
+      : null,
+    fileMeta.sha256 !== undefined
+      ? h(
+          'div',
+          { key: 'sha' },
+          [
+            h('dt', null, 'sha256'),
+            h(
+              'dd',
+              null,
+              h('code', { style: { fontSize: '11px', overflowWrap: 'anywhere' } }, fileMeta.sha256),
+            ),
+          ],
+        )
+      : null,
+  );
+}
+
+function renderActions(
+  actions: PackageSourceInputActions | undefined,
+  onClear: (() => void) | undefined,
+  onReplace: (() => void) | undefined,
+  onCopy: ((copyValue: string) => void) | undefined,
+): React.ReactElement | null {
+  if (actions === undefined) return null;
+  const buttons: React.ReactElement[] = [];
+  if (actions.clear === true) {
+    buttons.push(
+      h(
+        'button',
+        {
+          key: 'clear',
+          type: 'button',
+          className: 'facetheory-stitch-package-source-input-action facetheory-stitch-package-source-input-action-clear',
+          'data-action': 'clear',
+          'aria-label': 'Clear package source',
+          onClick: onClear,
+        },
+        'Clear',
+      ),
+    );
+  }
+  if (actions.replace === true) {
+    buttons.push(
+      h(
+        'button',
+        {
+          key: 'replace',
+          type: 'button',
+          className: 'facetheory-stitch-package-source-input-action facetheory-stitch-package-source-input-action-replace',
+          'data-action': 'replace',
+          'aria-label': 'Replace package source',
+          onClick: onReplace,
+        },
+        'Replace',
+      ),
+    );
+  }
+  if (actions.copy === true && actions.copyValue !== undefined) {
+    const copyValue = actions.copyValue;
+    buttons.push(
+      h(
+        'button',
+        {
+          key: 'copy',
+          type: 'button',
+          className: 'facetheory-stitch-package-source-input-action facetheory-stitch-package-source-input-action-copy',
+          'data-action': 'copy',
+          'data-copy-value': copyValue,
+          'aria-label': 'Copy package source',
+          onClick: onCopy !== undefined ? () => onCopy(copyValue) : undefined,
+        },
+        'Copy',
+      ),
+    );
+  }
+  if (buttons.length === 0) return null;
+  return h(
+    'div',
+    {
+      key: 'actions',
+      className: 'facetheory-stitch-package-source-input-actions',
+      style: { display: 'flex', gap: '6px', flexWrap: 'wrap' },
+    },
+    buttons,
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* PackageSourceInputPanel                                                    */
+/* -------------------------------------------------------------------------- */
+
+export interface PackageSourceInputPanelProps {
+  input: PackageSourceInput;
+  /** Required when 'paste' mode is exposed. */
+  onValueChange?: (next: string) => void;
+  /**
+   * Called when the host should accept new file metadata (drag/drop or
+   * file-picker). The primitive never reads the File body; the host parses
+   * the file outside and pushes back state.
+   */
+  onFiles?: (files: PackageSourceInputFileMeta[]) => void;
+  onClear?: () => void;
+  onReplace?: () => void;
+  /** Copy the host-supplied actions.copyValue payload. */
+  onCopy?: (copyValue: string) => void;
+}
+
+export function PackageSourceInputPanel(
+  props: PackageSourceInputPanelProps,
+): React.ReactElement {
+  const { input, onValueChange, onFiles, onClear, onReplace, onCopy } = props;
+  const labelId = input.label !== undefined ? `${input.groupId}-label` : undefined;
+  const descriptionId =
+    input.description !== undefined ? `${input.groupId}-description` : undefined;
+  const stateAnnouncementId = `${input.groupId}-state`;
+  const errorIds = input.errors.map((e) => `${input.groupId}-error-${e.id}`);
+  const ariaDescribedBy =
+    [descriptionId, stateAnnouncementId, ...errorIds]
+      .filter((id): id is string => typeof id === 'string')
+      .join(' ') || undefined;
+  const allowPaste = input.modes.includes('paste');
+  const allowUpload = input.modes.includes('upload');
+  const allowDropzone = input.modes.includes('dropzone');
+  const announceLabel = stateLabel(input.state, input.stateLabels);
+  const stateRole = isAlertState(input.state)
+    ? 'alert'
+    : isStatusState(input.state)
+      ? 'status'
+      : undefined;
+
+  return h(
+    'section',
+    {
+      className: `facetheory-stitch-package-source-input facetheory-stitch-package-source-input-state-${input.state}`,
+      'data-safety-policy': input.safetyPolicy,
+      'data-group-id': input.groupId,
+      'data-state': input.state,
+      'data-modes': input.modes.join(' '),
+      'data-error-count': String(input.errors.length),
+      'data-has-file': input.fileMeta !== undefined ? 'true' : 'false',
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+        padding: '12px',
+        borderRadius: 'var(--stitch-radius-lg, 12px)',
+        background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+      },
+    },
+    input.label !== undefined || input.description !== undefined
+      ? h(
+          'header',
+          { key: 'header', style: { display: 'flex', flexDirection: 'column', gap: '4px' } },
+          input.label !== undefined
+            ? h(
+                'label',
+                {
+                  id: labelId,
+                  htmlFor: allowPaste ? `${input.groupId}-paste` : undefined,
+                  style: { fontSize: '13px', fontWeight: 600 },
+                },
+                input.label as React.ReactNode,
+              )
+            : null,
+          input.description !== undefined
+            ? h(
+                'p',
+                {
+                  id: descriptionId,
+                  style: {
+                    margin: 0,
+                    fontSize: '12px',
+                    lineHeight: 1.5,
+                    color: 'var(--stitch-color-on-surface-variant, #464553)',
+                  },
+                },
+                input.description as React.ReactNode,
+              )
+            : null,
+        )
+      : null,
+    allowPaste
+      ? h(
+          'textarea',
+          {
+            key: 'paste',
+            id: `${input.groupId}-paste`,
+            className: 'facetheory-stitch-package-source-input-paste',
+            'data-mode': 'paste',
+            value: input.value,
+            placeholder: input.placeholder,
+            'aria-labelledby': labelId,
+            'aria-describedby': ariaDescribedBy,
+            'aria-invalid': isAlertState(input.state) ? 'true' : 'false',
+            onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+              if (onValueChange !== undefined) onValueChange(event.target.value);
+            },
+            style: {
+              width: '100%',
+              minHeight: '120px',
+              padding: '10px',
+              fontFamily: 'var(--stitch-font-label, ui-monospace, SFMono-Regular, Menlo, monospace)',
+              fontSize: '13px',
+              border: '1px solid var(--stitch-color-outline-variant, #c6c5d0)',
+              borderRadius: 'var(--stitch-radius-sm, 8px)',
+              background: 'var(--stitch-color-surface-container, #eaedff)',
+              color: 'inherit',
+              resize: 'vertical',
+            },
+          },
+        )
+      : null,
+    allowDropzone
+      ? renderDropzoneInner(input, onFiles, ariaDescribedBy)
+      : null,
+    allowUpload
+      ? h(
+          'div',
+          {
+            key: 'upload',
+            className: 'facetheory-stitch-package-source-input-upload',
+            'data-mode': 'upload',
+            style: { display: 'flex', alignItems: 'center', gap: '8px' },
+          },
+          h(
+            'label',
+            {
+              htmlFor: `${input.groupId}-file`,
+              style: { fontSize: '12px', color: 'var(--stitch-color-on-surface-variant, #464553)' },
+            },
+            'Choose a file:',
+          ),
+          h('input', {
+            id: `${input.groupId}-file`,
+            type: 'file',
+            className: 'facetheory-stitch-package-source-input-file',
+            'aria-describedby': ariaDescribedBy,
+            accept: input.fileAccept,
+            onChange:
+              onFiles !== undefined
+                ? (event: React.ChangeEvent<HTMLInputElement>) => {
+                    const files = event.target.files;
+                    if (files === null) return;
+                    const meta: PackageSourceInputFileMeta[] = [];
+                    for (let i = 0; i < files.length; i += 1) {
+                      const file = files.item(i);
+                      if (file === null) continue;
+                      const entry: PackageSourceInputFileMeta = {
+                        name: file.name,
+                        sizeBytes: file.size,
+                      };
+                      if (file.type) entry.mediaType = file.type;
+                      meta.push(entry);
+                    }
+                    onFiles(meta);
+                  }
+                : undefined,
+          }),
+        )
+      : null,
+    input.fileMeta !== undefined ? renderFileMeta(input.fileMeta) : null,
+    h(
+      'p',
+      {
+        key: 'state',
+        id: stateAnnouncementId,
+        className: `facetheory-stitch-package-source-input-state facetheory-stitch-package-source-input-state-label-${input.state}`,
+        'data-state-label': input.state,
+        role: stateRole,
+        'aria-live': stateRole === 'status' ? 'polite' : undefined,
+        style: {
+          margin: 0,
+          fontSize: '12px',
+          fontWeight: 600,
+          color: isAlertState(input.state)
+            ? 'var(--stitch-color-on-error-container, #93000a)'
+            : 'var(--stitch-color-on-surface-variant, #464553)',
+        },
+      },
+      announceLabel,
+    ),
+    renderErrors(input.errors, input.groupId),
+    renderActions(input.actions, onClear, onReplace, onCopy),
+    renderSafetyFootnote(input.safetyPolicy),
+  );
+}
+
+function renderDropzoneInner(
+  input: PackageSourceInput,
+  onFiles: PackageSourceInputPanelProps['onFiles'],
+  ariaDescribedBy: string | undefined,
+): React.ReactElement {
+  const announceLabel = stateLabel(input.state, input.stateLabels);
+  return h(
+    'div',
+    {
+      key: 'dropzone',
+      role: 'group',
+      className: `facetheory-stitch-package-source-input-dropzone facetheory-stitch-package-source-input-dropzone-state-${input.state}`,
+      'data-mode': 'dropzone',
+      'data-dropzone-state': input.state,
+      'aria-label': announceLabel,
+      'aria-describedby': ariaDescribedBy,
+      'aria-disabled': input.state === 'loading' ? 'true' : undefined,
+      tabIndex: 0,
+      onDragOver: (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+      },
+      onDrop: (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        if (onFiles === undefined) return;
+        const files = event.dataTransfer?.files;
+        if (files === undefined || files === null) return;
+        const meta: PackageSourceInputFileMeta[] = [];
+        for (let i = 0; i < files.length; i += 1) {
+          const file = files.item(i);
+          if (file === null) continue;
+          const entry: PackageSourceInputFileMeta = {
+            name: file.name,
+            sizeBytes: file.size,
+          };
+          if (file.type) entry.mediaType = file.type;
+          meta.push(entry);
+        }
+        onFiles(meta);
+      },
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '6px',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '20px',
+        border: '2px dashed var(--stitch-color-outline-variant, #c6c5d0)',
+        borderRadius: 'var(--stitch-radius-md, 10px)',
+        background: 'var(--stitch-color-surface-container, #eaedff)',
+        textAlign: 'center',
+      },
+    },
+    h('strong', { style: { fontSize: '13px' } }, 'Drop files here or use the picker'),
+    h(
+      'span',
+      { style: { fontSize: '11px', color: 'var(--stitch-color-on-surface-variant, #464553)' } },
+      'Files are parsed by TheoryMCP, not by FaceTheory.',
+    ),
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Standalone CodeDropzone                                                    */
+/* -------------------------------------------------------------------------- */
+
+export interface CodeDropzonePanelProps {
+  dropzone: CodeDropzoneProps;
+  onFiles?: (files: PackageSourceInputFileMeta[]) => void;
+}
+
+export function CodeDropzone(props: CodeDropzonePanelProps): React.ReactElement {
+  const { dropzone, onFiles } = props;
+  const labelId = dropzone.label !== undefined ? `${dropzone.dropzoneId}-label` : undefined;
+  const descriptionId =
+    dropzone.description !== undefined ? `${dropzone.dropzoneId}-description` : undefined;
+  const errorIds = (dropzone.errors ?? []).map((e) => `${dropzone.dropzoneId}-error-${e.id}`);
+  const ariaDescribedBy =
+    [descriptionId, ...errorIds]
+      .filter((id): id is string => typeof id === 'string')
+      .join(' ') || undefined;
+  const announceLabel = stateLabel(dropzone.state, dropzone.stateLabels);
+  const stateRole = isAlertState(dropzone.state)
+    ? 'alert'
+    : isStatusState(dropzone.state)
+      ? 'status'
+      : undefined;
+
+  return h(
+    'section',
+    {
+      id: dropzone.dropzoneId,
+      className: `facetheory-stitch-code-dropzone facetheory-stitch-code-dropzone-state-${dropzone.state}`,
+      'data-safety-policy': dropzone.safetyPolicy,
+      'data-dropzone-id': dropzone.dropzoneId,
+      'data-state': dropzone.state,
+      'data-has-file': dropzone.fileMeta !== undefined ? 'true' : 'false',
+      role: stateRole,
+      'aria-labelledby': labelId,
+      'aria-describedby': ariaDescribedBy,
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        padding: '12px',
+        borderRadius: 'var(--stitch-radius-lg, 12px)',
+        background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+      },
+    },
+    dropzone.label !== undefined
+      ? h(
+          'div',
+          { id: labelId, style: { fontSize: '13px', fontWeight: 600 } },
+          dropzone.label as React.ReactNode,
+        )
+      : null,
+    dropzone.description !== undefined
+      ? h(
+          'p',
+          { id: descriptionId, style: { margin: 0, fontSize: '12px', lineHeight: 1.5, color: 'var(--stitch-color-on-surface-variant, #464553)' } },
+          dropzone.description as React.ReactNode,
+        )
+      : null,
+    h(
+      'div',
+      {
+        role: 'group',
+        className: `facetheory-stitch-code-dropzone-target facetheory-stitch-code-dropzone-target-state-${dropzone.state}`,
+        'data-dropzone-state': dropzone.state,
+        'aria-label': announceLabel,
+        tabIndex: 0,
+        onDragOver: (event: React.DragEvent<HTMLDivElement>) => {
+          event.preventDefault();
+        },
+        onDrop: (event: React.DragEvent<HTMLDivElement>) => {
+          event.preventDefault();
+          if (onFiles === undefined) return;
+          const files = event.dataTransfer?.files;
+          if (files === undefined || files === null) return;
+          const meta: PackageSourceInputFileMeta[] = [];
+          for (let i = 0; i < files.length; i += 1) {
+            const file = files.item(i);
+            if (file === null) continue;
+            const entry: PackageSourceInputFileMeta = {
+              name: file.name,
+              sizeBytes: file.size,
+            };
+            if (file.type) entry.mediaType = file.type;
+            meta.push(entry);
+          }
+          onFiles(meta);
+        },
+        style: {
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '6px',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '20px',
+          border: '2px dashed var(--stitch-color-outline-variant, #c6c5d0)',
+          borderRadius: 'var(--stitch-radius-md, 10px)',
+          background: 'var(--stitch-color-surface-container, #eaedff)',
+          textAlign: 'center',
+        },
+      },
+      h(
+        'strong',
+        { style: { fontSize: '13px' } },
+        dropzone.emptyLabel ?? 'Drop files here',
+      ),
+      h(
+        'span',
+        { style: { fontSize: '11px', color: 'var(--stitch-color-on-surface-variant, #464553)' } },
+        'Files are parsed by TheoryMCP, not by FaceTheory.',
+      ),
+    ),
+    dropzone.fileMeta !== undefined ? renderFileMeta(dropzone.fileMeta) : null,
+    h(
+      'p',
+      {
+        className: `facetheory-stitch-code-dropzone-state-label facetheory-stitch-code-dropzone-state-label-${dropzone.state}`,
+        'data-state-label': dropzone.state,
+        role: stateRole,
+        'aria-live': stateRole === 'status' ? 'polite' : undefined,
+        style: { margin: 0, fontSize: '12px', fontWeight: 600 },
+      },
+      announceLabel,
+    ),
+    (dropzone.errors ?? []).length > 0
+      ? renderErrors(dropzone.errors ?? [], dropzone.dropzoneId)
+      : null,
+    renderSafetyFootnote(dropzone.safetyPolicy),
+  );
+}

--- a/ts/src/react/stitch-admin/package-source-input.ts
+++ b/ts/src/react/stitch-admin/package-source-input.ts
@@ -143,7 +143,7 @@ function renderErrors(
           ERROR_KIND_LABEL[error.kind],
         ),
         h('span', { className: 'facetheory-stitch-package-source-input-error-message' }, error.message as React.ReactNode),
-        error.evidence !== undefined && error.kind !== 'redacted'
+        error.evidence !== undefined && error.kind === 'invalid-syntax'
           ? h(
               'code',
               {

--- a/ts/src/react/stitch-admin/package-source-input.ts
+++ b/ts/src/react/stitch-admin/package-source-input.ts
@@ -169,25 +169,42 @@ function renderFileMeta(
       'data-file-name': fileMeta.name,
       style: { margin: 0, display: 'flex', flexWrap: 'wrap', gap: '6px 12px', fontSize: '12px' },
     },
-    h('div', { key: 'name' }, [h('dt', null, 'File'), h('dd', null, fileMeta.name)]),
+    h(
+      'div',
+      { key: 'name' },
+      h('dt', { key: 'dt' }, 'File'),
+      h('dd', { key: 'dd' }, fileMeta.name),
+    ),
     fileMeta.sizeBytes !== undefined
-      ? h('div', { key: 'size' }, [h('dt', null, 'Size'), h('dd', null, `${fileMeta.sizeBytes} B`)])
+      ? h(
+          'div',
+          { key: 'size' },
+          h('dt', { key: 'dt' }, 'Size'),
+          h('dd', { key: 'dd' }, `${fileMeta.sizeBytes} B`),
+        )
       : null,
     fileMeta.mediaType !== undefined
-      ? h('div', { key: 'media' }, [h('dt', null, 'Media type'), h('dd', null, fileMeta.mediaType)])
+      ? h(
+          'div',
+          { key: 'media' },
+          h('dt', { key: 'dt' }, 'Media type'),
+          h('dd', { key: 'dd' }, fileMeta.mediaType),
+        )
       : null,
     fileMeta.sha256 !== undefined
       ? h(
           'div',
           { key: 'sha' },
-          [
-            h('dt', null, 'sha256'),
+          h('dt', { key: 'dt' }, 'sha256'),
+          h(
+            'dd',
+            { key: 'dd' },
             h(
-              'dd',
-              null,
-              h('code', { style: { fontSize: '11px', overflowWrap: 'anywhere' } }, fileMeta.sha256),
+              'code',
+              { style: { fontSize: '11px', overflowWrap: 'anywhere' } },
+              fileMeta.sha256,
             ),
-          ],
+          ),
         )
       : null,
   );

--- a/ts/src/stitch-admin/index.ts
+++ b/ts/src/stitch-admin/index.ts
@@ -57,6 +57,17 @@ export type {
 } from './wizard-authority-context-strip-types.js';
 
 export type {
+  CodeDropzoneProps,
+  PackageSourceInput,
+  PackageSourceInputActions,
+  PackageSourceInputError,
+  PackageSourceInputErrorKind,
+  PackageSourceInputFileMeta,
+  PackageSourceInputMode,
+  PackageSourceInputState,
+} from './package-source-input-types.js';
+
+export type {
   ChoiceCardProps,
   SelectableCardGrid,
   SelectableCardGridLayout,

--- a/ts/src/stitch-admin/package-source-input-types.ts
+++ b/ts/src/stitch-admin/package-source-input-types.ts
@@ -49,10 +49,18 @@ export type PackageSourceInputErrorKind =
   | 'other';
 
 /**
- * A single error to render. Hosts pre-redact `evidence` if it points at
- * sensitive content — the primitive does NOT try to clean evidence and
- * does NOT redact secrets by inspection. For `redacted` errors hosts
- * typically pass `evidence: undefined` and rely on the `message` text.
+ * A single error to render.
+ *
+ * The primitive enforces a strict evidence-suppression rule: **only
+ * `invalid-syntax` errors render `evidence`**. For every other kind
+ * (`forbidden`, `redacted`, `unsafe`, `other`) the primitive ignores
+ * `evidence` and renders only the `message`. This protects against hosts
+ * accidentally passing secret-like content in `evidence` for any of the
+ * sensitive kinds.
+ *
+ * Hosts should treat `evidence` as a safe place to surface parse-location
+ * info (line / column / offset) for `invalid-syntax`. For every other
+ * kind, pre-redact aggressively or pass `evidence: undefined`.
  */
 export interface PackageSourceInputError {
   /** Stable identifier used for keying. */
@@ -61,8 +69,10 @@ export interface PackageSourceInputError {
   /** Short human-readable message. Adapters narrow to their native node type. */
   message: unknown;
   /**
-   * Optional pre-redacted evidence (e.g. a line/column reference or a
-   * caller-friendly token). The primitive renders verbatim.
+   * Optional caller-supplied evidence. Rendered verbatim **only** when
+   * `kind === 'invalid-syntax'`; suppressed for every other kind. Hosts
+   * must still treat this as a presentation field — FaceTheory does NOT
+   * try to clean evidence or redact secrets by inspection.
    */
   evidence?: string;
 }

--- a/ts/src/stitch-admin/package-source-input-types.ts
+++ b/ts/src/stitch-admin/package-source-input-types.ts
@@ -13,9 +13,15 @@
  *   - theory-mcp-server (the host) remains authoritative server-side
  *     before preview/apply.
  *   - Hosts may pass convenience parse/validation status; the primitive
- *     displays it. Hosts must pre-redact any error evidence — the
- *     primitive renders `evidence` verbatim and never asks for or displays
- *     raw secret values.
+ *     displays it.
+ *   - Error evidence policy: the primitive enforces an allow-list rule —
+ *     **only `kind: 'invalid-syntax'` renders `error.evidence`** (safe
+ *     parse-location details such as line / column / offset). Every other
+ *     kind (`forbidden`, `redacted`, `unsafe`, `other`) suppresses
+ *     caller-supplied `evidence` and renders only the human-readable
+ *     `message`. FaceTheory still does NOT parse, validate, scan,
+ *     classify, authorize, or clean secrets by inspection — the rule is
+ *     a presentation safety net, not a redaction service.
  *   - `state`, `errors`, and `fileMeta` are all caller-supplied. The
  *     primitive routes events back to the host via callbacks and never
  *     toggles its own state.

--- a/ts/src/stitch-admin/package-source-input-types.ts
+++ b/ts/src/stitch-admin/package-source-input-types.ts
@@ -1,0 +1,177 @@
+/**
+ * Framework-neutral types for the FaceTheory `PackageSourceInput` and
+ * lower-level `CodeDropzone` primitives. The TheoryMCP Agent Import &
+ * Completion Wizard uses these on the "where does the package come from"
+ * step (paste, file upload, or drag/drop). Hosts may enable any subset of
+ * modes.
+ *
+ * Trust boundary (load-bearing):
+ *
+ *   - Presentation-only. FaceTheory does NOT parse package bodies,
+ *     validate syntax, scan for secrets, check entitlements, check GitHub
+ *     or email policy, or authorize packages.
+ *   - theory-mcp-server (the host) remains authoritative server-side
+ *     before preview/apply.
+ *   - Hosts may pass convenience parse/validation status; the primitive
+ *     displays it. Hosts must pre-redact any error evidence — the
+ *     primitive renders `evidence` verbatim and never asks for or displays
+ *     raw secret values.
+ *   - `state`, `errors`, and `fileMeta` are all caller-supplied. The
+ *     primitive routes events back to the host via callbacks and never
+ *     toggles its own state.
+ */
+
+import type { WizardSafetyPolicy } from './wizard-types.js';
+
+/** Which input modes the host wants exposed in the primitive's UI. */
+export type PackageSourceInputMode = 'paste' | 'upload' | 'dropzone';
+
+/**
+ * Caller-supplied state machine. The primitive renders ARIA / role markers
+ * based on the value but never computes the transition. Most-recent host
+ * value wins; the primitive treats `state` as authoritative for display.
+ */
+export type PackageSourceInputState =
+  | 'idle'
+  | 'loading'
+  | 'validating'
+  | 'ready'
+  | 'invalid'
+  | 'forbidden'
+  | 'redacted';
+
+/** Kind of error rendered below the input. */
+export type PackageSourceInputErrorKind =
+  | 'invalid-syntax'
+  | 'forbidden'
+  | 'redacted'
+  | 'unsafe'
+  | 'other';
+
+/**
+ * A single error to render. Hosts pre-redact `evidence` if it points at
+ * sensitive content — the primitive does NOT try to clean evidence and
+ * does NOT redact secrets by inspection. For `redacted` errors hosts
+ * typically pass `evidence: undefined` and rely on the `message` text.
+ */
+export interface PackageSourceInputError {
+  /** Stable identifier used for keying. */
+  id: string;
+  kind: PackageSourceInputErrorKind;
+  /** Short human-readable message. Adapters narrow to their native node type. */
+  message: unknown;
+  /**
+   * Optional pre-redacted evidence (e.g. a line/column reference or a
+   * caller-friendly token). The primitive renders verbatim.
+   */
+  evidence?: string;
+}
+
+/**
+ * SSR-safe description of an attached file. The primitive never holds a
+ * real `File` object across renders — hosts pass this caller-controlled
+ * metadata so SSR markup is deterministic.
+ */
+export interface PackageSourceInputFileMeta {
+  name: string;
+  /** Optional caller-supplied size in bytes. */
+  sizeBytes?: number;
+  /** Optional caller-supplied media type. */
+  mediaType?: string;
+  /** Optional caller-supplied content sha. */
+  sha256?: string;
+}
+
+/**
+ * Which actions the primitive should render alongside the input. The host
+ * still owns the actual behavior — the primitive only renders the buttons
+ * and emits callbacks.
+ */
+export interface PackageSourceInputActions {
+  /** Render a "Clear" button that calls `onClear`. */
+  clear?: boolean;
+  /** Render a "Replace" button that calls `onReplace`. */
+  replace?: boolean;
+  /**
+   * Render a "Copy" button that calls `onCopy`. The primitive does NOT
+   * write to the clipboard; the host wires the actual copy. The button
+   * carries `data-copy-value="<host-supplied-payload>"` only when
+   * `actions.copyValue` is provided as a string.
+   */
+  copy?: boolean;
+  /**
+   * Caller-supplied copy payload for the Copy button. The primitive does
+   * NOT extract this from `value` (which may contain secrets).
+   */
+  copyValue?: string;
+}
+
+/**
+ * The PackageSourceInput envelope. Hosts compute selection state, errors,
+ * and file metadata; the primitive only displays them.
+ */
+export interface PackageSourceInput {
+  /** Stable HTML id used to wire `<label>` / `aria-describedby`. */
+  groupId: string;
+  /**
+   * Current paste-mode value. The host owns it; the primitive renders it
+   * inside the `<textarea>` and routes change events back via
+   * `onValueChange`.
+   */
+  value: string;
+  /** Authoritative display state. */
+  state: PackageSourceInputState;
+  /** Errors to render below the input. */
+  errors: PackageSourceInputError[];
+  /** Which input modes are exposed. The order is the render order. */
+  modes: PackageSourceInputMode[];
+  /** Optional attached-file metadata (SSR-safe). */
+  fileMeta?: PackageSourceInputFileMeta;
+  /** Optional placeholder for the paste textarea. */
+  placeholder?: string;
+  /** Optional label rendered above the input. */
+  label?: unknown;
+  /** Optional descriptive copy wired via `aria-describedby`. */
+  description?: unknown;
+  /**
+   * Optional caller-supplied "validating" / "ready" announcement text.
+   * Defaults to standard strings; hosts override for localization.
+   */
+  stateLabels?: Partial<Record<PackageSourceInputState, string>>;
+  /** Action buttons to render. */
+  actions?: PackageSourceInputActions;
+  /**
+   * Optional `accept` attribute for the file picker (MIME types or
+   * extensions). Caller-supplied; the primitive does NOT compute it.
+   */
+  fileAccept?: string;
+  /** Explicit safety policy assertion rendered into the DOM. */
+  safetyPolicy: WizardSafetyPolicy;
+}
+
+/**
+ * Standalone CodeDropzone props — the dropzone surface rendered outside
+ * the larger PackageSourceInput envelope. Same trust boundary applies.
+ */
+export interface CodeDropzoneProps {
+  /** Required stable id used to wire label / aria-describedby refs. */
+  dropzoneId: string;
+  /** Display label. Adapters narrow to their native node type. */
+  label?: unknown;
+  /** Helper copy / accessible description for the drop target. */
+  description?: unknown;
+  /** Authoritative state for the dropzone affordance. */
+  state: PackageSourceInputState;
+  /** Optional caller-supplied file metadata if a file is attached. */
+  fileMeta?: PackageSourceInputFileMeta;
+  /** Optional placeholder copy for the empty state. */
+  emptyLabel?: string;
+  /** Optional accept attribute for the underlying file picker. */
+  fileAccept?: string;
+  /** Optional state-to-label overrides. */
+  stateLabels?: Partial<Record<PackageSourceInputState, string>>;
+  /** Errors to surface inside the dropzone (typically `invalid-syntax`). */
+  errors?: PackageSourceInputError[];
+  /** Explicit safety policy assertion. */
+  safetyPolicy: WizardSafetyPolicy;
+}

--- a/ts/src/svelte/stitch-admin/CodeDropzone.svelte
+++ b/ts/src/svelte/stitch-admin/CodeDropzone.svelte
@@ -149,7 +149,7 @@
             data-error-kind-label={error.kind}
           >{ERROR_KIND_LABEL[error.kind]}</strong>
           <span class="facetheory-stitch-package-source-input-error-message">{error.message}</span>
-          {#if error.evidence !== undefined && error.kind !== 'redacted'}
+          {#if error.evidence !== undefined && error.kind === 'invalid-syntax'}
             <code class="facetheory-stitch-package-source-input-error-evidence">{error.evidence}</code>
           {/if}
         </li>

--- a/ts/src/svelte/stitch-admin/CodeDropzone.svelte
+++ b/ts/src/svelte/stitch-admin/CodeDropzone.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import type {
+    CodeDropzoneProps,
+    PackageSourceInputError,
+    PackageSourceInputErrorKind,
+    PackageSourceInputFileMeta,
+    PackageSourceInputState,
+  } from './types.js';
+
+  export let dropzone: CodeDropzoneProps;
+  export let onFiles: ((files: PackageSourceInputFileMeta[]) => void) | undefined = undefined;
+
+  const STATE_LABEL_DEFAULTS: Record<PackageSourceInputState, string> = {
+    idle: 'Awaiting source',
+    loading: 'Loading source',
+    validating: 'Validating source',
+    ready: 'Ready for server preview',
+    invalid: 'Invalid source',
+    forbidden: 'Source not allowed',
+    redacted: 'Source contains redacted content',
+  };
+  const ERROR_KIND_LABEL: Record<PackageSourceInputErrorKind, string> = {
+    'invalid-syntax': 'Invalid syntax',
+    forbidden: 'Forbidden',
+    redacted: 'Redacted',
+    unsafe: 'Unsafe',
+    other: 'Error',
+  };
+
+  function isAlertState(state: PackageSourceInputState): boolean {
+    return state === 'invalid' || state === 'forbidden' || state === 'redacted';
+  }
+  function isStatusState(state: PackageSourceInputState): boolean {
+    return state === 'loading' || state === 'validating' || state === 'ready';
+  }
+  function stateLabel(state: PackageSourceInputState): string {
+    if (dropzone.stateLabels !== undefined && dropzone.stateLabels[state] !== undefined) {
+      return dropzone.stateLabels[state] as string;
+    }
+    return STATE_LABEL_DEFAULTS[state];
+  }
+
+  function metaFromFileList(files: FileList | null): PackageSourceInputFileMeta[] {
+    const out: PackageSourceInputFileMeta[] = [];
+    if (files === null) return out;
+    for (let i = 0; i < files.length; i += 1) {
+      const file = files.item(i);
+      if (file === null) continue;
+      const entry: PackageSourceInputFileMeta = { name: file.name, sizeBytes: file.size };
+      if (file.type) entry.mediaType = file.type;
+      out.push(entry);
+    }
+    return out;
+  }
+
+  function handleDragOver(event: DragEvent): void {
+    event.preventDefault();
+  }
+  function handleDrop(event: DragEvent): void {
+    event.preventDefault();
+    if (onFiles === undefined) return;
+    onFiles(metaFromFileList(event.dataTransfer?.files ?? null));
+  }
+
+  $: labelId = dropzone.label !== undefined ? `${dropzone.dropzoneId}-label` : undefined;
+  $: descriptionId = dropzone.description !== undefined ? `${dropzone.dropzoneId}-description` : undefined;
+  $: errorIds = (dropzone.errors ?? []).map((e: PackageSourceInputError) => `${dropzone.dropzoneId}-error-${e.id}`);
+  $: ariaDescribedBy =
+    [descriptionId, ...errorIds]
+      .filter((id): id is string => typeof id === 'string')
+      .join(' ') || undefined;
+  $: announceLabel = stateLabel(dropzone.state);
+  $: stateRole = isAlertState(dropzone.state)
+    ? 'alert'
+    : isStatusState(dropzone.state)
+      ? 'status'
+      : undefined;
+</script>
+
+<section
+  id={dropzone.dropzoneId}
+  class={`facetheory-stitch-code-dropzone facetheory-stitch-code-dropzone-state-${dropzone.state}`}
+  data-safety-policy={dropzone.safetyPolicy}
+  data-dropzone-id={dropzone.dropzoneId}
+  data-state={dropzone.state}
+  data-has-file={dropzone.fileMeta !== undefined ? 'true' : 'false'}
+  role={stateRole}
+  aria-labelledby={labelId}
+  aria-describedby={ariaDescribedBy}
+>
+  {#if dropzone.label !== undefined}
+    <div id={labelId}>{dropzone.label}</div>
+  {/if}
+  {#if dropzone.description !== undefined}
+    <p id={descriptionId}>{dropzone.description}</p>
+  {/if}
+
+  <div
+    role="group"
+    class={`facetheory-stitch-code-dropzone-target facetheory-stitch-code-dropzone-target-state-${dropzone.state}`}
+    data-dropzone-state={dropzone.state}
+    aria-label={announceLabel}
+    tabindex="0"
+    on:dragover={handleDragOver}
+    on:drop={handleDrop}
+  >
+    <strong>{dropzone.emptyLabel ?? 'Drop files here'}</strong>
+    <span>Files are parsed by TheoryMCP, not by FaceTheory.</span>
+  </div>
+
+  {#if dropzone.fileMeta !== undefined}
+    <dl
+      class="facetheory-stitch-package-source-input-file-meta"
+      data-file-name={dropzone.fileMeta.name}
+    >
+      <div><dt>File</dt><dd>{dropzone.fileMeta.name}</dd></div>
+      {#if dropzone.fileMeta.sizeBytes !== undefined}
+        <div><dt>Size</dt><dd>{dropzone.fileMeta.sizeBytes} B</dd></div>
+      {/if}
+      {#if dropzone.fileMeta.mediaType !== undefined}
+        <div><dt>Media type</dt><dd>{dropzone.fileMeta.mediaType}</dd></div>
+      {/if}
+      {#if dropzone.fileMeta.sha256 !== undefined}
+        <div><dt>sha256</dt><dd><code>{dropzone.fileMeta.sha256}</code></dd></div>
+      {/if}
+    </dl>
+  {/if}
+
+  <p
+    class={`facetheory-stitch-code-dropzone-state-label facetheory-stitch-code-dropzone-state-label-${dropzone.state}`}
+    data-state-label={dropzone.state}
+    role={stateRole}
+    aria-live={stateRole === 'status' ? 'polite' : undefined}
+  >{announceLabel}</p>
+
+  {#if (dropzone.errors ?? []).length > 0}
+    <ul class="facetheory-stitch-package-source-input-errors" role="list" data-error-count={String((dropzone.errors ?? []).length)}>
+      {#each dropzone.errors ?? [] as error (error.id)}
+        <li
+          id={`${dropzone.dropzoneId}-error-${error.id}`}
+          class={`facetheory-stitch-package-source-input-error facetheory-stitch-package-source-input-error-${error.kind}`}
+          data-error-kind={error.kind}
+          data-error-id={error.id}
+          role="alert"
+          aria-live="polite"
+        >
+          <strong
+            class="facetheory-stitch-package-source-input-error-kind"
+            data-error-kind-label={error.kind}
+          >{ERROR_KIND_LABEL[error.kind]}</strong>
+          <span class="facetheory-stitch-package-source-input-error-message">{error.message}</span>
+          {#if error.evidence !== undefined && error.kind !== 'redacted'}
+            <code class="facetheory-stitch-package-source-input-error-evidence">{error.evidence}</code>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <p
+    class="facetheory-stitch-wizard-safety-footnote"
+    data-safety-policy={dropzone.safetyPolicy}
+  >Safety policy: {dropzone.safetyPolicy}</p>
+</section>

--- a/ts/src/svelte/stitch-admin/PackageSourceInputPanel.svelte
+++ b/ts/src/svelte/stitch-admin/PackageSourceInputPanel.svelte
@@ -216,7 +216,7 @@
             data-error-kind-label={error.kind}
           >{ERROR_KIND_LABEL[error.kind]}</strong>
           <span class="facetheory-stitch-package-source-input-error-message">{error.message}</span>
-          {#if error.evidence !== undefined && error.kind !== 'redacted'}
+          {#if error.evidence !== undefined && error.kind === 'invalid-syntax'}
             <code class="facetheory-stitch-package-source-input-error-evidence">{error.evidence}</code>
           {/if}
         </li>

--- a/ts/src/svelte/stitch-admin/PackageSourceInputPanel.svelte
+++ b/ts/src/svelte/stitch-admin/PackageSourceInputPanel.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+  import type {
+    PackageSourceInput,
+    PackageSourceInputError,
+    PackageSourceInputErrorKind,
+    PackageSourceInputFileMeta,
+    PackageSourceInputMode,
+    PackageSourceInputState,
+  } from './types.js';
+
+  export let input: PackageSourceInput;
+  export let onValueChange: ((next: string) => void) | undefined = undefined;
+  export let onFiles: ((files: PackageSourceInputFileMeta[]) => void) | undefined = undefined;
+  export let onClear: (() => void) | undefined = undefined;
+  export let onReplace: (() => void) | undefined = undefined;
+  export let onCopy: ((copyValue: string) => void) | undefined = undefined;
+
+  const STATE_LABEL_DEFAULTS: Record<PackageSourceInputState, string> = {
+    idle: 'Awaiting source',
+    loading: 'Loading source',
+    validating: 'Validating source',
+    ready: 'Ready for server preview',
+    invalid: 'Invalid source',
+    forbidden: 'Source not allowed',
+    redacted: 'Source contains redacted content',
+  };
+
+  const ERROR_KIND_LABEL: Record<PackageSourceInputErrorKind, string> = {
+    'invalid-syntax': 'Invalid syntax',
+    forbidden: 'Forbidden',
+    redacted: 'Redacted',
+    unsafe: 'Unsafe',
+    other: 'Error',
+  };
+
+  function isAlertState(state: PackageSourceInputState): boolean {
+    return state === 'invalid' || state === 'forbidden' || state === 'redacted';
+  }
+  function isStatusState(state: PackageSourceInputState): boolean {
+    return state === 'loading' || state === 'validating' || state === 'ready';
+  }
+  function stateLabel(state: PackageSourceInputState): string {
+    if (input.stateLabels !== undefined && input.stateLabels[state] !== undefined) {
+      return input.stateLabels[state] as string;
+    }
+    return STATE_LABEL_DEFAULTS[state];
+  }
+
+  function handlePaste(event: Event): void {
+    if (onValueChange === undefined) return;
+    onValueChange((event.target as HTMLTextAreaElement).value);
+  }
+
+  function metaFromFileList(files: FileList | null): PackageSourceInputFileMeta[] {
+    const out: PackageSourceInputFileMeta[] = [];
+    if (files === null) return out;
+    for (let i = 0; i < files.length; i += 1) {
+      const file = files.item(i);
+      if (file === null) continue;
+      const entry: PackageSourceInputFileMeta = { name: file.name, sizeBytes: file.size };
+      if (file.type) entry.mediaType = file.type;
+      out.push(entry);
+    }
+    return out;
+  }
+
+  function handleFileChange(event: Event): void {
+    if (onFiles === undefined) return;
+    onFiles(metaFromFileList((event.target as HTMLInputElement).files));
+  }
+
+  function handleDragOver(event: DragEvent): void {
+    event.preventDefault();
+  }
+
+  function handleDrop(event: DragEvent): void {
+    event.preventDefault();
+    if (onFiles === undefined) return;
+    onFiles(metaFromFileList(event.dataTransfer?.files ?? null));
+  }
+
+  function handleCopy(value: string): void {
+    if (onCopy !== undefined) onCopy(value);
+  }
+
+  $: labelId = input.label !== undefined ? `${input.groupId}-label` : undefined;
+  $: descriptionId = input.description !== undefined ? `${input.groupId}-description` : undefined;
+  $: stateAnnouncementId = `${input.groupId}-state`;
+  $: errorIds = input.errors.map((e) => `${input.groupId}-error-${e.id}`);
+  $: ariaDescribedBy =
+    [descriptionId, stateAnnouncementId, ...errorIds]
+      .filter((id): id is string => typeof id === 'string')
+      .join(' ') || undefined;
+  $: allowPaste = (input.modes as PackageSourceInputMode[]).includes('paste');
+  $: allowUpload = (input.modes as PackageSourceInputMode[]).includes('upload');
+  $: allowDropzone = (input.modes as PackageSourceInputMode[]).includes('dropzone');
+  $: announceLabel = stateLabel(input.state);
+  $: stateRole = isAlertState(input.state)
+    ? 'alert'
+    : isStatusState(input.state)
+      ? 'status'
+      : undefined;
+</script>
+
+<section
+  class={`facetheory-stitch-package-source-input facetheory-stitch-package-source-input-state-${input.state}`}
+  data-safety-policy={input.safetyPolicy}
+  data-group-id={input.groupId}
+  data-state={input.state}
+  data-modes={input.modes.join(' ')}
+  data-error-count={String(input.errors.length)}
+  data-has-file={input.fileMeta !== undefined ? 'true' : 'false'}
+>
+  {#if input.label !== undefined || input.description !== undefined}
+    <header>
+      {#if input.label !== undefined}
+        <label id={labelId} for={allowPaste ? `${input.groupId}-paste` : undefined}>
+          {input.label}
+        </label>
+      {/if}
+      {#if input.description !== undefined}
+        <p id={descriptionId}>{input.description}</p>
+      {/if}
+    </header>
+  {/if}
+
+  {#if allowPaste}
+    <textarea
+      id={`${input.groupId}-paste`}
+      class="facetheory-stitch-package-source-input-paste"
+      data-mode="paste"
+      value={input.value}
+      placeholder={input.placeholder}
+      aria-labelledby={labelId}
+      aria-describedby={ariaDescribedBy}
+      aria-invalid={isAlertState(input.state) ? 'true' : 'false'}
+      on:input={handlePaste}
+    ></textarea>
+  {/if}
+
+  {#if allowDropzone}
+    <div
+      role="group"
+      class={`facetheory-stitch-package-source-input-dropzone facetheory-stitch-package-source-input-dropzone-state-${input.state}`}
+      data-mode="dropzone"
+      data-dropzone-state={input.state}
+      aria-label={announceLabel}
+      aria-describedby={ariaDescribedBy}
+      aria-disabled={input.state === 'loading' ? 'true' : undefined}
+      tabindex="0"
+      on:dragover={handleDragOver}
+      on:drop={handleDrop}
+    >
+      <strong>Drop files here or use the picker</strong>
+      <span>Files are parsed by TheoryMCP, not by FaceTheory.</span>
+    </div>
+  {/if}
+
+  {#if allowUpload}
+    <div class="facetheory-stitch-package-source-input-upload" data-mode="upload">
+      <label for={`${input.groupId}-file`}>Choose a file:</label>
+      <input
+        id={`${input.groupId}-file`}
+        type="file"
+        class="facetheory-stitch-package-source-input-file"
+        accept={input.fileAccept}
+        aria-describedby={ariaDescribedBy}
+        on:change={handleFileChange}
+      />
+    </div>
+  {/if}
+
+  {#if input.fileMeta !== undefined}
+    <dl
+      class="facetheory-stitch-package-source-input-file-meta"
+      data-file-name={input.fileMeta.name}
+    >
+      <div><dt>File</dt><dd>{input.fileMeta.name}</dd></div>
+      {#if input.fileMeta.sizeBytes !== undefined}
+        <div><dt>Size</dt><dd>{input.fileMeta.sizeBytes} B</dd></div>
+      {/if}
+      {#if input.fileMeta.mediaType !== undefined}
+        <div><dt>Media type</dt><dd>{input.fileMeta.mediaType}</dd></div>
+      {/if}
+      {#if input.fileMeta.sha256 !== undefined}
+        <div><dt>sha256</dt><dd><code>{input.fileMeta.sha256}</code></dd></div>
+      {/if}
+    </dl>
+  {/if}
+
+  <p
+    id={stateAnnouncementId}
+    class={`facetheory-stitch-package-source-input-state facetheory-stitch-package-source-input-state-label-${input.state}`}
+    data-state-label={input.state}
+    role={stateRole}
+    aria-live={stateRole === 'status' ? 'polite' : undefined}
+  >{announceLabel}</p>
+
+  {#if input.errors.length > 0}
+    <ul
+      class="facetheory-stitch-package-source-input-errors"
+      role="list"
+      data-error-count={String(input.errors.length)}
+    >
+      {#each input.errors as error (error.id)}
+        <li
+          id={`${input.groupId}-error-${error.id}`}
+          class={`facetheory-stitch-package-source-input-error facetheory-stitch-package-source-input-error-${error.kind}`}
+          data-error-kind={error.kind}
+          data-error-id={error.id}
+          role="alert"
+          aria-live="polite"
+        >
+          <strong
+            class="facetheory-stitch-package-source-input-error-kind"
+            data-error-kind-label={error.kind}
+          >{ERROR_KIND_LABEL[error.kind]}</strong>
+          <span class="facetheory-stitch-package-source-input-error-message">{error.message}</span>
+          {#if error.evidence !== undefined && error.kind !== 'redacted'}
+            <code class="facetheory-stitch-package-source-input-error-evidence">{error.evidence}</code>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  {#if input.actions !== undefined && (input.actions.clear === true || input.actions.replace === true || (input.actions.copy === true && input.actions.copyValue !== undefined))}
+    <div class="facetheory-stitch-package-source-input-actions">
+      {#if input.actions.clear === true}
+        <button
+          type="button"
+          class="facetheory-stitch-package-source-input-action facetheory-stitch-package-source-input-action-clear"
+          data-action="clear"
+          aria-label="Clear package source"
+          on:click={() => onClear?.()}
+        >Clear</button>
+      {/if}
+      {#if input.actions.replace === true}
+        <button
+          type="button"
+          class="facetheory-stitch-package-source-input-action facetheory-stitch-package-source-input-action-replace"
+          data-action="replace"
+          aria-label="Replace package source"
+          on:click={() => onReplace?.()}
+        >Replace</button>
+      {/if}
+      {#if input.actions.copy === true && input.actions.copyValue !== undefined}
+        {@const copyValue = input.actions.copyValue}
+        <button
+          type="button"
+          class="facetheory-stitch-package-source-input-action facetheory-stitch-package-source-input-action-copy"
+          data-action="copy"
+          data-copy-value={copyValue}
+          aria-label="Copy package source"
+          on:click={() => handleCopy(copyValue)}
+        >Copy</button>
+      {/if}
+    </div>
+  {/if}
+
+  <p
+    class="facetheory-stitch-wizard-safety-footnote"
+    data-safety-policy={input.safetyPolicy}
+  >Safety policy: {input.safetyPolicy}</p>
+</section>

--- a/ts/src/svelte/stitch-admin/index.d.ts
+++ b/ts/src/svelte/stitch-admin/index.d.ts
@@ -396,6 +396,32 @@ export interface ChoiceCardPanelProps {
 export declare const SelectableCardGridPanel: Component<SelectableCardGridPanelProps>;
 export declare const ChoiceCard: Component<ChoiceCardPanelProps>;
 
+export type {
+  CodeDropzoneProps,
+  PackageSourceInput,
+  PackageSourceInputActions,
+  PackageSourceInputError,
+  PackageSourceInputErrorKind,
+  PackageSourceInputFileMeta,
+  PackageSourceInputMode,
+  PackageSourceInputState,
+} from '../../stitch-admin/package-source-input-types.js';
+
+export interface PackageSourceInputPanelProps {
+  input: import('../../stitch-admin/package-source-input-types.js').PackageSourceInput;
+  onValueChange?: (next: string) => void;
+  onFiles?: (files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[]) => void;
+  onClear?: () => void;
+  onReplace?: () => void;
+  onCopy?: (copyValue: string) => void;
+}
+export interface CodeDropzonePanelProps {
+  dropzone: import('../../stitch-admin/package-source-input-types.js').CodeDropzoneProps;
+  onFiles?: (files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[]) => void;
+}
+export declare const PackageSourceInputPanel: Component<PackageSourceInputPanelProps>;
+export declare const CodeDropzone: Component<CodeDropzonePanelProps>;
+
 export declare const WizardProgress: Component<WizardProgressPanelProps>;
 export declare const WizardPackageSummaryPanel: Component<WizardPackageSummaryPanelProps>;
 export declare const WizardFindingListPanel: Component<WizardFindingListPanelProps>;

--- a/ts/src/svelte/stitch-admin/index.ts
+++ b/ts/src/svelte/stitch-admin/index.ts
@@ -36,8 +36,21 @@ export { default as WizardAuthorityContextStripPanel } from './WizardAuthorityCo
 export { default as WizardServerResolvedContextBarPanel } from './WizardAuthorityContextStripPanel.svelte';
 export { default as SelectableCardGridPanel } from './SelectableCardGridPanel.svelte';
 export { default as ChoiceCard } from './ChoiceCard.svelte';
+export { default as PackageSourceInputPanel } from './PackageSourceInputPanel.svelte';
+export { default as CodeDropzone } from './CodeDropzone.svelte';
 export { default as WizardEditableTokenInputPanel } from './WizardEditableTokenInputPanel.svelte';
 export { default as WizardChipListPanel } from './WizardEditableTokenInputPanel.svelte';
+
+export type {
+  CodeDropzoneProps,
+  PackageSourceInput,
+  PackageSourceInputActions,
+  PackageSourceInputError,
+  PackageSourceInputErrorKind,
+  PackageSourceInputFileMeta,
+  PackageSourceInputMode,
+  PackageSourceInputState,
+} from '../../stitch-admin/package-source-input-types.js';
 
 export type {
   ChoiceCardProps,

--- a/ts/src/svelte/stitch-admin/types.ts
+++ b/ts/src/svelte/stitch-admin/types.ts
@@ -291,3 +291,28 @@ export interface ChoiceCardPanelProps {
   card: import('../../stitch-admin/selectable-card-grid-types.js').ChoiceCardProps;
   onChange?: (selected: boolean) => void;
 }
+
+export type {
+  CodeDropzoneProps,
+  PackageSourceInput,
+  PackageSourceInputActions,
+  PackageSourceInputError,
+  PackageSourceInputErrorKind,
+  PackageSourceInputFileMeta,
+  PackageSourceInputMode,
+  PackageSourceInputState,
+} from '../../stitch-admin/package-source-input-types.js';
+
+export interface PackageSourceInputPanelProps {
+  input: import('../../stitch-admin/package-source-input-types.js').PackageSourceInput;
+  onValueChange?: (next: string) => void;
+  onFiles?: (files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[]) => void;
+  onClear?: () => void;
+  onReplace?: () => void;
+  onCopy?: (copyValue: string) => void;
+}
+
+export interface CodeDropzonePanelProps {
+  dropzone: import('../../stitch-admin/package-source-input-types.js').CodeDropzoneProps;
+  onFiles?: (files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[]) => void;
+}

--- a/ts/src/vue/stitch-admin/index.ts
+++ b/ts/src/vue/stitch-admin/index.ts
@@ -146,6 +146,21 @@ export {
 } from './wizard-authority-context-strip.js';
 
 export {
+  PackageSourceInputPanel,
+  CodeDropzone,
+  type PackageSourceInputPanelProps,
+  type CodeDropzonePanelProps,
+  type CodeDropzoneProps,
+  type PackageSourceInput,
+  type PackageSourceInputActions,
+  type PackageSourceInputError,
+  type PackageSourceInputErrorKind,
+  type PackageSourceInputFileMeta,
+  type PackageSourceInputMode,
+  type PackageSourceInputState,
+} from './package-source-input.js';
+
+export {
   SelectableCardGridPanel,
   ChoiceCard,
   type SelectableCardGridPanelProps,

--- a/ts/src/vue/stitch-admin/package-source-input.ts
+++ b/ts/src/vue/stitch-admin/package-source-input.ts
@@ -117,7 +117,7 @@ function renderErrors(
             { class: 'facetheory-stitch-package-source-input-error-message' },
             renderPropContent(error.message as VNodeChild),
           ),
-          error.evidence !== undefined && error.kind !== 'redacted'
+          error.evidence !== undefined && error.kind === 'invalid-syntax'
             ? h(
                 'code',
                 { class: 'facetheory-stitch-package-source-input-error-evidence' },

--- a/ts/src/vue/stitch-admin/package-source-input.ts
+++ b/ts/src/vue/stitch-admin/package-source-input.ts
@@ -1,0 +1,570 @@
+/**
+ * Vue parity for `PackageSourceInputPanel` and `CodeDropzone`. Mirrors the
+ * React adapter's class names, data-* attributes, role markers, ARIA
+ * wiring, and safety-policy footnote.
+ */
+
+import { defineComponent, h } from 'vue';
+import type { PropType, VNodeChild } from 'vue';
+
+import type {
+  CodeDropzoneProps,
+  PackageSourceInput,
+  PackageSourceInputActions,
+  PackageSourceInputError,
+  PackageSourceInputErrorKind,
+  PackageSourceInputFileMeta,
+  PackageSourceInputMode,
+  PackageSourceInputState,
+} from '../../stitch-admin/package-source-input-types.js';
+import type { WizardSafetyPolicy } from '../../stitch-admin/wizard-types.js';
+import { renderPropContent } from '../stitch-common.js';
+
+export type {
+  CodeDropzoneProps,
+  PackageSourceInput,
+  PackageSourceInputActions,
+  PackageSourceInputError,
+  PackageSourceInputErrorKind,
+  PackageSourceInputFileMeta,
+  PackageSourceInputMode,
+  PackageSourceInputState,
+};
+
+const STATE_LABEL_DEFAULTS: Record<PackageSourceInputState, string> = {
+  idle: 'Awaiting source',
+  loading: 'Loading source',
+  validating: 'Validating source',
+  ready: 'Ready for server preview',
+  invalid: 'Invalid source',
+  forbidden: 'Source not allowed',
+  redacted: 'Source contains redacted content',
+};
+
+const ERROR_KIND_LABEL: Record<PackageSourceInputErrorKind, string> = {
+  'invalid-syntax': 'Invalid syntax',
+  forbidden: 'Forbidden',
+  redacted: 'Redacted',
+  unsafe: 'Unsafe',
+  other: 'Error',
+};
+
+const ALERT_STATES = new Set<PackageSourceInputState>(['invalid', 'forbidden', 'redacted']);
+const STATUS_STATES = new Set<PackageSourceInputState>(['loading', 'validating', 'ready']);
+
+function isAlertState(state: PackageSourceInputState): boolean {
+  return ALERT_STATES.has(state);
+}
+function isStatusState(state: PackageSourceInputState): boolean {
+  return STATUS_STATES.has(state);
+}
+function stateLabel(
+  state: PackageSourceInputState,
+  overrides?: PackageSourceInput['stateLabels'],
+): string {
+  if (overrides !== undefined && overrides[state] !== undefined) {
+    return overrides[state] as string;
+  }
+  return STATE_LABEL_DEFAULTS[state];
+}
+
+function renderSafetyFootnote(policy: WizardSafetyPolicy): VNodeChild {
+  return h(
+    'p',
+    {
+      class: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+    },
+    `Safety policy: ${policy}`,
+  );
+}
+
+function renderErrors(
+  errors: PackageSourceInputError[],
+  groupId: string,
+): VNodeChild {
+  if (errors.length === 0) return null;
+  return h(
+    'ul',
+    {
+      class: 'facetheory-stitch-package-source-input-errors',
+      role: 'list',
+      'data-error-count': String(errors.length),
+    },
+    errors.map((error) =>
+      h(
+        'li',
+        {
+          key: error.id,
+          id: `${groupId}-error-${error.id}`,
+          class: `facetheory-stitch-package-source-input-error facetheory-stitch-package-source-input-error-${error.kind}`,
+          'data-error-kind': error.kind,
+          'data-error-id': error.id,
+          role: 'alert',
+          'aria-live': 'polite',
+        },
+        [
+          h(
+            'strong',
+            {
+              class: 'facetheory-stitch-package-source-input-error-kind',
+              'data-error-kind-label': error.kind,
+            },
+            ERROR_KIND_LABEL[error.kind],
+          ),
+          h(
+            'span',
+            { class: 'facetheory-stitch-package-source-input-error-message' },
+            renderPropContent(error.message as VNodeChild),
+          ),
+          error.evidence !== undefined && error.kind !== 'redacted'
+            ? h(
+                'code',
+                { class: 'facetheory-stitch-package-source-input-error-evidence' },
+                error.evidence,
+              )
+            : null,
+        ],
+      ),
+    ),
+  );
+}
+
+function renderFileMeta(fileMeta: PackageSourceInputFileMeta): VNodeChild {
+  return h(
+    'dl',
+    {
+      class: 'facetheory-stitch-package-source-input-file-meta',
+      'data-file-name': fileMeta.name,
+    },
+    [
+      h('div', { key: 'name' }, [h('dt', null, 'File'), h('dd', null, fileMeta.name)]),
+      fileMeta.sizeBytes !== undefined
+        ? h('div', { key: 'size' }, [
+            h('dt', null, 'Size'),
+            h('dd', null, `${fileMeta.sizeBytes} B`),
+          ])
+        : null,
+      fileMeta.mediaType !== undefined
+        ? h('div', { key: 'media' }, [
+            h('dt', null, 'Media type'),
+            h('dd', null, fileMeta.mediaType),
+          ])
+        : null,
+      fileMeta.sha256 !== undefined
+        ? h('div', { key: 'sha' }, [
+            h('dt', null, 'sha256'),
+            h('dd', null, h('code', null, fileMeta.sha256)),
+          ])
+        : null,
+    ],
+  );
+}
+
+function renderActions(
+  actions: PackageSourceInputActions | undefined,
+  onClear: (() => void) | undefined,
+  onReplace: (() => void) | undefined,
+  onCopy: ((copyValue: string) => void) | undefined,
+): VNodeChild {
+  if (actions === undefined) return null;
+  const buttons: VNodeChild[] = [];
+  if (actions.clear === true) {
+    buttons.push(
+      h(
+        'button',
+        {
+          key: 'clear',
+          type: 'button',
+          class: 'facetheory-stitch-package-source-input-action facetheory-stitch-package-source-input-action-clear',
+          'data-action': 'clear',
+          'aria-label': 'Clear package source',
+          onClick: onClear,
+        },
+        'Clear',
+      ),
+    );
+  }
+  if (actions.replace === true) {
+    buttons.push(
+      h(
+        'button',
+        {
+          key: 'replace',
+          type: 'button',
+          class: 'facetheory-stitch-package-source-input-action facetheory-stitch-package-source-input-action-replace',
+          'data-action': 'replace',
+          'aria-label': 'Replace package source',
+          onClick: onReplace,
+        },
+        'Replace',
+      ),
+    );
+  }
+  if (actions.copy === true && actions.copyValue !== undefined) {
+    const copyValue = actions.copyValue;
+    buttons.push(
+      h(
+        'button',
+        {
+          key: 'copy',
+          type: 'button',
+          class: 'facetheory-stitch-package-source-input-action facetheory-stitch-package-source-input-action-copy',
+          'data-action': 'copy',
+          'data-copy-value': copyValue,
+          'aria-label': 'Copy package source',
+          onClick: onCopy !== undefined ? () => onCopy(copyValue) : undefined,
+        },
+        'Copy',
+      ),
+    );
+  }
+  if (buttons.length === 0) return null;
+  return h(
+    'div',
+    { class: 'facetheory-stitch-package-source-input-actions' },
+    buttons,
+  );
+}
+
+function renderDropzoneInner(
+  input: PackageSourceInput,
+  ariaDescribedBy: string | undefined,
+  onFiles: ((files: PackageSourceInputFileMeta[]) => void) | undefined,
+): VNodeChild {
+  const announceLabel = stateLabel(input.state, input.stateLabels);
+  const props: Record<string, unknown> = {
+    role: 'group',
+    class: `facetheory-stitch-package-source-input-dropzone facetheory-stitch-package-source-input-dropzone-state-${input.state}`,
+    'data-mode': 'dropzone',
+    'data-dropzone-state': input.state,
+    'aria-label': announceLabel,
+    tabindex: 0,
+  };
+  if (ariaDescribedBy !== undefined) props['aria-describedby'] = ariaDescribedBy;
+  if (input.state === 'loading') props['aria-disabled'] = 'true';
+  if (onFiles !== undefined) {
+    props.onDragover = (event: DragEvent) => event.preventDefault();
+    props.onDrop = (event: DragEvent) => {
+      event.preventDefault();
+      const files = event.dataTransfer?.files;
+      if (files === undefined || files === null) return;
+      const meta: PackageSourceInputFileMeta[] = [];
+      for (let i = 0; i < files.length; i += 1) {
+        const file = files.item(i);
+        if (file === null) continue;
+        const entry: PackageSourceInputFileMeta = { name: file.name, sizeBytes: file.size };
+        if (file.type) entry.mediaType = file.type;
+        meta.push(entry);
+      }
+      onFiles(meta);
+    };
+  }
+  return h(
+    'div',
+    props,
+    [
+      h('strong', null, 'Drop files here or use the picker'),
+      h('span', null, 'Files are parsed by TheoryMCP, not by FaceTheory.'),
+    ],
+  );
+}
+
+export interface PackageSourceInputPanelProps {
+  input: PackageSourceInput;
+  onValueChange?: (next: string) => void;
+  onFiles?: (files: PackageSourceInputFileMeta[]) => void;
+  onClear?: () => void;
+  onReplace?: () => void;
+  onCopy?: (copyValue: string) => void;
+}
+
+export const PackageSourceInputPanel = defineComponent({
+  name: 'FaceTheoryVuePackageSourceInputPanel',
+  props: {
+    input: { type: Object as PropType<PackageSourceInput>, required: true },
+    onValueChange: {
+      type: Function as PropType<(next: string) => void>,
+      required: false,
+    },
+    onFiles: {
+      type: Function as PropType<(files: PackageSourceInputFileMeta[]) => void>,
+      required: false,
+    },
+    onClear: {
+      type: Function as PropType<() => void>,
+      required: false,
+    },
+    onReplace: {
+      type: Function as PropType<() => void>,
+      required: false,
+    },
+    onCopy: {
+      type: Function as PropType<(copyValue: string) => void>,
+      required: false,
+    },
+  },
+  setup(props) {
+    return () => {
+      const input = props.input;
+      const onValueChange = props.onValueChange;
+      const onFiles = props.onFiles;
+      const labelId =
+        input.label !== undefined ? `${input.groupId}-label` : undefined;
+      const descriptionId =
+        input.description !== undefined
+          ? `${input.groupId}-description`
+          : undefined;
+      const stateAnnouncementId = `${input.groupId}-state`;
+      const errorIds = input.errors.map((e) => `${input.groupId}-error-${e.id}`);
+      const ariaDescribedBy =
+        [descriptionId, stateAnnouncementId, ...errorIds]
+          .filter((id): id is string => typeof id === 'string')
+          .join(' ') || undefined;
+      const allowPaste = input.modes.includes('paste');
+      const allowUpload = input.modes.includes('upload');
+      const allowDropzone = input.modes.includes('dropzone');
+      const announceLabel = stateLabel(input.state, input.stateLabels);
+      const stateRole = isAlertState(input.state)
+        ? 'alert'
+        : isStatusState(input.state)
+          ? 'status'
+          : undefined;
+
+      const textareaProps: Record<string, unknown> = {
+        id: `${input.groupId}-paste`,
+        class: 'facetheory-stitch-package-source-input-paste',
+        'data-mode': 'paste',
+        value: input.value,
+        placeholder: input.placeholder,
+        'aria-invalid': isAlertState(input.state) ? 'true' : 'false',
+      };
+      if (labelId !== undefined) textareaProps['aria-labelledby'] = labelId;
+      if (ariaDescribedBy !== undefined)
+        textareaProps['aria-describedby'] = ariaDescribedBy;
+      if (onValueChange !== undefined) {
+        textareaProps.onInput = (event: Event) =>
+          onValueChange((event.target as HTMLTextAreaElement).value);
+      }
+
+      const fileProps: Record<string, unknown> = {
+        id: `${input.groupId}-file`,
+        type: 'file',
+        class: 'facetheory-stitch-package-source-input-file',
+      };
+      if (ariaDescribedBy !== undefined)
+        fileProps['aria-describedby'] = ariaDescribedBy;
+      if (input.fileAccept !== undefined) fileProps.accept = input.fileAccept;
+      if (onFiles !== undefined) {
+        fileProps.onChange = (event: Event) => {
+          const target = event.target as HTMLInputElement;
+          const files = target.files;
+          if (files === null) return;
+          const meta: PackageSourceInputFileMeta[] = [];
+          for (let i = 0; i < files.length; i += 1) {
+            const file = files.item(i);
+            if (file === null) continue;
+            const entry: PackageSourceInputFileMeta = {
+              name: file.name,
+              sizeBytes: file.size,
+            };
+            if (file.type) entry.mediaType = file.type;
+            meta.push(entry);
+          }
+          onFiles(meta);
+        };
+      }
+
+      const stateProps: Record<string, unknown> = {
+        id: stateAnnouncementId,
+        class: `facetheory-stitch-package-source-input-state facetheory-stitch-package-source-input-state-label-${input.state}`,
+        'data-state-label': input.state,
+      };
+      if (stateRole !== undefined) stateProps.role = stateRole;
+      if (stateRole === 'status') stateProps['aria-live'] = 'polite';
+
+      return h(
+        'section',
+        {
+          class: `facetheory-stitch-package-source-input facetheory-stitch-package-source-input-state-${input.state}`,
+          'data-safety-policy': input.safetyPolicy,
+          'data-group-id': input.groupId,
+          'data-state': input.state,
+          'data-modes': input.modes.join(' '),
+          'data-error-count': String(input.errors.length),
+          'data-has-file': input.fileMeta !== undefined ? 'true' : 'false',
+        },
+        [
+          input.label !== undefined || input.description !== undefined
+            ? h(
+                'header',
+                null,
+                [
+                  input.label !== undefined
+                    ? h(
+                        'label',
+                        {
+                          id: labelId,
+                          for: allowPaste ? `${input.groupId}-paste` : undefined,
+                        },
+                        renderPropContent(input.label as VNodeChild),
+                      )
+                    : null,
+                  input.description !== undefined
+                    ? h(
+                        'p',
+                        { id: descriptionId },
+                        renderPropContent(input.description as VNodeChild),
+                      )
+                    : null,
+                ],
+              )
+            : null,
+          allowPaste ? h('textarea', textareaProps) : null,
+          allowDropzone ? renderDropzoneInner(input, ariaDescribedBy, onFiles) : null,
+          allowUpload
+            ? h(
+                'div',
+                {
+                  class: 'facetheory-stitch-package-source-input-upload',
+                  'data-mode': 'upload',
+                },
+                [
+                  h(
+                    'label',
+                    { for: `${input.groupId}-file` },
+                    'Choose a file:',
+                  ),
+                  h('input', fileProps),
+                ],
+              )
+            : null,
+          input.fileMeta !== undefined ? renderFileMeta(input.fileMeta) : null,
+          h('p', stateProps, announceLabel),
+          renderErrors(input.errors, input.groupId),
+          renderActions(
+            input.actions,
+            props.onClear,
+            props.onReplace,
+            props.onCopy,
+          ),
+          renderSafetyFootnote(input.safetyPolicy),
+        ],
+      );
+    };
+  },
+});
+
+export interface CodeDropzonePanelProps {
+  dropzone: CodeDropzoneProps;
+  onFiles?: (files: PackageSourceInputFileMeta[]) => void;
+}
+
+export const CodeDropzone = defineComponent({
+  name: 'FaceTheoryVueCodeDropzone',
+  props: {
+    dropzone: { type: Object as PropType<CodeDropzoneProps>, required: true },
+    onFiles: {
+      type: Function as PropType<(files: PackageSourceInputFileMeta[]) => void>,
+      required: false,
+    },
+  },
+  setup(props) {
+    return () => {
+      const dropzone = props.dropzone;
+      const onFiles = props.onFiles;
+      const labelId =
+        dropzone.label !== undefined
+          ? `${dropzone.dropzoneId}-label`
+          : undefined;
+      const descriptionId =
+        dropzone.description !== undefined
+          ? `${dropzone.dropzoneId}-description`
+          : undefined;
+      const errorIds = (dropzone.errors ?? []).map(
+        (e) => `${dropzone.dropzoneId}-error-${e.id}`,
+      );
+      const ariaDescribedBy =
+        [descriptionId, ...errorIds]
+          .filter((id): id is string => typeof id === 'string')
+          .join(' ') || undefined;
+      const announceLabel = stateLabel(dropzone.state, dropzone.stateLabels);
+      const stateRole = isAlertState(dropzone.state)
+        ? 'alert'
+        : isStatusState(dropzone.state)
+          ? 'status'
+          : undefined;
+      const sectionProps: Record<string, unknown> = {
+        id: dropzone.dropzoneId,
+        class: `facetheory-stitch-code-dropzone facetheory-stitch-code-dropzone-state-${dropzone.state}`,
+        'data-safety-policy': dropzone.safetyPolicy,
+        'data-dropzone-id': dropzone.dropzoneId,
+        'data-state': dropzone.state,
+        'data-has-file': dropzone.fileMeta !== undefined ? 'true' : 'false',
+      };
+      if (stateRole !== undefined) sectionProps.role = stateRole;
+      if (labelId !== undefined) sectionProps['aria-labelledby'] = labelId;
+      if (ariaDescribedBy !== undefined)
+        sectionProps['aria-describedby'] = ariaDescribedBy;
+      const targetProps: Record<string, unknown> = {
+        role: 'group',
+        class: `facetheory-stitch-code-dropzone-target facetheory-stitch-code-dropzone-target-state-${dropzone.state}`,
+        'data-dropzone-state': dropzone.state,
+        'aria-label': announceLabel,
+        tabindex: 0,
+      };
+      if (onFiles !== undefined) {
+        targetProps.onDragover = (event: DragEvent) => event.preventDefault();
+        targetProps.onDrop = (event: DragEvent) => {
+          event.preventDefault();
+          const files = event.dataTransfer?.files;
+          if (files === undefined || files === null) return;
+          const meta: PackageSourceInputFileMeta[] = [];
+          for (let i = 0; i < files.length; i += 1) {
+            const file = files.item(i);
+            if (file === null) continue;
+            const entry: PackageSourceInputFileMeta = {
+              name: file.name,
+              sizeBytes: file.size,
+            };
+            if (file.type) entry.mediaType = file.type;
+            meta.push(entry);
+          }
+          onFiles(meta);
+        };
+      }
+      const stateProps: Record<string, unknown> = {
+        class: `facetheory-stitch-code-dropzone-state-label facetheory-stitch-code-dropzone-state-label-${dropzone.state}`,
+        'data-state-label': dropzone.state,
+      };
+      if (stateRole !== undefined) stateProps.role = stateRole;
+      if (stateRole === 'status') stateProps['aria-live'] = 'polite';
+      return h(
+        'section',
+        sectionProps,
+        [
+          dropzone.label !== undefined
+            ? h('div', { id: labelId }, renderPropContent(dropzone.label as VNodeChild))
+            : null,
+          dropzone.description !== undefined
+            ? h('p', { id: descriptionId }, renderPropContent(dropzone.description as VNodeChild))
+            : null,
+          h(
+            'div',
+            targetProps,
+            [
+              h('strong', null, dropzone.emptyLabel ?? 'Drop files here'),
+              h('span', null, 'Files are parsed by TheoryMCP, not by FaceTheory.'),
+            ],
+          ),
+          dropzone.fileMeta !== undefined ? renderFileMeta(dropzone.fileMeta) : null,
+          h('p', stateProps, announceLabel),
+          (dropzone.errors ?? []).length > 0
+            ? renderErrors(dropzone.errors ?? [], dropzone.dropzoneId)
+            : null,
+          renderSafetyFootnote(dropzone.safetyPolicy),
+        ],
+      );
+    };
+  },
+});

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -23,6 +23,7 @@ await import('./unit/stitch-admin-wizard.test.js');
 await import('./unit/stitch-admin-wizard-reconciliation-plan.test.js');
 await import('./unit/stitch-admin-wizard-authority-context-strip.test.js');
 await import('./unit/stitch-admin-selectable-card-grid.test.js');
+await import('./unit/stitch-admin-package-source-input.test.js');
 await import('./unit/stitch-admin-wizard-editable-token-input.test.js');
 await import('./unit/portal-fixtures.test.js');
 await import('./unit/antd-coverage.test.js');

--- a/ts/test/unit/stitch-admin-package-source-input.test.ts
+++ b/ts/test/unit/stitch-admin-package-source-input.test.ts
@@ -1,0 +1,307 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as React from 'react';
+
+import { createFaceApp } from '../../src/app.js';
+import { createReactFace } from '../../src/adapters/react.js';
+import { createAntdIntegration } from '../../src/react/antd.js';
+import type {
+  CodeDropzoneProps,
+  PackageSourceInput,
+} from '../../src/stitch-admin/index.js';
+import {
+  CodeDropzone,
+  PackageSourceInputPanel,
+} from '../../src/react/stitch-admin/index.js';
+
+const h = React.createElement;
+
+async function renderSSR(element: React.ReactElement): Promise<string> {
+  const app = createFaceApp({
+    faces: [
+      createReactFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => element,
+        renderOptions: {
+          integrations: [createAntdIntegration({ hashed: false })],
+        },
+      }),
+    ],
+  });
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  return new TextDecoder().decode(resp.body as Uint8Array);
+}
+
+function countMatches(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+const NOOP_VALUE_CHANGE = (): void => {};
+const NOOP_FILES = (): void => {};
+
+const SAMPLE_INPUT_PASTE: PackageSourceInput = {
+  groupId: 'pkg-src',
+  value: 'name: acme-agent\nversion: 0.1.0\n',
+  state: 'validating',
+  errors: [],
+  modes: ['paste', 'dropzone', 'upload'],
+  label: 'Package source',
+  description: 'TheoryMCP parses and validates server-side before preview.',
+  placeholder: 'Paste your agent manifest…',
+  fileAccept: '.yaml,.yml,.json',
+  actions: { clear: true, replace: true, copy: true, copyValue: 'name: acme-agent\nversion: 0.1.0\n' },
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+const SAMPLE_INPUT_INVALID: PackageSourceInput = {
+  groupId: 'pkg-invalid',
+  value: 'bad',
+  state: 'invalid',
+  errors: [
+    { id: 'syntax-1', kind: 'invalid-syntax', message: 'Expected top-level mapping at line 1', evidence: 'line 1, col 1' },
+    { id: 'unsafe-1', kind: 'unsafe', message: 'Manifest references an unsupported scheme' },
+  ],
+  modes: ['paste'],
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+const SAMPLE_INPUT_FORBIDDEN: PackageSourceInput = {
+  groupId: 'pkg-forbidden',
+  value: '',
+  state: 'forbidden',
+  errors: [
+    { id: 'fb-1', kind: 'forbidden', message: 'Operator policy blocks this manifest for the current route.' },
+  ],
+  modes: ['paste'],
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+const SAMPLE_INPUT_REDACTED: PackageSourceInput = {
+  groupId: 'pkg-redacted',
+  value: '',
+  state: 'redacted',
+  errors: [
+    {
+      id: 'red-1',
+      kind: 'redacted',
+      message: 'Manifest contains redacted content that cannot be displayed.',
+      // Intentionally include caller-supplied "evidence" pointing at a fake secret
+      // so the test can prove the primitive never renders it for kind=redacted.
+      evidence: 'AKIA-NEVER-SHOWN-1234567890',
+    },
+  ],
+  modes: ['paste'],
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+const SAMPLE_INPUT_READY: PackageSourceInput = {
+  groupId: 'pkg-ready',
+  value: 'name: acme-agent\nversion: 0.1.0\n',
+  state: 'ready',
+  errors: [],
+  modes: ['paste'],
+  fileMeta: { name: 'acme-agent.yaml', sizeBytes: 412, mediaType: 'application/yaml', sha256: 'abc123' },
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+/* -------------------------------------------------------------------------- */
+/* Paste / upload / dropzone mode rendering                                   */
+/* -------------------------------------------------------------------------- */
+
+test('PackageSourceInputPanel renders paste, dropzone, and upload modes with stable data attrs', async () => {
+  const body = await renderSSR(
+    h(PackageSourceInputPanel, {
+      input: SAMPLE_INPUT_PASTE,
+      onValueChange: NOOP_VALUE_CHANGE,
+      onFiles: NOOP_FILES,
+    }),
+  );
+  assert.ok(body.includes('facetheory-stitch-package-source-input'));
+  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(body.includes('data-group-id="pkg-src"'));
+  assert.ok(body.includes('data-state="validating"'));
+  assert.ok(body.includes('data-modes="paste dropzone upload"'));
+  // Paste textarea with the right id.
+  assert.ok(body.includes('id="pkg-src-paste"'));
+  assert.ok(body.includes('data-mode="paste"'));
+  // Dropzone with role=group and labelled by the announce label.
+  assert.ok(body.includes('data-mode="dropzone"'));
+  assert.ok(body.includes('data-dropzone-state="validating"'));
+  // File picker with the right id and accept.
+  assert.ok(body.includes('id="pkg-src-file"'));
+  assert.ok(body.includes('data-mode="upload"'));
+  assert.ok(body.includes('accept=".yaml,.yml,.json"'));
+  // State announced via role=status with aria-live=polite for validating.
+  assert.ok(body.includes('Validating source'));
+  assert.ok(body.includes('role="status"'));
+  assert.ok(body.includes('aria-live="polite"'));
+  // Safety policy footnote rendered.
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Error kinds                                                                */
+/* -------------------------------------------------------------------------- */
+
+test('PackageSourceInputPanel renders invalid-syntax + unsafe errors with role=alert and evidence', async () => {
+  const body = await renderSSR(
+    h(PackageSourceInputPanel, {
+      input: SAMPLE_INPUT_INVALID,
+      onValueChange: NOOP_VALUE_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('data-state="invalid"'));
+  assert.ok(body.includes('data-error-count="2"'));
+  assert.ok(body.includes('data-error-kind="invalid-syntax"'));
+  assert.ok(body.includes('data-error-kind="unsafe"'));
+  assert.ok(body.includes('Invalid syntax'));
+  assert.ok(body.includes('Expected top-level mapping at line 1'));
+  // Caller-supplied non-redacted evidence is rendered for invalid-syntax.
+  assert.ok(body.includes('line 1, col 1'));
+  // Both error entries carry role=alert; the alert-state announcement also
+  // does (because state=invalid is itself an alert), so total is 3.
+  assert.equal(countMatches(body, 'role="alert"'), 3);
+  // Errors specifically carry the role on `<li>` elements with data-error-kind.
+  assert.equal(countMatches(body, 'data-error-kind="invalid-syntax"'), 1);
+  assert.equal(countMatches(body, 'data-error-kind="unsafe"'), 1);
+  // The textarea aria-invalid mirrors the alert state.
+  assert.ok(body.includes('aria-invalid="true"'));
+});
+
+test('PackageSourceInputPanel renders forbidden error with role=alert + state label', async () => {
+  const body = await renderSSR(
+    h(PackageSourceInputPanel, {
+      input: SAMPLE_INPUT_FORBIDDEN,
+      onValueChange: NOOP_VALUE_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('data-state="forbidden"'));
+  assert.ok(body.includes('data-error-kind="forbidden"'));
+  assert.ok(body.includes('Forbidden'));
+  assert.ok(body.includes('Operator policy blocks this manifest for the current route.'));
+  assert.ok(body.includes('Source not allowed'));
+});
+
+test('PackageSourceInputPanel never renders caller-supplied evidence for kind=redacted', async () => {
+  const body = await renderSSR(
+    h(PackageSourceInputPanel, {
+      input: SAMPLE_INPUT_REDACTED,
+      onValueChange: NOOP_VALUE_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('data-state="redacted"'));
+  assert.ok(body.includes('data-error-kind="redacted"'));
+  assert.ok(body.includes('Manifest contains redacted content that cannot be displayed.'));
+  // Even though the fixture deliberately includes a fake secret in `evidence`,
+  // the primitive must NOT render it for kind=redacted.
+  assert.equal(
+    body.includes('AKIA-NEVER-SHOWN-1234567890'),
+    false,
+    'redacted errors must not render caller-supplied evidence',
+  );
+});
+
+/* -------------------------------------------------------------------------- */
+/* Ready state + file meta                                                    */
+/* -------------------------------------------------------------------------- */
+
+test('PackageSourceInputPanel renders ready state with file metadata', async () => {
+  const body = await renderSSR(
+    h(PackageSourceInputPanel, {
+      input: SAMPLE_INPUT_READY,
+      onValueChange: NOOP_VALUE_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('data-state="ready"'));
+  assert.ok(body.includes('data-has-file="true"'));
+  assert.ok(body.includes('Ready for server preview'));
+  assert.ok(body.includes('data-file-name="acme-agent.yaml"'));
+  assert.ok(body.includes('412 B'));
+  assert.ok(body.includes('application/yaml'));
+  assert.ok(body.includes('abc123'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Actions                                                                    */
+/* -------------------------------------------------------------------------- */
+
+test('PackageSourceInputPanel renders Clear/Replace/Copy as real keyboard-accessible buttons', async () => {
+  const body = await renderSSR(
+    h(PackageSourceInputPanel, {
+      input: SAMPLE_INPUT_PASTE,
+      onValueChange: NOOP_VALUE_CHANGE,
+    }),
+  );
+  assert.ok(body.includes('data-action="clear"'));
+  assert.ok(body.includes('data-action="replace"'));
+  assert.ok(body.includes('data-action="copy"'));
+  assert.ok(body.includes('aria-label="Clear package source"'));
+  assert.ok(body.includes('aria-label="Replace package source"'));
+  assert.ok(body.includes('aria-label="Copy package source"'));
+  assert.ok(body.includes('data-copy-value="name: acme-agent\nversion: 0.1.0\n"') || body.includes('data-copy-value="name: acme-agent') /* paranoid match */);
+  assert.equal(countMatches(body, '<button type="button"'), 3);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Determinism                                                                */
+/* -------------------------------------------------------------------------- */
+
+test('PackageSourceInputPanel produces byte-identical SSR output for the same input', async () => {
+  const first = await renderSSR(
+    h(PackageSourceInputPanel, { input: SAMPLE_INPUT_PASTE, onValueChange: NOOP_VALUE_CHANGE }),
+  );
+  const second = await renderSSR(
+    h(PackageSourceInputPanel, { input: SAMPLE_INPUT_PASTE, onValueChange: NOOP_VALUE_CHANGE }),
+  );
+  assert.equal(first, second, 'PackageSourceInputPanel must be deterministic');
+});
+
+/* -------------------------------------------------------------------------- */
+/* Standalone CodeDropzone                                                    */
+/* -------------------------------------------------------------------------- */
+
+test('CodeDropzone renders state-labeled dropzone with file metadata and errors', async () => {
+  const dropzone: CodeDropzoneProps = {
+    dropzoneId: 'drop-1',
+    label: 'Drop a package',
+    description: 'TheoryMCP parses and validates server-side.',
+    state: 'validating',
+    fileMeta: { name: 'acme-agent.yaml', sizeBytes: 412 },
+    safetyPolicy: 'no-secret-or-production-like-data',
+    errors: [{ id: 'e1', kind: 'invalid-syntax', message: 'Manifest tail not closed' }],
+  };
+  const body = await renderSSR(h(CodeDropzone, { dropzone }));
+  assert.ok(body.includes('facetheory-stitch-code-dropzone'));
+  assert.ok(body.includes('data-dropzone-id="drop-1"'));
+  assert.ok(body.includes('data-state="validating"'));
+  assert.ok(body.includes('Validating source'));
+  assert.ok(body.includes('data-file-name="acme-agent.yaml"'));
+  assert.ok(body.includes('data-error-kind="invalid-syntax"'));
+  assert.ok(body.includes('Manifest tail not closed'));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Fixture safety guard                                                       */
+/* -------------------------------------------------------------------------- */
+
+test('PackageSourceInputPanel fixtures contain no AWS keys or other production-like secrets in displayed surfaces', () => {
+  // The intentional fake-secret in SAMPLE_INPUT_REDACTED.evidence is the test's
+  // way of proving the primitive does NOT render redacted evidence. It must
+  // never be rendered into the DOM (verified by the redacted-evidence test).
+  // Confirm no OTHER fixture serialization contains AWS keys / api_key= /
+  // BEGIN PRIVATE KEY / Authorization: in displayed surfaces.
+  for (const input of [SAMPLE_INPUT_PASTE, SAMPLE_INPUT_INVALID, SAMPLE_INPUT_FORBIDDEN, SAMPLE_INPUT_READY]) {
+    const serialized = JSON.stringify(input);
+    const forbidden = ['AKIA', 'aws_secret', 'BEGIN PRIVATE KEY', 'Authorization:', 'api_key='];
+    for (const needle of forbidden) {
+      assert.equal(
+        serialized.includes(needle),
+        false,
+        `fixture "${input.groupId}" must not include "${needle}"`,
+      );
+    }
+  }
+});

--- a/ts/test/unit/stitch-admin-package-source-input.test.ts
+++ b/ts/test/unit/stitch-admin-package-source-input.test.ts
@@ -184,6 +184,59 @@ test('PackageSourceInputPanel renders forbidden error with role=alert + state la
   assert.ok(body.includes('Source not allowed'));
 });
 
+test('PackageSourceInputPanel only renders evidence for kind=invalid-syntax; forbidden/unsafe/other evidence is suppressed', async () => {
+  const input: PackageSourceInput = {
+    groupId: 'pkg-mixed',
+    value: '',
+    state: 'invalid',
+    errors: [
+      // Safe parse-location evidence — must still render.
+      {
+        id: 'syntax-1',
+        kind: 'invalid-syntax',
+        message: 'Expected top-level mapping at line 1',
+        evidence: 'line 1, col 1',
+      },
+      // Host accidentally puts a fake AWS-shaped secret into forbidden.evidence.
+      {
+        id: 'forbidden-1',
+        kind: 'forbidden',
+        message: 'Operator policy blocks this manifest.',
+        evidence: 'AKIA-FAKE-FORBIDDEN-EVIDENCE-1234567890',
+      },
+      // Host accidentally puts a fake secret into unsafe.evidence.
+      {
+        id: 'unsafe-1',
+        kind: 'unsafe',
+        message: 'Manifest references an unsupported scheme.',
+        evidence: 'AKIA-FAKE-UNSAFE-EVIDENCE-1234567890',
+      },
+      // Host accidentally puts a fake secret into other.evidence.
+      {
+        id: 'other-1',
+        kind: 'other',
+        message: 'Validation could not complete.',
+        evidence: 'AKIA-FAKE-OTHER-EVIDENCE-1234567890',
+      },
+    ],
+    modes: ['paste'],
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(
+    h(PackageSourceInputPanel, { input, onValueChange: NOOP_VALUE_CHANGE }),
+  );
+  // invalid-syntax evidence renders verbatim (parse-location).
+  assert.ok(body.includes('line 1, col 1'));
+  // forbidden / unsafe / other evidence is suppressed across the board.
+  assert.equal(body.includes('AKIA-FAKE-FORBIDDEN-EVIDENCE-1234567890'), false);
+  assert.equal(body.includes('AKIA-FAKE-UNSAFE-EVIDENCE-1234567890'), false);
+  assert.equal(body.includes('AKIA-FAKE-OTHER-EVIDENCE-1234567890'), false);
+  // Messages still render for the sensitive kinds.
+  assert.ok(body.includes('Operator policy blocks this manifest.'));
+  assert.ok(body.includes('Manifest references an unsupported scheme.'));
+  assert.ok(body.includes('Validation could not complete.'));
+});
+
 test('PackageSourceInputPanel never renders caller-supplied evidence for kind=redacted', async () => {
   const body = await renderSSR(
     h(PackageSourceInputPanel, {

--- a/ts/test/unit/svelte-stitch-admin.test.ts
+++ b/ts/test/unit/svelte-stitch-admin.test.ts
@@ -937,3 +937,80 @@ test('svelte ChoiceCard renders standalone card with selection family + safety p
   assert.ok(body.includes('data-option-recommended="true"'));
   assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
 });
+
+test('svelte package-source-input: renders paste/dropzone/upload with stable data attrs', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/PackageSourceInputPanel.svelte'),
+    {
+      input: {
+        groupId: 'pkg-src',
+        value: 'name: acme\n',
+        state: 'validating',
+        errors: [],
+        modes: ['paste', 'dropzone', 'upload'],
+        label: 'Package source',
+        description: 'TheoryMCP validates server-side.',
+        fileAccept: '.yaml,.yml,.json',
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+      onValueChange: (): void => {},
+      onFiles: (): void => {},
+    },
+  );
+  assert.ok(body.includes('facetheory-stitch-package-source-input'));
+  assert.ok(body.includes('data-state="validating"'));
+  assert.ok(body.includes('data-modes="paste dropzone upload"'));
+  assert.ok(body.includes('id="pkg-src-paste"'));
+  assert.ok(body.includes('data-mode="dropzone"'));
+  assert.ok(body.includes('accept=".yaml,.yml,.json"'));
+  assert.ok(body.includes('Validating source'));
+  assert.ok(body.includes('role="status"'));
+});
+
+test('svelte package-source-input: never renders caller-supplied evidence for kind=redacted', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/PackageSourceInputPanel.svelte'),
+    {
+      input: {
+        groupId: 'pkg-red',
+        value: '',
+        state: 'redacted',
+        errors: [
+          {
+            id: 'red-1',
+            kind: 'redacted',
+            message: 'Manifest contains redacted content.',
+            evidence: 'AKIA-NEVER-SHOWN-SVELTE-1234567890',
+          },
+        ],
+        modes: ['paste'],
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+      onValueChange: (): void => {},
+    },
+  );
+  assert.ok(body.includes('data-state="redacted"'));
+  assert.ok(body.includes('data-error-kind="redacted"'));
+  assert.ok(body.includes('Manifest contains redacted content.'));
+  assert.equal(body.includes('AKIA-NEVER-SHOWN-SVELTE-1234567890'), false);
+});
+
+test('svelte code-dropzone: renders state-labeled dropzone with file metadata', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/CodeDropzone.svelte'),
+    {
+      dropzone: {
+        dropzoneId: 'drop-svelte',
+        label: 'Drop a package',
+        state: 'ready',
+        fileMeta: { name: 'acme.yaml', sizeBytes: 412 },
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+    },
+  );
+  assert.ok(body.includes('facetheory-stitch-code-dropzone'));
+  assert.ok(body.includes('data-dropzone-id="drop-svelte"'));
+  assert.ok(body.includes('data-state="ready"'));
+  assert.ok(body.includes('Ready for server preview'));
+  assert.ok(body.includes('data-file-name="acme.yaml"'));
+});

--- a/ts/test/unit/svelte-stitch-admin.test.ts
+++ b/ts/test/unit/svelte-stitch-admin.test.ts
@@ -1014,3 +1014,59 @@ test('svelte code-dropzone: renders state-labeled dropzone with file metadata', 
   assert.ok(body.includes('Ready for server preview'));
   assert.ok(body.includes('data-file-name="acme.yaml"'));
 });
+
+test('svelte package-source-input: only invalid-syntax renders evidence; forbidden/unsafe/other suppressed', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/PackageSourceInputPanel.svelte'),
+    {
+      input: {
+        groupId: 'pkg-mixed-svelte',
+        value: '',
+        state: 'invalid',
+        errors: [
+          { id: 'syntax-1', kind: 'invalid-syntax', message: 'Expected top-level mapping at line 1', evidence: 'line 1, col 1' },
+          { id: 'forbidden-1', kind: 'forbidden', message: 'Operator policy blocks this manifest.', evidence: 'AKIA-SVELTE-FORBIDDEN-EVIDENCE-1234567890' },
+          { id: 'unsafe-1', kind: 'unsafe', message: 'Manifest references an unsupported scheme.', evidence: 'AKIA-SVELTE-UNSAFE-EVIDENCE-1234567890' },
+          { id: 'other-1', kind: 'other', message: 'Validation could not complete.', evidence: 'AKIA-SVELTE-OTHER-EVIDENCE-1234567890' },
+        ],
+        modes: ['paste'],
+        safetyPolicy: 'no-secret-or-production-like-data',
+      },
+      onValueChange: (): void => {},
+    },
+  );
+  assert.ok(body.includes('line 1, col 1'));
+  assert.equal(body.includes('AKIA-SVELTE-FORBIDDEN-EVIDENCE-1234567890'), false);
+  assert.equal(body.includes('AKIA-SVELTE-UNSAFE-EVIDENCE-1234567890'), false);
+  assert.equal(body.includes('AKIA-SVELTE-OTHER-EVIDENCE-1234567890'), false);
+  assert.ok(body.includes('Operator policy blocks this manifest.'));
+  assert.ok(body.includes('Manifest references an unsupported scheme.'));
+  assert.ok(body.includes('Validation could not complete.'));
+});
+
+test('svelte code-dropzone: only invalid-syntax renders evidence; forbidden/unsafe/other suppressed', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/CodeDropzone.svelte'),
+    {
+      dropzone: {
+        dropzoneId: 'drop-mixed-svelte',
+        label: 'Drop a package',
+        state: 'invalid',
+        safetyPolicy: 'no-secret-or-production-like-data',
+        errors: [
+          { id: 'syntax-1', kind: 'invalid-syntax', message: 'Expected top-level mapping at line 1', evidence: 'line 1, col 1' },
+          { id: 'forbidden-1', kind: 'forbidden', message: 'Policy blocks.', evidence: 'AKIA-SVELTE-DZ-FORBIDDEN-EVIDENCE-1234567890' },
+          { id: 'unsafe-1', kind: 'unsafe', message: 'Unsupported scheme.', evidence: 'AKIA-SVELTE-DZ-UNSAFE-EVIDENCE-1234567890' },
+          { id: 'other-1', kind: 'other', message: 'Validation could not complete.', evidence: 'AKIA-SVELTE-DZ-OTHER-EVIDENCE-1234567890' },
+        ],
+      },
+    },
+  );
+  assert.ok(body.includes('line 1, col 1'));
+  assert.equal(body.includes('AKIA-SVELTE-DZ-FORBIDDEN-EVIDENCE-1234567890'), false);
+  assert.equal(body.includes('AKIA-SVELTE-DZ-UNSAFE-EVIDENCE-1234567890'), false);
+  assert.equal(body.includes('AKIA-SVELTE-DZ-OTHER-EVIDENCE-1234567890'), false);
+  assert.ok(body.includes('Policy blocks.'));
+  assert.ok(body.includes('Unsupported scheme.'));
+  assert.ok(body.includes('Validation could not complete.'));
+});

--- a/ts/test/unit/vue-stitch-admin.test.ts
+++ b/ts/test/unit/vue-stitch-admin.test.ts
@@ -1120,3 +1120,92 @@ test('vue ChoiceCard renders standalone card with selection family + safety poli
   assert.ok(body.includes('data-option-recommended="true"'));
   assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
 });
+
+import {
+  PackageSourceInputPanel as VuePackageSourceInputPanel,
+  CodeDropzone as VueCodeDropzone,
+} from '../../src/vue/stitch-admin/index.js';
+import type {
+  CodeDropzoneProps as VueCodeDropzoneProps,
+  PackageSourceInput as VuePackageSourceInput,
+} from '../../src/stitch-admin/index.js';
+
+test('vue package-source-input: renders paste/dropzone/upload modes with stable data attrs', async () => {
+  const input: VuePackageSourceInput = {
+    groupId: 'pkg-src',
+    value: 'name: acme\n',
+    state: 'validating',
+    errors: [],
+    modes: ['paste', 'dropzone', 'upload'],
+    label: 'Package source',
+    description: 'TheoryMCP validates server-side.',
+    fileAccept: '.yaml,.yml,.json',
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(
+    h(VuePackageSourceInputPanel, { input, onValueChange: () => {}, onFiles: () => {} }),
+  );
+  assert.ok(body.includes('facetheory-stitch-package-source-input'));
+  assert.ok(body.includes('data-state="validating"'));
+  assert.ok(body.includes('data-modes="paste dropzone upload"'));
+  assert.ok(body.includes('id="pkg-src-paste"'));
+  assert.ok(body.includes('data-mode="paste"'));
+  assert.ok(body.includes('data-mode="dropzone"'));
+  assert.ok(body.includes('data-mode="upload"'));
+  assert.ok(body.includes('accept=".yaml,.yml,.json"'));
+  assert.ok(body.includes('Validating source'));
+  assert.ok(body.includes('role="status"'));
+});
+
+test('vue package-source-input: renders forbidden + redacted error kinds, never raw secret evidence', async () => {
+  const input: VuePackageSourceInput = {
+    groupId: 'pkg-redacted',
+    value: '',
+    state: 'redacted',
+    errors: [
+      {
+        id: 'red-1',
+        kind: 'redacted',
+        message: 'Manifest contains redacted content.',
+        evidence: 'AKIA-NEVER-SHOWN-VUE-1234567890',
+      },
+    ],
+    modes: ['paste'],
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }));
+  assert.ok(body.includes('data-state="redacted"'));
+  assert.ok(body.includes('data-error-kind="redacted"'));
+  assert.ok(body.includes('Manifest contains redacted content.'));
+  assert.equal(body.includes('AKIA-NEVER-SHOWN-VUE-1234567890'), false);
+});
+
+test('vue package-source-input: byte-identical SSR for same input', async () => {
+  const input: VuePackageSourceInput = {
+    groupId: 'pkg-det',
+    value: 'x',
+    state: 'idle',
+    errors: [],
+    modes: ['paste'],
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const first = await renderSSR(h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }));
+  const second = await renderSSR(h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }));
+  assert.equal(first, second);
+});
+
+test('vue code-dropzone: renders state-labeled dropzone with file metadata', async () => {
+  const dropzone: VueCodeDropzoneProps = {
+    dropzoneId: 'drop-vue',
+    label: 'Drop a package',
+    state: 'ready',
+    fileMeta: { name: 'acme.yaml', sizeBytes: 412 },
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(h(VueCodeDropzone, { dropzone }));
+  assert.ok(body.includes('facetheory-stitch-code-dropzone'));
+  assert.ok(body.includes('data-dropzone-id="drop-vue"'));
+  assert.ok(body.includes('data-state="ready"'));
+  assert.ok(body.includes('Ready for server preview'));
+  assert.ok(body.includes('data-file-name="acme.yaml"'));
+});

--- a/ts/test/unit/vue-stitch-admin.test.ts
+++ b/ts/test/unit/vue-stitch-admin.test.ts
@@ -1209,3 +1209,27 @@ test('vue code-dropzone: renders state-labeled dropzone with file metadata', asy
   assert.ok(body.includes('Ready for server preview'));
   assert.ok(body.includes('data-file-name="acme.yaml"'));
 });
+
+test('vue package-source-input: only invalid-syntax renders evidence; forbidden/unsafe/other suppressed', async () => {
+  const input: VuePackageSourceInput = {
+    groupId: 'pkg-mixed-vue',
+    value: '',
+    state: 'invalid',
+    errors: [
+      { id: 'syntax-1', kind: 'invalid-syntax', message: 'Expected top-level mapping at line 1', evidence: 'line 1, col 1' },
+      { id: 'forbidden-1', kind: 'forbidden', message: 'Operator policy blocks this manifest.', evidence: 'AKIA-VUE-FORBIDDEN-EVIDENCE-1234567890' },
+      { id: 'unsafe-1', kind: 'unsafe', message: 'Manifest references an unsupported scheme.', evidence: 'AKIA-VUE-UNSAFE-EVIDENCE-1234567890' },
+      { id: 'other-1', kind: 'other', message: 'Validation could not complete.', evidence: 'AKIA-VUE-OTHER-EVIDENCE-1234567890' },
+    ],
+    modes: ['paste'],
+    safetyPolicy: 'no-secret-or-production-like-data',
+  };
+  const body = await renderSSR(h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }));
+  assert.ok(body.includes('line 1, col 1'));
+  assert.equal(body.includes('AKIA-VUE-FORBIDDEN-EVIDENCE-1234567890'), false);
+  assert.equal(body.includes('AKIA-VUE-UNSAFE-EVIDENCE-1234567890'), false);
+  assert.equal(body.includes('AKIA-VUE-OTHER-EVIDENCE-1234567890'), false);
+  assert.ok(body.includes('Operator policy blocks this manifest.'));
+  assert.ok(body.includes('Manifest references an unsupported scheme.'));
+  assert.ok(body.includes('Validation could not complete.'));
+});


### PR DESCRIPTION
## Milestone

Factory assignment **THE-1455 / APW-FT6** — PackageSourceInput + CodeDropzone with React + Vue + Svelte parity from the start.

- Linear issue: THE-1455 — APW-FT6: Request FaceTheory PackageSourceInput / CodeDropzone
- PR target: `project/theorymcp-agent-import-completion-wizard-20260521` (NOT `staging`)
- Project branch base: `8beb7217d6ae8869ad1914b1cf57146534543138` (THE-1454 / PR #221 merge)
- Milestone branch: `facetheory/agent-import-wizard-package-source-input`
- Head commit: `4218aa9ef73ba9ce2f8869d91882dab2dad936ad` (signed)
  - `bf6e60a` — `feat(stitch-admin): add PackageSourceInput + CodeDropzone with React+Vue+Svelte parity`
  - `b6ae612` — `fix(stitch-admin): only invalid-syntax renders evidence; suppress forbidden/redacted/unsafe/other`
  - `984b89c` — `docs(stitch-admin): align package-source trust-boundary comment with implemented rule`
  - `4218aa9` — `fix(stitch-admin): add stable keys inside React renderFileMeta dt/dd pairs` (clears React key warnings)

## What changed

The "where does the package come from" wizard surface for the TheoryMCP Agent Import & Completion Wizard. `PackageSourceInputPanel` supports any subset of three input modes (paste, dropzone, upload), a 7-state presentational state machine, and a per-error display contract. `CodeDropzone` is the lower-level drop-target primitive. Ships with React + Vue + Svelte parity from the start.

### Trust boundary (load-bearing)

- Presentation-only. FaceTheory does **not** parse package bodies, validate syntax, scan for secrets, check entitlements, or check GitHub / email policy.
- theory-mcp-server remains authoritative server-side before preview / apply.
- **Error evidence policy (allow-list rule):** the primitive renders `error.evidence` **only** when `kind === 'invalid-syntax'` (safe parse-location details such as line / column / offset). Every other kind (`forbidden`, `redacted`, `unsafe`, `other`) suppresses caller-supplied `evidence` and renders only the human-readable `message`. FaceTheory still does NOT parse, validate, scan, classify, authorize, or clean secrets by inspection — the rule is a presentation safety net, not a redaction service. Five dedicated parity tests (one per adapter surface plus the Svelte CodeDropzone surface) stuff AKIA-shaped fake secrets into the sensitive kinds' `evidence` and assert they never reach the DOM.
- The primitive never holds a real `File` object across renders. `input.fileMeta` is caller-supplied SSR-safe metadata.
- AWS dependency boundary preserved: the documented narrow AWS CDK bundled `brace-expansion` exception is unchanged.

### State machine → role markers

| State        | Role marker     | Meaning                                          |
| ------------ | --------------- | ------------------------------------------------ |
| `idle`       | (none)          | Awaiting source.                                 |
| `loading`    | `role="status"` | Source is being loaded.                          |
| `validating` | `role="status"` | Source is being validated server-side.           |
| `ready`      | `role="status"` | Ready for server preview.                        |
| `invalid`    | `role="alert"`  | Source failed validation.                        |
| `forbidden`  | `role="alert"`  | Policy blocks this source.                       |
| `redacted`   | `role="alert"`  | Source contains redacted content.                |

### Framework-neutral types (`ts/src/stitch-admin/package-source-input-types.ts`)

- `PackageSourceInputMode = 'paste' | 'upload' | 'dropzone'`
- `PackageSourceInputState` (7-state machine, see above)
- `PackageSourceInputErrorKind = 'invalid-syntax' | 'forbidden' | 'redacted' | 'unsafe' | 'other'`
- `PackageSourceInputError { id, kind, message, evidence? }` — `evidence` is rendered verbatim **only** when `kind === 'invalid-syntax'`.
- `PackageSourceInputFileMeta { name, sizeBytes?, mediaType?, sha256? }`
- `PackageSourceInputActions { clear?, replace?, copy?, copyValue? }`
- `PackageSourceInput` envelope + `CodeDropzoneProps` for standalone use.

### Adapters

- React (`ts/src/react/stitch-admin/package-source-input.ts`): real `<textarea>`, real `<input type="file">`, real `<button type="button">`s, `role="group"` dropzone `<div>` with `tabindex="0"` and text `aria-label`.
- Vue (`ts/src/vue/stitch-admin/package-source-input.ts`): same DOM via `defineComponent + h`.
- Svelte (`ts/src/svelte/stitch-admin/PackageSourceInputPanel.svelte` + `CodeDropzone.svelte`): same DOM via Svelte SSR.

### Explicit React / Vue / Svelte parity summary

| Surface                                                                | React | Vue | Svelte |
| ---------------------------------------------------------------------- | :---: | :-: | :----: |
| `PackageSourceInputPanel`                                              | ✅    | ✅  | ✅      |
| `CodeDropzone`                                                         | ✅    | ✅  | ✅      |
| Paste mode (`<textarea>`)                                              | ✅    | ✅  | ✅      |
| Dropzone mode (`role="group" + tabindex="0"`)                          | ✅    | ✅  | ✅      |
| Upload mode (`<input type="file">`)                                    | ✅    | ✅  | ✅      |
| State machine → role markers                                           | ✅    | ✅  | ✅      |
| Errors render with `role="alert"` + aria-live                          | ✅    | ✅  | ✅      |
| **Only `invalid-syntax` renders evidence; other kinds suppress**       | ✅    | ✅  | ✅      |
| Sensitive-kind evidence suppression covered by AKIA-shaped fixture tests | ✅  | ✅  | ✅      |
| Real keyboard-accessible Clear/Replace/Copy buttons                    | ✅    | ✅  | ✅      |
| `aria-invalid` on textarea for alert states                            | ✅    | ✅  | ✅      |
| Safety-policy footnote                                                 | ✅    | ✅  | ✅      |
| **React key warnings cleared** (Factory reproducer: 0 matches)         | ✅    | n/a | n/a    |

### Tests

- `ts/test/unit/stitch-admin-package-source-input.test.ts` (React, **10 tests**): paste/dropzone/upload mode rendering with stable data attrs, invalid-syntax + unsafe errors with `role="alert"` and visible evidence, forbidden error, **only `invalid-syntax` renders evidence; forbidden/unsafe/other suppress AKIA-shaped fake-secret evidence**, kind=redacted suppresses evidence, ready state with file metadata, real keyboard-accessible Clear/Replace/Copy buttons, byte-identical SSR determinism, standalone CodeDropzone state-labeled rendering, fixture safety guard.
- `ts/test/unit/vue-stitch-admin.test.ts` — **+5 Vue parity tests** covering the same surfaces, including a Vue-specific AKIA-shaped sensitive-kind evidence-suppression test.
- `ts/test/unit/svelte-stitch-admin.test.ts` — **+5 Svelte parity tests** covering the same surfaces, including separate Svelte-specific AKIA-shaped sensitive-kind evidence-suppression tests for both the panel and the standalone `CodeDropzone`.
- `npm test` now reports **441 tests / 440 pass / 1 skip** (was 421 / 420 / 1 skip on the base; +20 from this milestone across React/Vue/Svelte).

### Docs (`docs/wizard-primitives.md`)

- Primitives table updated.
- "Package source input / code dropzone" section restated to express the allow-list rule: **only `invalid-syntax` errors render `evidence`**; the other four kinds suppress.

## Validation

Run from the repo root against PR head `4218aa9ef73ba9ce2f8869d91882dab2dad936ad`.

- `git diff --check origin/project/theorymcp-agent-import-completion-wizard-20260521...HEAD` — clean
- `scripts/verify-version-alignment.sh` → `version-alignment: PASS (3.2.1)`
- `cd ts && npm ci` — clean
- `cd ts && npm run typecheck` — pass
- `cd ts && npm run lint` — pass
- `cd ts && npm test` → **`tests 441 / pass 440 / fail 0 / skipped 1`**
- `cd ts && npm run build` — pass
- `scripts/verify-npm-audit.sh`:
  - `npm-audit: PASS (ts)`
  - `npm-audit: ALLOW (infra/apptheory-ssr-site) brace-expansion via bundled aws-cdk-lib tarball; no custom CDK tarball is maintained`
  - `npm-audit: ALLOW (infra/apptheory-ssg-isr-site) brace-expansion via bundled aws-cdk-lib tarball; no custom CDK tarball is maintained`
- `make rubric` — **exits 0**.
- `scripts/pack-dev-archive.sh --skip-build --output-dir /tmp/theorycloud-facetheory-dev-archives` — archive + sidecar produced.
- `( cd /tmp/theorycloud-facetheory-dev-archives && sha256sum --check theory-cloud-facetheory-3.2.1-dev-4218aa9ef73b.tgz.sha256 )` → `theory-cloud-facetheory-3.2.1-dev-4218aa9ef73b.tgz: OK`

### React key-warning confirmation (Factory's exact reproducer)

```bash
cd ts
npx tsx test/unit/stitch-admin-package-source-input.test.ts > /tmp/factory-review-facetheory-pr222-target-react-test.log 2>&1
grep -n 'Each child in a list should have a unique "key" prop\|Check the render method of' /tmp/factory-review-facetheory-pr222-target-react-test.log
```

→ 0 matches. `grep` exits 1 (no lines found). Full `npm test` stderr is also clean of these warnings.

## Temporary local archive handoff

- Command: `scripts/pack-dev-archive.sh --output-dir /tmp/theorycloud-facetheory-dev-archives`
- Archive basename (from PR head `4218aa9`): `theory-cloud-facetheory-3.2.1-dev-4218aa9ef73b.tgz`
- sha256: `3979da34ffbe03ea4549e70cd1b8c2b9c3f82f5b96a1213518e5f68f55aa5322`
- Verify (works from any cwd):
  ```bash
  ( cd /tmp/theorycloud-facetheory-dev-archives \
      && sha256sum --check theory-cloud-facetheory-3.2.1-dev-4218aa9ef73b.tgz.sha256 )
  ```
- Content sha **changes** from the earlier packs in this PR because the `4218aa9` React key fix is shipped through `dist/`: the React adapter's `renderFileMeta()` now emits the updated `h(...)` call pattern (positional children with explicit `key: 'dt'` / `key: 'dd'` instead of an inner unkeyed array). The Vue and Svelte builds in `dist/` are unchanged. TheoryMCP consumers re-pulling the dev archive will pick up the warning-free React build.

## Safety / scope confirmation

- No npm release / publish / GitHub Release / release-asset workflow / tag / version bump / staging-or-main promotion.
- No AWS / cloud / IAM / DNS / cert / account / deploy / smoke / canary.
- No AWS dependency repackaging; the documented narrow AWS CDK bundled `brace-expansion` exception boundary is intact.
- No theory-mcp-server implementation.
- No cross-repo contract change beyond documenting the FaceTheory component surface.
- No secrets, credentials, live receipts, raw package bodies, customer data, or production-like confidential fixtures.
- No sibling repo edits, parent Factory repo edits, or framework changes.
- No git worktrees; normal checkout only.
- No PR to staging.
- Did NOT start THE-1456 / FT7.

## Residual risks / blockers

- None. `make rubric` exits 0. The evidence-suppression rule is uniform across all four surfaces (React + Vue + Svelte `PackageSourceInputPanel` + Svelte `CodeDropzone`): **only `invalid-syntax` evidence renders; every other kind suppresses**. Five dedicated parity tests (one per adapter surface plus the Svelte CodeDropzone surface) prove the rule with AKIA-shaped fake-secret evidence fixtures. React key warnings are cleared (Factory's exact reproducer returns 0 matches). The documented narrow AWS CDK bundled transitive allowlist is intact.

## Files

Shared types:
- `ts/src/stitch-admin/package-source-input-types.ts` (new) — defines the allow-list rule on `PackageSourceInputError.evidence` and re-states the trust boundary at the top of the file.
- `ts/src/stitch-admin/index.ts` (re-exports)

React adapter:
- `ts/src/react/stitch-admin/package-source-input.ts` (new — `PackageSourceInputPanel` + `CodeDropzone`; evidence gated on `error.kind === 'invalid-syntax'`; `renderFileMeta()` uses positional keyed dt/dd children)
- `ts/src/react/stitch-admin/index.ts` (re-exports)

Vue adapter:
- `ts/src/vue/stitch-admin/package-source-input.ts` (new; same evidence gate as React)
- `ts/src/vue/stitch-admin/index.ts` (re-exports)

Svelte adapter:
- `ts/src/svelte/stitch-admin/PackageSourceInputPanel.svelte` (new; same evidence gate)
- `ts/src/svelte/stitch-admin/CodeDropzone.svelte` (new; same evidence gate)
- `ts/src/svelte/stitch-admin/index.ts` (re-exports + alias re-exports)
- `ts/src/svelte/stitch-admin/index.d.ts` (Component declarations + prop interfaces)
- `ts/src/svelte/stitch-admin/types.ts` (shared type re-exports + panel-props)

Tests:
- `ts/test/unit/stitch-admin-package-source-input.test.ts` (new, 10 React tests including the sensitive-kind evidence-suppression test)
- `ts/test/unit/vue-stitch-admin.test.ts` (+5 Vue parity tests including the sensitive-kind evidence-suppression test)
- `ts/test/unit/svelte-stitch-admin.test.ts` (+5 Svelte parity tests including separate sensitive-kind evidence-suppression tests for the panel and the standalone CodeDropzone)
- `ts/test/run-unit.ts` (register the new React test file)

Docs:
- `docs/wizard-primitives.md` (primitives table + PackageSourceInput section: trust boundary, state machine, accessibility, evidence allow-list rule, worked TheoryMCP example)

Refs: THE-1455 (APW-FT6).