### PR TITLE
feat(stitch-admin): AuditTrailPanel + DisclosurePanel with React+Vue+Svelte parity (THE-1456)

### DIFF
--- a/docs/wizard-primitives.md
+++ b/docs/wizard-primitives.md
@@ -20,10 +20,10 @@ shape.
 
 The contract is deliberately **presentational**:
 
-- FaceTheory *displays* host-supplied data.
-- FaceTheory *does not* validate TheoryMCP routes, sessions, entitlements,
+- FaceTheory _displays_ host-supplied data.
+- FaceTheory _does not_ validate TheoryMCP routes, sessions, entitlements,
   GitHub bindings, mailbox bindings, capability decisions, or secrets.
-- FaceTheory *does not* parse, fetch, hash, or open archives, packages, or
+- FaceTheory _does not_ parse, fetch, hash, or open archives, packages, or
   evidence files. Hosts pre-compute those values.
 
 Every primitive renders the same DOM for the same input across server-side
@@ -33,12 +33,12 @@ primitive twice and asserting byte-identical SSR output.
 
 ## Where the primitives live
 
-| Layer | Module | What it exports |
-| --- | --- | --- |
-| Framework-neutral types | `@theory-cloud/facetheory/stitch-admin` | `WizardProgressState`, `WizardPackageSummary`, `WizardFindingList`, `WizardReconcileSummary`, `WizardReconciliationPlan`, `WizardAuthorityContextStrip`, `WizardCapabilityReview`, `WizardEnablementChecklist`, `WizardRecoveryStatus`, `WizardEmptyStateConfig`, `WizardEditableTokenInput`, `WizardSafetyPolicy`, and supporting enums and aliases. |
-| React adapter | `@theory-cloud/facetheory/react/stitch-admin` | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`), `SelectableCardGridPanel`, `ChoiceCard`, `PackageSourceInputPanel`, `CodeDropzone`, `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
-| Vue adapter | `@theory-cloud/facetheory/vue/stitch-admin` | Same primitive set as React, including `SelectableCardGridPanel` and `ChoiceCard`. |
-| Svelte adapter | `@theory-cloud/facetheory/svelte/stitch-admin` | Same primitive set, exposed as `.svelte` components with matching component-prop interfaces. |
+| Layer                   | Module                                         | What it exports                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Framework-neutral types | `@theory-cloud/facetheory/stitch-admin`        | `WizardProgressState`, `WizardPackageSummary`, `WizardFindingList`, `WizardReconcileSummary`, `WizardReconciliationPlan`, `WizardAuthorityContextStrip`, `WizardCapabilityReview`, `WizardEnablementChecklist`, `WizardRecoveryStatus`, `WizardEmptyStateConfig`, `WizardEditableTokenInput`, `WizardSafetyPolicy`, and supporting enums and aliases.                                                                                                                                                                         |
+| React adapter           | `@theory-cloud/facetheory/react/stitch-admin`  | `WizardProgress`, `WizardPackageSummaryPanel`, `WizardFindingListPanel`, `WizardReconcileSummaryPanel`, `WizardReconciliationPlanPanel` (alias `WizardDiffListPanel`), `WizardAuthorityContextStripPanel` (alias `WizardServerResolvedContextBarPanel`), `WizardEditableTokenInputPanel` (alias `WizardChipListPanel`), `SelectableCardGridPanel`, `ChoiceCard`, `PackageSourceInputPanel`, `CodeDropzone`, `WizardCapabilityReviewPanel`, `WizardEnablementChecklistPanel`, `WizardRecoveryStatusPanel`, `WizardEmptyState`. |
+| Vue adapter             | `@theory-cloud/facetheory/vue/stitch-admin`    | Same primitive set as React, including `SelectableCardGridPanel` and `ChoiceCard`.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| Svelte adapter          | `@theory-cloud/facetheory/svelte/stitch-admin` | Same primitive set, exposed as `.svelte` components with matching component-prop interfaces.                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 
 ### Adapter parity status
 
@@ -63,7 +63,7 @@ Every primitive that could otherwise leak production-looking or secret-like
 data carries an explicit `WizardSafetyPolicy` literal:
 
 ```ts
-type WizardSafetyPolicy = 'no-secret-or-production-like-data';
+type WizardSafetyPolicy = "no-secret-or-production-like-data";
 ```
 
 - The host **passes the literal in** to confirm the contract.
@@ -74,7 +74,7 @@ type WizardSafetyPolicy = 'no-secret-or-production-like-data';
   surfaces the assertion.
 
 `WizardReconcileEntry` and `WizardCapability` have additional redaction levers
-the primitive *does* enforce at render time:
+the primitive _does_ enforce at render time:
 
 - `WizardReconcileEntry.redacted: true` or `kind: 'redacted'` → the entry's
   detail is replaced with `[redacted]`.
@@ -99,15 +99,15 @@ These two primitives describe different things and live side by side:
   the **plan** the host intends to execute next, with the richer operation
   kinds:
 
-  | Canonical kind | Stable alias              | Meaning                                                 |
-  | -------------- | ------------------------- | ------------------------------------------------------- |
-  | `create`       | —                         | Will create a new resource                              |
-  | `update`       | —                         | Will update an existing resource                        |
-  | `satisfied`    | `already_satisfied`       | Desired state already matches; no work                  |
-  | `conflict`     | —                         | Incompatible with another row or external state         |
-  | `blocked`      | —                         | Cannot proceed; the host explains why in `reason`       |
-  | `external`     | `external_step_required`  | Will be completed outside this wizard                   |
-  | `noop`         | `not_requested`           | Explicitly requested as a no-op                         |
+  | Canonical kind | Stable alias             | Meaning                                           |
+  | -------------- | ------------------------ | ------------------------------------------------- |
+  | `create`       | —                        | Will create a new resource                        |
+  | `update`       | —                        | Will update an existing resource                  |
+  | `satisfied`    | `already_satisfied`      | Desired state already matches; no work            |
+  | `conflict`     | —                        | Incompatible with another row or external state   |
+  | `blocked`      | —                        | Cannot proceed; the host explains why in `reason` |
+  | `external`     | `external_step_required` | Will be completed outside this wizard             |
+  | `noop`         | `not_requested`          | Explicitly requested as a no-op                   |
 
   Aliases are accepted on input and normalized to the canonical kind at
   render time. The canonical kind appears in `data-row-kind`; the original
@@ -183,7 +183,7 @@ interface WizardAuthorityContextItem {
   value: unknown;
   icon?: unknown;
   badge?: unknown;
-  tone?: 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+  tone?: "neutral" | "info" | "success" | "warning" | "danger";
   copyable?: boolean;
   copyValue?: string;
   title?: string;
@@ -199,12 +199,12 @@ pairing, and `href` is filtered through the Stitch admin safe-href filter
 
 `layout` controls how items are arranged:
 
-| Value    | Behavior                                                                                            |
-| -------- | --------------------------------------------------------------------------------------------------- |
-| `strip`  | Single horizontal row. `wrap` controls whether items wrap (`true`, default) or scroll (`false`).    |
-| `grid`   | CSS Grid `auto-fit, minmax(220px, 1fr)`. Items reflow as the container narrows.                     |
-| `stack`  | Vertical stack — preferred in narrow admin sidebars.                                                |
-| `auto`   | Default. CSS-only responsive grid that stacks on narrow viewports **without hiding any cell**.      |
+| Value   | Behavior                                                                                         |
+| ------- | ------------------------------------------------------------------------------------------------ |
+| `strip` | Single horizontal row. `wrap` controls whether items wrap (`true`, default) or scroll (`false`). |
+| `grid`  | CSS Grid `auto-fit, minmax(220px, 1fr)`. Items reflow as the container narrows.                  |
+| `stack` | Vertical stack — preferred in narrow admin sidebars.                                             |
+| `auto`  | Default. CSS-only responsive grid that stacks on narrow viewports **without hiding any cell**.   |
 
 Layout is implemented in inline CSS (no media queries inside the component,
 no JavaScript layout), so SSR output and hydrated DOM are byte-identical.
@@ -242,18 +242,27 @@ authority and read-only state come from the host.
 <WizardAuthorityContextStripPanel
   strip={{
     items: [
-      { key: 'tenant', label: 'Tenant', value: 'theory-mcp' },
-      { key: 'namespace', label: 'Namespace', value: 'acme', tone: 'info' },
-      { key: 'route', label: 'MCP route', value: '/agents/acme',
-        copyable: true, copyValue: '/agents/acme' },
-      { key: 'operator', label: 'Operator', value: 'aron@equal-to.ai',
-        badge: 'session' },
+      { key: "tenant", label: "Tenant", value: "theory-mcp" },
+      { key: "namespace", label: "Namespace", value: "acme", tone: "info" },
+      {
+        key: "route",
+        label: "MCP route",
+        value: "/agents/acme",
+        copyable: true,
+        copyValue: "/agents/acme",
+      },
+      {
+        key: "operator",
+        label: "Operator",
+        value: "aron@equal-to.ai",
+        badge: "session",
+      },
     ],
-    authorityLabel: 'Server-derived',
-    readOnlyLabel: 'Read-only',
-    layout: 'auto',
-    size: 'md',
-    safetyPolicy: 'no-secret-or-production-like-data',
+    authorityLabel: "Server-derived",
+    readOnlyLabel: "Read-only",
+    layout: "auto",
+    size: "md",
+    safetyPolicy: "no-secret-or-production-like-data",
   }}
   onCopyItem={(itemKey, value) => host.copyToClipboard(itemKey, value)}
 />
@@ -292,11 +301,11 @@ are byte-identical for the same props.
 
 ### Key handling
 
-| Key       | Behavior                                                                  |
-| --------- | ------------------------------------------------------------------------- |
-| Enter     | Commit draft. Calls `onChange([...value, normalizedDraft])` and clears.   |
-| Comma     | Same as Enter.                                                            |
-| Backspace | If draft is empty and there is at least one token, remove the last one.   |
+| Key       | Behavior                                                                |
+| --------- | ----------------------------------------------------------------------- |
+| Enter     | Commit draft. Calls `onChange([...value, normalizedDraft])` and clears. |
+| Comma     | Same as Enter.                                                          |
+| Backspace | If draft is empty and there is at least one token, remove the last one. |
 
 Commit is suppressed when the draft is empty, when `validateToken` returns
 `{ valid: false }`, when the resulting token would be a duplicate and
@@ -336,15 +345,17 @@ color-only cues.
 ```tsx
 <WizardEditableTokenInputPanel
   input={{
-    inputId: 'allowed-senders',
-    value: ['qa@example.com', 'ops@example.com'],
-    label: 'Allowed senders',
-    description: 'Server validation remains authoritative.',
-    placeholder: 'Add another address…',
-    removeLabelKind: 'sender',
+    inputId: "allowed-senders",
+    value: ["qa@example.com", "ops@example.com"],
+    label: "Allowed senders",
+    description: "Server validation remains authoritative.",
+    placeholder: "Add another address…",
+    removeLabelKind: "sender",
     validateToken: (token) =>
-      token.includes('@') ? { valid: true } : { valid: false, message: 'Address must contain @' },
-    safetyPolicy: 'no-secret-or-production-like-data',
+      token.includes("@")
+        ? { valid: true }
+        : { valid: false, message: "Address must contain @" },
+    safetyPolicy: "no-secret-or-production-like-data",
     draftValue: host.draft,
   }}
   onChange={(next) => host.setAllowedSenders(next)}
@@ -381,7 +392,7 @@ interface SelectableCardOption {
   description?: unknown;
   icon?: unknown;
   badge?: unknown;
-  tone?: 'neutral' | 'info' | 'success' | 'warning' | 'danger' | 'recommended';
+  tone?: "neutral" | "info" | "success" | "warning" | "danger" | "recommended";
   riskLabel?: string;
   disabledReason?: string;
   recommended?: boolean;
@@ -421,23 +432,39 @@ The host owns acceptance — passing back a different list is fine.
 ```tsx
 <SelectableCardGridPanel
   grid={{
-    groupId: 'allowed-action',
-    selection: 'single',
-    selectedKeys: ['create'],
+    groupId: "allowed-action",
+    selection: "single",
+    selectedKeys: ["create"],
     options: [
-      { key: 'create', title: 'Create new namespace', tone: 'success', recommended: true },
-      { key: 'reuse', title: 'Reuse existing namespace', tone: 'info' },
-      { key: 'replace', title: 'Replace existing namespace',
-        tone: 'warning', riskLabel: 'High blast radius' },
-      { key: 'archive', title: 'Archive without binding',
-        disabledReason: 'Requires operator review before archival.' },
-      { key: 'forbidden', title: 'Forbidden namespace',
-        blocked: true, blockedReason: 'Server policy blocks this option.' },
+      {
+        key: "create",
+        title: "Create new namespace",
+        tone: "success",
+        recommended: true,
+      },
+      { key: "reuse", title: "Reuse existing namespace", tone: "info" },
+      {
+        key: "replace",
+        title: "Replace existing namespace",
+        tone: "warning",
+        riskLabel: "High blast radius",
+      },
+      {
+        key: "archive",
+        title: "Archive without binding",
+        disabledReason: "Requires operator review before archival.",
+      },
+      {
+        key: "forbidden",
+        title: "Forbidden namespace",
+        blocked: true,
+        blockedReason: "Server policy blocks this option.",
+      },
     ],
-    label: 'Allowed action',
-    description: 'TheoryMCP resolves which of these are available per route.',
-    layout: 'grid',
-    safetyPolicy: 'no-secret-or-production-like-data',
+    label: "Allowed action",
+    description: "TheoryMCP resolves which of these are available per route.",
+    layout: "grid",
+    safetyPolicy: "no-secret-or-production-like-data",
   }}
   onChange={(next) => host.setAllowedAction(next[0])}
 />
@@ -503,18 +530,23 @@ display contract.
 ```tsx
 <PackageSourceInputPanel
   input={{
-    groupId: 'pkg-src',
+    groupId: "pkg-src",
     value: host.pasteValue,
-    state: 'validating',
+    state: "validating",
     errors: host.errors,
-    modes: ['paste', 'dropzone', 'upload'],
-    label: 'Package source',
-    description: 'TheoryMCP parses and validates server-side before preview.',
-    placeholder: 'Paste your agent manifest…',
-    fileAccept: '.yaml,.yml,.json',
+    modes: ["paste", "dropzone", "upload"],
+    label: "Package source",
+    description: "TheoryMCP parses and validates server-side before preview.",
+    placeholder: "Paste your agent manifest…",
+    fileAccept: ".yaml,.yml,.json",
     fileMeta: host.attachedFile,
-    actions: { clear: true, replace: true, copy: true, copyValue: host.pasteValue },
-    safetyPolicy: 'no-secret-or-production-like-data',
+    actions: {
+      clear: true,
+      replace: true,
+      copy: true,
+      copyValue: host.pasteValue,
+    },
+    safetyPolicy: "no-secret-or-production-like-data",
   }}
   onValueChange={(next) => host.setPasteValue(next)}
   onFiles={(files) => host.handleFiles(files)}
@@ -541,7 +573,7 @@ import {
   WizardEnablementChecklistPanel,
   WizardRecoveryStatusPanel,
   WizardEmptyState,
-} from '@theory-cloud/facetheory/react/stitch-admin';
+} from "@theory-cloud/facetheory/react/stitch-admin";
 ```
 
 A typical reconciliation step in the TheoryMCP Agent Import & Completion
@@ -551,25 +583,65 @@ Wizard:
 <WizardReconciliationPlanPanel
   plan={{
     rows: [
-      { key: 'ns', label: 'Create namespace acme', kind: 'create',
-        summary: 'Will create namespace acme in tenant theory-mcp' },
-      { key: 'agent', label: 'Update agent acme', kind: 'update',
-        summary: 'Bump declared capabilities' },
-      { key: 'binding', label: 'Mailbox binding', kind: 'already_satisfied',
-        summary: 'Mailbox allowlist already includes the agent' },
-      { key: 'github', label: 'GitHub binding', kind: 'conflict',
-        reason: 'Existing binding targets theory-cloud/Other; resolve before continuing.' },
-      { key: 'policy', label: 'Enforcement policy', kind: 'blocked',
-        reason: 'Operator review record not present.' },
-      { key: 'secret', label: 'Rotate signing secret', kind: 'external_step_required',
-        reason: 'Cannot rotate from this wizard; complete in the rotation tool.' },
-      { key: 'deploy', label: 'Deployment', kind: 'not_requested',
-        summary: 'Deployment intentionally not part of this run' },
+      {
+        key: "ns",
+        label: "Create namespace acme",
+        kind: "create",
+        summary: "Will create namespace acme in tenant theory-mcp",
+      },
+      {
+        key: "agent",
+        label: "Update agent acme",
+        kind: "update",
+        summary: "Bump declared capabilities",
+      },
+      {
+        key: "binding",
+        label: "Mailbox binding",
+        kind: "already_satisfied",
+        summary: "Mailbox allowlist already includes the agent",
+      },
+      {
+        key: "github",
+        label: "GitHub binding",
+        kind: "conflict",
+        reason:
+          "Existing binding targets theory-cloud/Other; resolve before continuing.",
+      },
+      {
+        key: "policy",
+        label: "Enforcement policy",
+        kind: "blocked",
+        reason: "Operator review record not present.",
+      },
+      {
+        key: "secret",
+        label: "Rotate signing secret",
+        kind: "external_step_required",
+        reason:
+          "Cannot rotate from this wizard; complete in the rotation tool.",
+      },
+      {
+        key: "deploy",
+        label: "Deployment",
+        kind: "not_requested",
+        summary: "Deployment intentionally not part of this run",
+      },
     ],
-    totals: { create: 1, update: 1, satisfied: 1, conflict: 1, blocked: 1, external: 1, noop: 1 },
-    safetyPolicy: 'no-secret-or-production-like-data',
+    totals: {
+      create: 1,
+      update: 1,
+      satisfied: 1,
+      conflict: 1,
+      blocked: 1,
+      external: 1,
+      noop: 1,
+    },
+    safetyPolicy: "no-secret-or-production-like-data",
   }}
-  onToggleRow={(rowKey, nextExpanded) => host.setRowExpanded(rowKey, nextExpanded)}
+  onToggleRow={(rowKey, nextExpanded) =>
+    host.setRowExpanded(rowKey, nextExpanded)
+  }
 />
 ```
 
@@ -580,12 +652,12 @@ passes host-owned data straight in. For example:
 <WizardProgress
   state={{
     steps: [
-      { key: 'connect', label: 'Connect repository', status: 'complete' },
-      { key: 'validate', label: 'Validate manifest', status: 'in-progress' },
-      { key: 'review', label: 'Review capabilities', status: 'pending' },
-      { key: 'enable', label: 'Enable agent', status: 'pending' },
+      { key: "connect", label: "Connect repository", status: "complete" },
+      { key: "validate", label: "Validate manifest", status: "in-progress" },
+      { key: "review", label: "Review capabilities", status: "pending" },
+      { key: "enable", label: "Enable agent", status: "pending" },
     ],
-    currentStepKey: 'validate',
+    currentStepKey: "validate",
   }}
 />
 ```
@@ -595,11 +667,11 @@ Empty / error states must declare the wizard safety policy:
 ```tsx
 <WizardEmptyState
   config={{
-    intent: 'not-configured',
-    title: 'Configure a TheoryMCP binding to begin',
-    description: 'Connect a GitHub binding and a mailbox before importing.',
-    actionLabel: 'Open binding settings',
-    safetyPolicy: 'no-secret-or-production-like-data',
+    intent: "not-configured",
+    title: "Configure a TheoryMCP binding to begin",
+    description: "Connect a GitHub binding and a mailbox before importing.",
+    actionLabel: "Open binding settings",
+    safetyPolicy: "no-secret-or-production-like-data",
   }}
 />
 ```
@@ -609,11 +681,11 @@ Recovery / resume references must redact tokens before passing them in:
 ```tsx
 <WizardRecoveryStatusPanel
   status={{
-    state: 'resumable',
-    lastSavedAt: '2026-05-21T03:15:00.000Z',
-    ageLabel: 'saved 6 minutes ago',
+    state: "resumable",
+    lastSavedAt: "2026-05-21T03:15:00.000Z",
+    ageLabel: "saved 6 minutes ago",
     resumeTokenReference: {
-      label: 'session abc12…', // host-redacted label, never the raw token
+      label: "session abc12…", // host-redacted label, never the raw token
       redacted: true,
     },
   }}
@@ -699,3 +771,107 @@ is discarded and consumers re-pin against the published release tarball.
 The host (TheoryMCP) is responsible for redacting these before invoking the
 wizard primitives; the archive itself only contains the FaceTheory build
 output from `npm pack`.
+
+## Audit trail + disclosure panel
+
+`AuditTrailPanel` and the lower-level `DisclosurePanel` render the
+**validation-history / final-review** surface for the TheoryMCP Agent
+Import & Completion Wizard. They are framework-neutral by contract:
+
+- React adapter: `import { AuditTrailPanel, DisclosurePanel } from
+'@theory-cloud/facetheory/react/stitch-admin'`
+- Vue adapter: `import { AuditTrailPanel, DisclosurePanel } from
+'@theory-cloud/facetheory/vue/stitch-admin'`
+- Svelte adapter: `import { AuditTrailPanel, DisclosurePanel } from
+'@theory-cloud/facetheory/svelte/stitch-admin'`
+
+Shared types: `AuditTrail`, `AuditTrailEvent`, `AuditTrailEventGroup`,
+`AuditTrailEventMetadataEntry`, `AuditTrailEventExternalLink`,
+`AuditTrailEventStatus`, `AuditTrailEventTone`, `AuditTrailVariant`, and
+`DisclosurePanelProps` are re-exported from
+`@theory-cloud/facetheory/stitch-admin` and used identically by all three
+adapters.
+
+### Trust boundary
+
+- **Presentation-only.** FaceTheory does not decide redaction or audit
+  policy, parse event content, fetch external state, apply changes,
+  authorize anything, or invent operational receipts.
+- **theory-mcp-server is authoritative.** The host supplies already-redacted
+  event text, metadata, group structure, and per-event disclosure state.
+- **Redaction marker rule.** When an event carries `redactedMarker`, the
+  primitive renders the marker as text and **suppresses** the event's
+  `body`, `metadata`, and `externalLink` even if the caller supplied them.
+  The host is responsible for the marker copy (e.g. `"[redacted by policy]"`,
+  `"[redacted — mailbox secret]"`); the primitive renders it verbatim.
+- **External link rule.** `externalLink.href` is filtered through the
+  Stitch admin safe-href guard. Only `http:` and `https:` URLs survive;
+  `javascript:`, `data:`, and malformed values are dropped at render time.
+  Safe external links emit `rel="noopener noreferrer"` and
+  `target="_blank"`.
+
+### Event shape and accessibility
+
+- Each event renders as an `<li>` with `data-event-id`, `data-event-tone`,
+  `data-event-status`, and `data-event-redacted`. Events with
+  `status: 'error'` carry `role="alert"`; all other events carry
+  `role="listitem"`.
+- Tone (`neutral | info | success | warning | danger`) drives the visible
+  palette **and** a sibling text pill labeled `Neutral / Info / Success /
+Warning / Danger` so high-contrast viewers see the cue.
+- Status (`info | success | warning | error`) is rendered as a status pill
+  labeled `Info / Success / Warning / Error`.
+- Timestamps render in a `<time datetime="…">` element using the
+  caller-supplied stable string — the primitive never computes time.
+- Metadata entries render as `<dl>` / `<dt>` / `<dd>` pairs only when
+  `variant === 'detailed'`.
+
+### Group disclosure
+
+- Each group renders a real `<button type="button">` toggle with
+  `aria-expanded` and `aria-controls` wiring to the events region.
+- Group state is **caller-controlled** via `group.expanded`. The primitive
+  mirrors it in `aria-expanded` and renders the events region as `hidden`
+  when collapsed; the primitive never toggles itself.
+- Consumers wire `onToggleGroup(groupId, nextExpanded)` to receive intent.
+- The `<div role="region" aria-labelledby={group.id} hidden={!expanded}>`
+  events region keeps screen-reader users oriented when groups collapse.
+
+### Variants
+
+- `'detailed'` — full event body, metadata table, and external link
+  (subject to the redaction-marker and safe-href rules).
+- `'compact'` — timestamp, title, tone/status pills, actor row, and
+  external link only; body and metadata are omitted.
+
+### Empty state
+
+When no events are present across all groups, the primitive renders a
+`role="status"` empty-state element using either `trail.emptyLabel` or the
+default `"No audit events."` string. The safety-policy footnote is
+emitted regardless.
+
+### Standalone `DisclosurePanel`
+
+`DisclosurePanel` is the lower-level disclosure primitive used by the
+audit-trail panel and reusable on its own. It renders:
+
+- a real `<button type="button" aria-expanded aria-controls>` toggle,
+- an optional `description` paragraph under the toggle,
+- a `<div role="region" aria-labelledby hidden={!expanded}>` content panel
+  that renders its adapter-specific children only when expanded,
+- the explicit `Safety policy: …` footnote.
+
+When `status === 'error'`, the section also carries `role="alert"` so
+prominent failure copy is announced.
+
+### Trust-boundary tests
+
+The React / Vue / Svelte parity suites assert (via AKIA-shaped fake-secret
+fixtures) that:
+
+- caller-supplied `body`, `metadata`, and `externalLink.label` on a
+  redacted event are **never** rendered into the DOM;
+- `javascript:alert(1)` external links are dropped along with their label;
+- safe https links retain `rel="noopener noreferrer"` and `target="_blank"`;
+- repeated SSR renders of the same trail are byte-identical.

--- a/ts/src/react/stitch-admin/audit-trail.ts
+++ b/ts/src/react/stitch-admin/audit-trail.ts
@@ -1,0 +1,795 @@
+import * as React from 'react';
+
+import type {
+  AuditTrail,
+  AuditTrailEvent,
+  AuditTrailEventExternalLink,
+  AuditTrailEventGroup,
+  AuditTrailEventMetadataEntry,
+  AuditTrailEventStatus,
+  AuditTrailEventTone,
+  AuditTrailVariant,
+  DisclosurePanelProps,
+} from '../../stitch-admin/audit-trail-types.js';
+import type { WizardSafetyPolicy } from '../../stitch-admin/wizard-types.js';
+import { safeMetadataHref } from '../../stitch-admin/safe-url.js';
+import { MetadataBadgeGroup } from './operator-notices.js';
+
+const h = React.createElement;
+
+export type {
+  AuditTrail,
+  AuditTrailEvent,
+  AuditTrailEventExternalLink,
+  AuditTrailEventGroup,
+  AuditTrailEventMetadataEntry,
+  AuditTrailEventStatus,
+  AuditTrailEventTone,
+  AuditTrailVariant,
+  DisclosurePanelProps,
+};
+
+interface TonePalette {
+  background: string;
+  color: string;
+  border: string;
+  label: string;
+}
+
+const TONE_PALETTE: Record<AuditTrailEventTone, TonePalette> = {
+  neutral: {
+    background: 'var(--stitch-color-surface-container, #eaedff)',
+    color: 'var(--stitch-color-on-surface, #131b2e)',
+    border: 'var(--stitch-color-outline-variant, #c6c5d0)',
+    label: 'Neutral',
+  },
+  info: {
+    background: 'var(--stitch-color-primary-container, #e0e0ff)',
+    color: 'var(--stitch-color-on-primary-container, #000066)',
+    border: 'var(--stitch-color-primary-container, #e0e0ff)',
+    label: 'Info',
+  },
+  success: {
+    background: 'var(--stitch-color-tertiary-container, #004c45)',
+    color: 'var(--stitch-color-on-tertiary-container, #52c1b4)',
+    border: 'var(--stitch-color-tertiary-container, #004c45)',
+    label: 'Success',
+  },
+  warning: {
+    background: 'var(--stitch-color-secondary-container, #ffecc0)',
+    color: 'var(--stitch-color-on-secondary-container, #3f2e00)',
+    border: 'var(--stitch-color-secondary-container, #ffecc0)',
+    label: 'Warning',
+  },
+  danger: {
+    background: 'var(--stitch-color-error-container, #ffdad6)',
+    color: 'var(--stitch-color-on-error-container, #93000a)',
+    border: 'var(--stitch-color-error-container, #ffdad6)',
+    label: 'Danger',
+  },
+};
+
+const STATUS_LABEL: Record<AuditTrailEventStatus, string> = {
+  info: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  error: 'Error',
+};
+
+function isErrorEvent(event: AuditTrailEvent): boolean {
+  return event.status === 'error';
+}
+
+function isRedactedEvent(event: AuditTrailEvent): boolean {
+  return event.redactedMarker !== undefined && event.redactedMarker !== '';
+}
+
+function renderSafetyFootnote(policy: WizardSafetyPolicy): React.ReactElement {
+  return h(
+    'p',
+    {
+      key: 'safety',
+      className: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+      style: {
+        margin: 0,
+        fontSize: '11px',
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+      },
+    },
+    `Safety policy: ${policy}`,
+  );
+}
+
+function renderTonePill(event: AuditTrailEvent): React.ReactElement | null {
+  const tone = event.tone;
+  if (tone === undefined) return null;
+  const palette = TONE_PALETTE[tone];
+  return h(
+    'span',
+    {
+      key: 'tone-pill',
+      className: `facetheory-stitch-audit-event-tone facetheory-stitch-audit-event-tone-${tone}`,
+      'data-tone-pill': tone,
+      style: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '2px 8px',
+        borderRadius: '9999px',
+        background: palette.background,
+        color: palette.color,
+        fontSize: '11px',
+        fontWeight: 600,
+        lineHeight: 1.4,
+      },
+    },
+    palette.label,
+  );
+}
+
+function renderStatusPill(event: AuditTrailEvent): React.ReactElement | null {
+  const status = event.status;
+  if (status === undefined) return null;
+  return h(
+    'span',
+    {
+      key: 'status-pill',
+      className: `facetheory-stitch-audit-event-status facetheory-stitch-audit-event-status-${status}`,
+      'data-status-pill': status,
+      style: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '2px 8px',
+        borderRadius: '9999px',
+        background:
+          status === 'error'
+            ? 'var(--stitch-color-error-container, #ffdad6)'
+            : status === 'warning'
+              ? 'var(--stitch-color-secondary-container, #ffecc0)'
+              : status === 'success'
+                ? 'var(--stitch-color-tertiary-container, #004c45)'
+                : 'var(--stitch-color-primary-container, #e0e0ff)',
+        color:
+          status === 'error'
+            ? 'var(--stitch-color-on-error-container, #93000a)'
+            : status === 'warning'
+              ? 'var(--stitch-color-on-secondary-container, #3f2e00)'
+              : status === 'success'
+                ? 'var(--stitch-color-on-tertiary-container, #52c1b4)'
+                : 'var(--stitch-color-on-primary-container, #000066)',
+        fontSize: '11px',
+        fontWeight: 600,
+        lineHeight: 1.4,
+      },
+    },
+    STATUS_LABEL[status],
+  );
+}
+
+function renderActorRow(event: AuditTrailEvent): React.ReactElement | null {
+  if (event.actor === undefined && event.actorSource === undefined) return null;
+  return h(
+    'div',
+    {
+      key: 'actor',
+      className: 'facetheory-stitch-audit-event-actor',
+      style: {
+        display: 'flex',
+        gap: '6px',
+        alignItems: 'center',
+        fontSize: '12px',
+        color: 'var(--stitch-color-on-surface-variant, #464553)',
+      },
+    },
+    event.actor !== undefined
+      ? h(
+          'span',
+          { key: 'actor-label', 'data-actor-label': 'true' },
+          event.actor as React.ReactNode,
+        )
+      : null,
+    event.actorSource !== undefined
+      ? h(
+          'span',
+          {
+            key: 'actor-source',
+            className: 'facetheory-stitch-audit-event-actor-source',
+            'data-actor-source': 'true',
+          },
+          event.actorSource,
+        )
+      : null,
+  );
+}
+
+function renderMetadata(
+  metadata: AuditTrailEventMetadataEntry[],
+): React.ReactElement {
+  return h(
+    'dl',
+    {
+      key: 'metadata',
+      className: 'facetheory-stitch-audit-event-metadata',
+      'data-metadata-count': String(metadata.length),
+      style: {
+        margin: 0,
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 2fr)',
+        gap: '4px 12px',
+        fontSize: '12px',
+      },
+    },
+    metadata.map((entry) =>
+      h(
+        React.Fragment,
+        { key: entry.key },
+        h(
+          'dt',
+          {
+            key: 'dt',
+            className: 'facetheory-stitch-audit-event-metadata-key',
+            'data-metadata-key': entry.key,
+          },
+          entry.label as React.ReactNode,
+        ),
+        h(
+          'dd',
+          {
+            key: 'dd',
+            className: 'facetheory-stitch-audit-event-metadata-value',
+          },
+          entry.value as React.ReactNode,
+        ),
+      ),
+    ),
+  );
+}
+
+function renderExternalLink(
+  link: AuditTrailEventExternalLink,
+): React.ReactElement | null {
+  const safeHref = safeMetadataHref(link.href);
+  if (safeHref === undefined) return null;
+  return h(
+    'a',
+    {
+      key: 'external',
+      className: 'facetheory-stitch-audit-event-external-link',
+      'data-external-link': 'true',
+      href: safeHref,
+      rel: 'noopener noreferrer',
+      target: '_blank',
+      style: { fontSize: '12px' },
+    },
+    link.label !== undefined ? (link.label as React.ReactNode) : link.href,
+  );
+}
+
+function renderEventBody(
+  event: AuditTrailEvent,
+  variant: AuditTrailVariant,
+): React.ReactElement[] {
+  const children: React.ReactElement[] = [];
+  if (isRedactedEvent(event)) {
+    children.push(
+      h(
+        'p',
+        {
+          key: 'redacted',
+          className: 'facetheory-stitch-audit-event-redacted-marker',
+          'data-event-redacted-marker': 'true',
+          style: {
+            margin: 0,
+            fontFamily:
+              'var(--stitch-font-label, ui-monospace, SFMono-Regular, Menlo, monospace)',
+            fontSize: '12px',
+            color: 'var(--stitch-color-on-surface-variant, #464553)',
+          },
+        },
+        event.redactedMarker,
+      ),
+    );
+    return children;
+  }
+  if (event.body !== undefined && variant === 'detailed') {
+    children.push(
+      h(
+        'p',
+        {
+          key: 'body',
+          className: 'facetheory-stitch-audit-event-body',
+          style: {
+            margin: 0,
+            fontSize: '13px',
+            lineHeight: 1.5,
+            color: 'var(--stitch-color-on-surface, #131b2e)',
+          },
+        },
+        event.body as React.ReactNode,
+      ),
+    );
+  }
+  if (
+    event.metadata !== undefined &&
+    event.metadata.length > 0 &&
+    variant === 'detailed'
+  ) {
+    children.push(renderMetadata(event.metadata));
+  }
+  if (event.externalLink !== undefined) {
+    const link = renderExternalLink(event.externalLink);
+    if (link !== null) children.push(link);
+  }
+  return children;
+}
+
+function renderEvent(
+  event: AuditTrailEvent,
+  variant: AuditTrailVariant,
+): React.ReactElement {
+  const tone = event.tone ?? 'neutral';
+  const palette = TONE_PALETTE[tone];
+  const error = isErrorEvent(event);
+  const redacted = isRedactedEvent(event);
+  const role: 'listitem' | 'alert' = error ? 'alert' : 'listitem';
+  return h(
+    'li',
+    {
+      key: event.id,
+      className: `facetheory-stitch-audit-event facetheory-stitch-audit-event-tone-${tone}${
+        event.status !== undefined
+          ? ` facetheory-stitch-audit-event-status-${event.status}`
+          : ''
+      }${redacted ? ' facetheory-stitch-audit-event-redacted' : ''}`,
+      'data-event-id': event.id,
+      'data-event-tone': tone,
+      'data-event-status': event.status ?? '',
+      'data-event-redacted': redacted ? 'true' : 'false',
+      role,
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: variant === 'detailed' ? '8px' : '4px',
+        padding: variant === 'detailed' ? '12px' : '8px 12px',
+        borderRadius: 'var(--stitch-radius-md, 10px)',
+        background: palette.background,
+        color: palette.color,
+        border: `1px solid ${palette.border}`,
+      },
+    },
+    h(
+      'div',
+      {
+        key: 'header',
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          flexWrap: 'wrap',
+        },
+      },
+      h(
+        'time',
+        {
+          key: 'timestamp',
+          className: 'facetheory-stitch-audit-event-timestamp',
+          'data-event-timestamp': event.timestamp,
+          dateTime: event.timestamp,
+          style: { fontSize: '11px', fontWeight: 600 },
+        },
+        event.timestamp,
+      ),
+      event.icon !== undefined
+        ? h(
+            'span',
+            {
+              key: 'icon',
+              className: 'facetheory-stitch-audit-event-icon',
+              'aria-hidden': 'true',
+            },
+            event.icon as React.ReactNode,
+          )
+        : null,
+      h(
+        'strong',
+        {
+          key: 'title',
+          className: 'facetheory-stitch-audit-event-title',
+          style: { fontSize: '13px' },
+        },
+        event.title as React.ReactNode,
+      ),
+      renderStatusPill(event),
+      renderTonePill(event),
+    ),
+    renderActorRow(event),
+    ...renderEventBody(event, variant),
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* DisclosurePanel                                                            */
+/* -------------------------------------------------------------------------- */
+
+export interface DisclosurePanelPanelProps {
+  panel: DisclosurePanelProps;
+  onToggle?: (nextExpanded: boolean) => void;
+  children?: React.ReactNode;
+}
+
+export function DisclosurePanel(
+  props: DisclosurePanelPanelProps,
+): React.ReactElement {
+  const { panel, onToggle, children } = props;
+  const tone = panel.tone ?? 'neutral';
+  const palette = TONE_PALETTE[tone];
+  const error = panel.status === 'error';
+  const stateRole: 'alert' | undefined = error ? 'alert' : undefined;
+  const panelContentId = `${panel.panelId}-region`;
+  return h(
+    'section',
+    {
+      className: `facetheory-stitch-disclosure-panel facetheory-stitch-disclosure-panel-tone-${tone}${
+        panel.status !== undefined
+          ? ` facetheory-stitch-disclosure-panel-status-${panel.status}`
+          : ''
+      }`,
+      'data-disclosure-id': panel.panelId,
+      'data-disclosure-expanded': panel.expanded ? 'true' : 'false',
+      'data-disclosure-tone': tone,
+      'data-disclosure-status': panel.status ?? '',
+      'data-safety-policy': panel.safetyPolicy,
+      role: stateRole,
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        padding: '12px',
+        borderRadius: 'var(--stitch-radius-md, 10px)',
+        background: palette.background,
+        color: palette.color,
+        border: `1px solid ${palette.border}`,
+      },
+    },
+    h(
+      'button',
+      {
+        key: 'toggle',
+        type: 'button',
+        id: panel.panelId,
+        className: 'facetheory-stitch-disclosure-panel-toggle',
+        'aria-expanded': panel.expanded ? 'true' : 'false',
+        'aria-controls': panelContentId,
+        'data-disclosure-toggle': panel.panelId,
+        onClick:
+          onToggle !== undefined ? () => onToggle(!panel.expanded) : undefined,
+        style: {
+          appearance: 'none',
+          background: 'transparent',
+          border: 'none',
+          textAlign: 'left',
+          padding: 0,
+          color: 'inherit',
+          cursor: onToggle !== undefined ? 'pointer' : 'default',
+          font: 'inherit',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+        },
+      },
+      h(
+        'span',
+        {
+          key: 'label',
+          className: 'facetheory-stitch-disclosure-panel-label',
+          style: { fontSize: '14px', fontWeight: 600 },
+        },
+        panel.label as React.ReactNode,
+      ),
+      h(
+        'span',
+        {
+          key: 'state',
+          className: 'facetheory-stitch-disclosure-panel-state',
+          'data-disclosure-state-label': panel.expanded
+            ? 'expanded'
+            : 'collapsed',
+          style: { fontSize: '11px', fontWeight: 600 },
+        },
+        panel.expanded ? 'Hide' : 'Show',
+      ),
+    ),
+    panel.description !== undefined
+      ? h(
+          'p',
+          {
+            key: 'description',
+            className: 'facetheory-stitch-disclosure-panel-description',
+            style: { margin: 0, fontSize: '12px', lineHeight: 1.5 },
+          },
+          panel.description as React.ReactNode,
+        )
+      : null,
+    h(
+      'div',
+      {
+        key: 'content',
+        id: panelContentId,
+        className: 'facetheory-stitch-disclosure-panel-content',
+        role: 'region',
+        'aria-labelledby': panel.panelId,
+        'aria-hidden': panel.expanded ? 'false' : 'true',
+        hidden: !panel.expanded,
+      },
+      panel.expanded ? children : null,
+    ),
+    renderSafetyFootnote(panel.safetyPolicy),
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* AuditTrailPanel                                                            */
+/* -------------------------------------------------------------------------- */
+
+export interface AuditTrailPanelProps {
+  trail: AuditTrail;
+  onToggleGroup?: (groupId: string, nextExpanded: boolean) => void;
+}
+
+export function AuditTrailPanel(
+  props: AuditTrailPanelProps,
+): React.ReactElement {
+  const { trail, onToggleGroup } = props;
+  const labelId =
+    trail.label !== undefined ? `${trail.groupId}-label` : undefined;
+  const descriptionId =
+    trail.description !== undefined
+      ? `${trail.groupId}-description`
+      : undefined;
+  const totalEvents = trail.groups.reduce((acc, g) => acc + g.events.length, 0);
+  const errorEvents = trail.groups.reduce(
+    (acc, g) => acc + g.events.filter((e) => e.status === 'error').length,
+    0,
+  );
+  const isEmpty = totalEvents === 0;
+  return h(
+    'section',
+    {
+      className: `facetheory-stitch-audit-trail facetheory-stitch-audit-trail-variant-${trail.variant}`,
+      'data-safety-policy': trail.safetyPolicy,
+      'data-group-id': trail.groupId,
+      'data-variant': trail.variant,
+      'data-group-count': String(trail.groups.length),
+      'data-event-count': String(totalEvents),
+      'data-error-count': String(errorEvents),
+      'aria-labelledby': labelId,
+      'aria-describedby': descriptionId,
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+        padding: '12px',
+        borderRadius: 'var(--stitch-radius-lg, 12px)',
+        background: 'var(--stitch-color-surface-container-low, #f2f3ff)',
+        color: 'var(--stitch-color-on-surface, #131b2e)',
+      },
+    },
+    trail.label !== undefined || trail.description !== undefined
+      ? h(
+          'header',
+          {
+            key: 'header',
+            style: { display: 'flex', flexDirection: 'column', gap: '4px' },
+          },
+          trail.label !== undefined
+            ? h(
+                'h2',
+                {
+                  key: 'label',
+                  id: labelId,
+                  className: 'facetheory-stitch-audit-trail-label',
+                  style: { margin: 0, fontSize: '14px' },
+                },
+                trail.label as React.ReactNode,
+              )
+            : null,
+          trail.description !== undefined
+            ? h(
+                'p',
+                {
+                  key: 'description',
+                  id: descriptionId,
+                  className: 'facetheory-stitch-audit-trail-description',
+                  style: { margin: 0, fontSize: '12px', lineHeight: 1.5 },
+                },
+                trail.description as React.ReactNode,
+              )
+            : null,
+        )
+      : null,
+    trail.metadata !== undefined
+      ? h(MetadataBadgeGroup, { key: 'metadata', metadata: trail.metadata })
+      : null,
+    isEmpty
+      ? h(
+          'div',
+          {
+            key: 'empty',
+            className: 'facetheory-stitch-audit-trail-empty',
+            role: 'status',
+            style: {
+              padding: '14px',
+              borderRadius: 'var(--stitch-radius-md, 10px)',
+              background: 'var(--stitch-color-surface-container, #eaedff)',
+              color: 'var(--stitch-color-on-surface-variant, #464553)',
+              fontSize: '13px',
+            },
+          },
+          trail.emptyLabel !== undefined
+            ? (trail.emptyLabel as React.ReactNode)
+            : 'No audit events.',
+        )
+      : h(
+          'ul',
+          {
+            key: 'groups',
+            role: 'list',
+            className: 'facetheory-stitch-audit-trail-groups',
+            style: {
+              margin: 0,
+              padding: 0,
+              listStyle: 'none',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '8px',
+            },
+          },
+          trail.groups.map((group) =>
+            renderGroup(group, trail.variant, onToggleGroup),
+          ),
+        ),
+    renderSafetyFootnote(trail.safetyPolicy),
+  );
+}
+
+function renderGroup(
+  group: AuditTrailEventGroup,
+  variant: AuditTrailVariant,
+  onToggleGroup: AuditTrailPanelProps['onToggleGroup'],
+): React.ReactElement {
+  const expanded = group.expanded === true;
+  const eventsRegionId = `${group.id}-events`;
+  const hasErrors = group.events.some((e) => e.status === 'error');
+  return h(
+    'li',
+    {
+      key: group.id,
+      className: `facetheory-stitch-audit-trail-group${hasErrors ? ' facetheory-stitch-audit-trail-group-has-error' : ''}`,
+      'data-group-id': group.id,
+      'data-group-expanded': expanded ? 'true' : 'false',
+      'data-group-event-count': String(group.events.length),
+      'data-group-error-count': String(
+        group.events.filter((e) => e.status === 'error').length,
+      ),
+      style: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        padding: '10px 12px',
+        borderRadius: 'var(--stitch-radius-md, 10px)',
+        background: 'var(--stitch-color-surface-container, #eaedff)',
+        border: '1px solid var(--stitch-color-outline-variant, #c6c5d0)',
+      },
+    },
+    h(
+      'button',
+      {
+        key: 'toggle',
+        type: 'button',
+        id: group.id,
+        className: 'facetheory-stitch-audit-trail-group-toggle',
+        'aria-expanded': expanded ? 'true' : 'false',
+        'aria-controls': eventsRegionId,
+        'data-group-toggle': group.id,
+        onClick:
+          onToggleGroup !== undefined
+            ? () => onToggleGroup(group.id, !expanded)
+            : undefined,
+        style: {
+          appearance: 'none',
+          background: 'transparent',
+          border: 'none',
+          textAlign: 'left',
+          padding: 0,
+          color: 'inherit',
+          cursor: onToggleGroup !== undefined ? 'pointer' : 'default',
+          font: 'inherit',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+        },
+      },
+      h(
+        'span',
+        {
+          key: 'label',
+          className: 'facetheory-stitch-audit-trail-group-label',
+          style: { fontSize: '13px', fontWeight: 600 },
+        },
+        group.label as React.ReactNode,
+      ),
+      h(
+        'span',
+        {
+          key: 'count',
+          className: 'facetheory-stitch-audit-trail-group-count',
+          'data-group-event-count-label': String(group.events.length),
+          style: {
+            fontSize: '11px',
+            fontWeight: 600,
+            color: 'var(--stitch-color-on-surface-variant, #464553)',
+          },
+        },
+        `${group.events.length} events`,
+      ),
+      h(
+        'span',
+        {
+          key: 'state',
+          className: 'facetheory-stitch-audit-trail-group-state',
+          'data-group-state-label': expanded ? 'expanded' : 'collapsed',
+          style: { fontSize: '11px', fontWeight: 600 },
+        },
+        expanded ? 'Hide' : 'Show',
+      ),
+    ),
+    group.description !== undefined
+      ? h(
+          'p',
+          {
+            key: 'description',
+            className: 'facetheory-stitch-audit-trail-group-description',
+            style: {
+              margin: 0,
+              fontSize: '12px',
+              lineHeight: 1.5,
+              color: 'var(--stitch-color-on-surface-variant, #464553)',
+            },
+          },
+          group.description as React.ReactNode,
+        )
+      : null,
+    h(
+      'div',
+      {
+        key: 'events',
+        id: eventsRegionId,
+        className: 'facetheory-stitch-audit-trail-group-events',
+        role: 'region',
+        'aria-labelledby': group.id,
+        'aria-hidden': expanded ? 'false' : 'true',
+        hidden: !expanded,
+      },
+      expanded
+        ? h(
+            'ol',
+            {
+              role: 'list',
+              className: 'facetheory-stitch-audit-trail-event-list',
+              style: {
+                margin: 0,
+                padding: 0,
+                listStyle: 'none',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '6px',
+              },
+            },
+            group.events.map((event) => renderEvent(event, variant)),
+          )
+        : null,
+    ),
+  );
+}

--- a/ts/src/react/stitch-admin/index.ts
+++ b/ts/src/react/stitch-admin/index.ts
@@ -165,6 +165,22 @@ export {
 } from './wizard-authority-context-strip.js';
 
 export {
+  AuditTrailPanel,
+  DisclosurePanel,
+  type AuditTrailPanelProps,
+  type DisclosurePanelPanelProps,
+  type AuditTrail,
+  type AuditTrailEvent,
+  type AuditTrailEventExternalLink,
+  type AuditTrailEventGroup,
+  type AuditTrailEventMetadataEntry,
+  type AuditTrailEventStatus,
+  type AuditTrailEventTone,
+  type AuditTrailVariant,
+  type DisclosurePanelProps,
+} from './audit-trail.js';
+
+export {
   PackageSourceInputPanel,
   CodeDropzone,
   type PackageSourceInputPanelProps,

--- a/ts/src/stitch-admin/audit-trail-types.ts
+++ b/ts/src/stitch-admin/audit-trail-types.ts
@@ -1,0 +1,177 @@
+/**
+ * Framework-neutral types for the FaceTheory `AuditTrailPanel` and
+ * lower-level `DisclosurePanel` primitives. The TheoryMCP Agent Import &
+ * Completion Wizard uses these on the final-review / validation-history
+ * surfaces.
+ *
+ * Trust boundary (load-bearing):
+ *
+ *   - Presentation-only. FaceTheory does NOT decide redaction or audit
+ *     policy, parse event content, fetch external state, apply changes,
+ *     authorize anything, or invent operational receipts.
+ *   - theory-mcp-server (the host) supplies already-redacted event text
+ *     and metadata. FaceTheory only renders the audit trail and the
+ *     disclosure behavior.
+ *   - Redaction marker rule: when an event carries `redactedMarker`, the
+ *     primitive renders the marker as text and suppresses the event's
+ *     `body`, `metadata`, and `externalLink`. The host must pre-redact
+ *     anything else; the primitive does NOT inspect or transform raw
+ *     secret values.
+ *   - External link rule: `externalLink.href` is filtered through the
+ *     Stitch admin safe-href guard (`safeMetadataHref`). Only `http:` and
+ *     `https:` URLs survive; everything else (e.g. `javascript:`) is
+ *     dropped at render time. The primitive emits `rel="noopener
+ *     noreferrer"` and `target="_blank"` on safe external links.
+ */
+
+import type { OperatorVisibilityMetadata } from './operator-visibility-types.js';
+import type { WizardSafetyPolicy } from './wizard-types.js';
+
+/**
+ * Tone hint for an audit event chip. Adapters choose the concrete color
+ * tokens; the tone is also rendered as a TEXT pill so high-contrast
+ * viewers see the cue.
+ */
+export type AuditTrailEventTone =
+  | 'neutral'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger';
+
+/**
+ * Status of an audit event. Drives the role marker for prominent rows
+ * (`error` → `role="alert"`) and the chip label.
+ */
+export type AuditTrailEventStatus = 'info' | 'success' | 'warning' | 'error';
+
+/** Caller-supplied key-value metadata pair rendered in detailed variant. */
+export interface AuditTrailEventMetadataEntry {
+  /** Stable identifier used for keying. */
+  key: string;
+  /** Display label for the key. */
+  label: unknown;
+  /** Display value. The host pre-redacts; the primitive renders verbatim. */
+  value: unknown;
+}
+
+/** Caller-supplied external link reference for an event. */
+export interface AuditTrailEventExternalLink {
+  href: string;
+  /** Optional display label. Defaults to `href` text if omitted. */
+  label?: unknown;
+}
+
+/**
+ * A single audit event row.
+ *
+ * When `redactedMarker` is set, the primitive renders ONLY the timestamp,
+ * actor (if present), the marker text, and the status/tone pills.
+ * `body`, `metadata`, and `externalLink` are suppressed regardless of
+ * caller value to keep raw secret-like data out of the DOM.
+ */
+export interface AuditTrailEvent {
+  /** Stable identifier used for keying. */
+  id: string;
+  /**
+   * ISO-8601 timestamp or any caller-supplied stable string. The primitive
+   * never computes the timestamp; it just renders.
+   */
+  timestamp: string;
+  /** Caller-supplied actor label (e.g. principal, agent, service). */
+  actor?: unknown;
+  /**
+   * Optional caller-supplied source label for the actor (e.g.
+   * "Autheory session", "Server-derived"). Rendered as a small text chip.
+   */
+  actorSource?: string;
+  /** Event title. Adapters narrow to their native node type. */
+  title: unknown;
+  /** Optional body / details. Adapters narrow to their native node type. */
+  body?: unknown;
+  /** Optional leading icon. Decorative; adapters render with `aria-hidden`. */
+  icon?: unknown;
+  /** Optional tone hint. Defaults to `neutral`. */
+  tone?: AuditTrailEventTone;
+  /** Optional status. Drives role markers; `error` is announced as alert. */
+  status?: AuditTrailEventStatus;
+  /**
+   * When set, the primitive renders this marker text instead of the
+   * event body and suppresses `body`, `metadata`, and `externalLink`.
+   * The host owns the marker copy ("[redacted by policy]", "[redacted —
+   * mailbox secret]", etc.). The primitive renders it verbatim.
+   */
+  redactedMarker?: string;
+  /** Optional external-step link, filtered via safeMetadataHref. */
+  externalLink?: AuditTrailEventExternalLink;
+  /** Optional key-value metadata rendered in detailed variant. */
+  metadata?: AuditTrailEventMetadataEntry[];
+}
+
+/**
+ * A grouping of audit events. Hosts compute groups (parse / reconciliation
+ * / GitHub setup / email setup / final apply) and the disclosure state.
+ */
+export interface AuditTrailEventGroup {
+  /** Stable identifier used for keying and `aria-controls` wiring. */
+  id: string;
+  /** Group heading label. Adapters narrow to their native node type. */
+  label: unknown;
+  /** Optional descriptive copy under the heading. */
+  description?: unknown;
+  /** Events rendered in caller-supplied chronological order. */
+  events: AuditTrailEvent[];
+  /**
+   * Caller-controlled disclosure state. The primitive mirrors this in
+   * `aria-expanded` and renders the events section as `hidden` when
+   * `false`. The primitive does NOT toggle itself.
+   */
+  expanded?: boolean;
+}
+
+/** Audit trail variant. */
+export type AuditTrailVariant = 'compact' | 'detailed';
+
+export interface AuditTrail {
+  /** Required stable group id used to wire root `aria-*` refs. */
+  groupId: string;
+  /** Optional heading label rendered above the groups. */
+  label?: unknown;
+  /** Optional descriptive copy under the heading. */
+  description?: unknown;
+  groups: AuditTrailEventGroup[];
+  variant: AuditTrailVariant;
+  /** Optional empty-state label rendered when no groups have events. */
+  emptyLabel?: unknown;
+  /** Explicit safety policy assertion rendered into the DOM. */
+  safetyPolicy: WizardSafetyPolicy;
+  /**
+   * Optional already-server-resolved metadata badges for the trail as a
+   * whole (authority / provenance / correlation / confidence / staleness).
+   * Adapters render via `MetadataBadgeGroup`.
+   */
+  metadata?: OperatorVisibilityMetadata;
+}
+
+/**
+ * Standalone `DisclosurePanel` props. The lower-level primitive renders a
+ * keyboard-accessible disclosure (real `<button type="button">` toggle
+ * with `aria-expanded` + `aria-controls`) and a panel with the standard
+ * `hidden` attribute when collapsed. Hosts own `expanded` state.
+ */
+export interface DisclosurePanelProps {
+  /** Required stable id used to wire `aria-controls` and the panel id. */
+  panelId: string;
+  /** Heading label. Adapters narrow to their native node type. */
+  label: unknown;
+  /** Optional descriptive copy rendered under the toggle. */
+  description?: unknown;
+  /** Caller-controlled expansion state. */
+  expanded: boolean;
+  /** Optional tone hint for the disclosure header. */
+  tone?: AuditTrailEventTone;
+  /** Optional status; `error` makes the panel announce as `role="alert"`. */
+  status?: AuditTrailEventStatus;
+  /** Explicit safety policy assertion. */
+  safetyPolicy: WizardSafetyPolicy;
+}

--- a/ts/src/stitch-admin/index.ts
+++ b/ts/src/stitch-admin/index.ts
@@ -57,6 +57,18 @@ export type {
 } from './wizard-authority-context-strip-types.js';
 
 export type {
+  AuditTrail,
+  AuditTrailEvent,
+  AuditTrailEventExternalLink,
+  AuditTrailEventGroup,
+  AuditTrailEventMetadataEntry,
+  AuditTrailEventStatus,
+  AuditTrailEventTone,
+  AuditTrailVariant,
+  DisclosurePanelProps,
+} from './audit-trail-types.js';
+
+export type {
   CodeDropzoneProps,
   PackageSourceInput,
   PackageSourceInputActions,

--- a/ts/src/svelte/stitch-admin/AuditTrailPanel.svelte
+++ b/ts/src/svelte/stitch-admin/AuditTrailPanel.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+  import type {
+    AuditTrail,
+    AuditTrailEvent,
+    AuditTrailEventGroup,
+    AuditTrailEventStatus,
+    AuditTrailEventTone,
+    AuditTrailVariant,
+  } from '../../stitch-admin/audit-trail-types.js';
+  import MetadataBadgeGroup from './MetadataBadgeGroup.svelte';
+
+  export let trail: AuditTrail;
+  export let onToggleGroup:
+    | ((groupId: string, nextExpanded: boolean) => void)
+    | undefined = undefined;
+
+  const STATUS_LABEL: Record<AuditTrailEventStatus, string> = {
+    info: 'Info',
+    success: 'Success',
+    warning: 'Warning',
+    error: 'Error',
+  };
+  const TONE_LABEL: Record<AuditTrailEventTone, string> = {
+    neutral: 'Neutral',
+    info: 'Info',
+    success: 'Success',
+    warning: 'Warning',
+    danger: 'Danger',
+  };
+
+  function isRedacted(event: AuditTrailEvent): boolean {
+    return event.redactedMarker !== undefined && event.redactedMarker !== '';
+  }
+  function eventRole(event: AuditTrailEvent): 'alert' | 'listitem' {
+    return event.status === 'error' ? 'alert' : 'listitem';
+  }
+  // Mirrors `stitch-admin/safe-url.ts#safeMetadataHref` — kept inline so the
+  // Svelte SSR test harness doesn't need to resolve sibling JS modules across
+  // the temp-dir boundary used by the unit-test compiler shim.
+  const SAFE_HREF_BASE = 'https://facetheory.invalid';
+  function safeLinkHref(href: string): string | undefined {
+    const value = String(href ?? '').trim();
+    if (value === '') return undefined;
+    try {
+      const parsed = new URL(value, SAFE_HREF_BASE);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return undefined;
+      }
+      return value;
+    } catch {
+      return undefined;
+    }
+  }
+  function groupErrorCount(group: AuditTrailEventGroup): number {
+    return group.events.filter((e) => e.status === 'error').length;
+  }
+  function totalEvents(t: AuditTrail): number {
+    return t.groups.reduce((acc, g) => acc + g.events.length, 0);
+  }
+  function totalErrors(t: AuditTrail): number {
+    return t.groups.reduce(
+      (acc, g) => acc + g.events.filter((e) => e.status === 'error').length,
+      0,
+    );
+  }
+  function handleToggleGroup(groupId: string, expanded: boolean): void {
+    if (onToggleGroup === undefined) return;
+    onToggleGroup(groupId, !expanded);
+  }
+
+  $: variant = trail.variant as AuditTrailVariant;
+  $: labelId = trail.label !== undefined ? `${trail.groupId}-label` : undefined;
+  $: descriptionId =
+    trail.description !== undefined ? `${trail.groupId}-description` : undefined;
+  $: eventCount = totalEvents(trail);
+  $: errorCount = totalErrors(trail);
+  $: isEmpty = eventCount === 0;
+</script>
+
+<section
+  class={`facetheory-stitch-audit-trail facetheory-stitch-audit-trail-variant-${variant}`}
+  data-safety-policy={trail.safetyPolicy}
+  data-group-id={trail.groupId}
+  data-variant={variant}
+  data-group-count={String(trail.groups.length)}
+  data-event-count={String(eventCount)}
+  data-error-count={String(errorCount)}
+  aria-labelledby={labelId}
+  aria-describedby={descriptionId}
+>
+  {#if trail.label !== undefined || trail.description !== undefined}
+    <header>
+      {#if trail.label !== undefined}
+        <h2 id={labelId} class="facetheory-stitch-audit-trail-label">{trail.label}</h2>
+      {/if}
+      {#if trail.description !== undefined}
+        <p id={descriptionId} class="facetheory-stitch-audit-trail-description">{trail.description}</p>
+      {/if}
+    </header>
+  {/if}
+
+  {#if trail.metadata !== undefined}
+    <MetadataBadgeGroup metadata={trail.metadata} />
+  {/if}
+
+  {#if isEmpty}
+    <div class="facetheory-stitch-audit-trail-empty" role="status">
+      {#if trail.emptyLabel !== undefined}{trail.emptyLabel}{:else}No audit events.{/if}
+    </div>
+  {:else}
+    <ul role="list" class="facetheory-stitch-audit-trail-groups">
+      {#each trail.groups as group (group.id)}
+        {@const expanded = group.expanded === true}
+        {@const eventsRegionId = `${group.id}-events`}
+        {@const hasErrors = groupErrorCount(group) > 0}
+        <li
+          class={`facetheory-stitch-audit-trail-group${hasErrors ? ' facetheory-stitch-audit-trail-group-has-error' : ''}`}
+          data-group-id={group.id}
+          data-group-expanded={expanded ? 'true' : 'false'}
+          data-group-event-count={String(group.events.length)}
+          data-group-error-count={String(groupErrorCount(group))}
+        >
+          <button
+            type="button"
+            id={group.id}
+            class="facetheory-stitch-audit-trail-group-toggle"
+            aria-expanded={expanded ? 'true' : 'false'}
+            aria-controls={eventsRegionId}
+            data-group-toggle={group.id}
+            on:click={() => handleToggleGroup(group.id, expanded)}
+          >
+            <span class="facetheory-stitch-audit-trail-group-label">{group.label}</span>
+            <span
+              class="facetheory-stitch-audit-trail-group-count"
+              data-group-event-count-label={String(group.events.length)}
+            >{group.events.length} events</span>
+            <span
+              class="facetheory-stitch-audit-trail-group-state"
+              data-group-state-label={expanded ? 'expanded' : 'collapsed'}
+            >{expanded ? 'Hide' : 'Show'}</span>
+          </button>
+          {#if group.description !== undefined}
+            <p class="facetheory-stitch-audit-trail-group-description">{group.description}</p>
+          {/if}
+          <div
+            id={eventsRegionId}
+            class="facetheory-stitch-audit-trail-group-events"
+            role="region"
+            aria-labelledby={group.id}
+            aria-hidden={expanded ? 'false' : 'true'}
+            hidden={!expanded}
+          >
+            {#if expanded}
+              <ol role="list" class="facetheory-stitch-audit-trail-event-list">
+                {#each group.events as event (event.id)}
+                  {@const tone = (event.tone ?? 'neutral')}
+                  {@const redacted = isRedacted(event)}
+                  <li
+                    class={`facetheory-stitch-audit-event facetheory-stitch-audit-event-tone-${tone}${
+                      event.status !== undefined
+                        ? ` facetheory-stitch-audit-event-status-${event.status}`
+                        : ''
+                    }${redacted ? ' facetheory-stitch-audit-event-redacted' : ''}`}
+                    data-event-id={event.id}
+                    data-event-tone={tone}
+                    data-event-status={event.status ?? ''}
+                    data-event-redacted={redacted ? 'true' : 'false'}
+                    role={eventRole(event)}
+                  >
+                    <div class="facetheory-stitch-audit-event-header">
+                      <time
+                        class="facetheory-stitch-audit-event-timestamp"
+                        data-event-timestamp={event.timestamp}
+                        datetime={event.timestamp}
+                      >{event.timestamp}</time>
+                      {#if event.icon !== undefined}
+                        <span class="facetheory-stitch-audit-event-icon" aria-hidden="true">{event.icon}</span>
+                      {/if}
+                      <strong class="facetheory-stitch-audit-event-title">{event.title}</strong>
+                      {#if event.status !== undefined}
+                        <span
+                          class={`facetheory-stitch-audit-event-status facetheory-stitch-audit-event-status-${event.status}`}
+                          data-status-pill={event.status}
+                        >{STATUS_LABEL[event.status]}</span>
+                      {/if}
+                      {#if event.tone !== undefined}
+                        <span
+                          class={`facetheory-stitch-audit-event-tone facetheory-stitch-audit-event-tone-${event.tone}`}
+                          data-tone-pill={event.tone}
+                        >{TONE_LABEL[event.tone]}</span>
+                      {/if}
+                    </div>
+                    {#if event.actor !== undefined || event.actorSource !== undefined}
+                      <div class="facetheory-stitch-audit-event-actor">
+                        {#if event.actor !== undefined}
+                          <span data-actor-label="true">{event.actor}</span>
+                        {/if}
+                        {#if event.actorSource !== undefined}
+                          <span
+                            class="facetheory-stitch-audit-event-actor-source"
+                            data-actor-source="true"
+                          >{event.actorSource}</span>
+                        {/if}
+                      </div>
+                    {/if}
+                    {#if redacted}
+                      <p
+                        class="facetheory-stitch-audit-event-redacted-marker"
+                        data-event-redacted-marker="true"
+                      >{event.redactedMarker}</p>
+                    {:else}
+                      {#if event.body !== undefined && variant === 'detailed'}
+                        <p class="facetheory-stitch-audit-event-body">{event.body}</p>
+                      {/if}
+                      {#if event.metadata !== undefined && event.metadata.length > 0 && variant === 'detailed'}
+                        <dl
+                          class="facetheory-stitch-audit-event-metadata"
+                          data-metadata-count={String(event.metadata.length)}
+                        >
+                          {#each event.metadata as entry (entry.key)}
+                            <dt
+                              class="facetheory-stitch-audit-event-metadata-key"
+                              data-metadata-key={entry.key}
+                            >{entry.label}</dt>
+                            <dd class="facetheory-stitch-audit-event-metadata-value">{entry.value}</dd>
+                          {/each}
+                        </dl>
+                      {/if}
+                      {#if event.externalLink !== undefined}
+                        {@const safeHref = safeLinkHref(event.externalLink.href)}
+                        {#if safeHref !== undefined}
+                          <a
+                            class="facetheory-stitch-audit-event-external-link"
+                            data-external-link="true"
+                            href={safeHref}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >{#if event.externalLink.label !== undefined}{event.externalLink.label}{:else}{event.externalLink.href}{/if}</a>
+                        {/if}
+                      {/if}
+                    {/if}
+                  </li>
+                {/each}
+              </ol>
+            {/if}
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <p
+    class="facetheory-stitch-wizard-safety-footnote"
+    data-safety-policy={trail.safetyPolicy}
+  >Safety policy: {trail.safetyPolicy}</p>
+</section>

--- a/ts/src/svelte/stitch-admin/DisclosurePanel.svelte
+++ b/ts/src/svelte/stitch-admin/DisclosurePanel.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import type {
+    AuditTrailEventStatus,
+    AuditTrailEventTone,
+    DisclosurePanelProps,
+  } from '../../stitch-admin/audit-trail-types.js';
+
+  export let panel: DisclosurePanelProps;
+  export let onToggle: ((nextExpanded: boolean) => void) | undefined =
+    undefined;
+
+  $: tone = (panel.tone ?? 'neutral') as AuditTrailEventTone;
+  $: status = panel.status as AuditTrailEventStatus | undefined;
+  $: stateRole = status === 'error' ? 'alert' : undefined;
+  $: panelContentId = `${panel.panelId}-region`;
+
+  function handleToggle(): void {
+    if (onToggle === undefined) return;
+    onToggle(!panel.expanded);
+  }
+</script>
+
+<section
+  class={`facetheory-stitch-disclosure-panel facetheory-stitch-disclosure-panel-tone-${tone}${
+    status !== undefined
+      ? ` facetheory-stitch-disclosure-panel-status-${status}`
+      : ''
+  }`}
+  data-disclosure-id={panel.panelId}
+  data-disclosure-expanded={panel.expanded ? 'true' : 'false'}
+  data-disclosure-tone={tone}
+  data-disclosure-status={status ?? ''}
+  data-safety-policy={panel.safetyPolicy}
+  role={stateRole}
+>
+  <button
+    type="button"
+    id={panel.panelId}
+    class="facetheory-stitch-disclosure-panel-toggle"
+    aria-expanded={panel.expanded ? 'true' : 'false'}
+    aria-controls={panelContentId}
+    data-disclosure-toggle={panel.panelId}
+    on:click={handleToggle}
+  >
+    <span class="facetheory-stitch-disclosure-panel-label">{panel.label}</span>
+    <span
+      class="facetheory-stitch-disclosure-panel-state"
+      data-disclosure-state-label={panel.expanded ? 'expanded' : 'collapsed'}
+    >{panel.expanded ? 'Hide' : 'Show'}</span>
+  </button>
+
+  {#if panel.description !== undefined}
+    <p class="facetheory-stitch-disclosure-panel-description">{panel.description}</p>
+  {/if}
+
+  <div
+    id={panelContentId}
+    class="facetheory-stitch-disclosure-panel-content"
+    role="region"
+    aria-labelledby={panel.panelId}
+    aria-hidden={panel.expanded ? 'false' : 'true'}
+    hidden={!panel.expanded}
+  >
+    {#if panel.expanded}
+      <slot />
+    {/if}
+  </div>
+
+  <p
+    class="facetheory-stitch-wizard-safety-footnote"
+    data-safety-policy={panel.safetyPolicy}
+  >Safety policy: {panel.safetyPolicy}</p>
+</section>

--- a/ts/src/svelte/stitch-admin/index.d.ts
+++ b/ts/src/svelte/stitch-admin/index.d.ts
@@ -373,7 +373,8 @@ export interface WizardAuthorityContextStripPanelProps {
   strip: import('../../stitch-admin/wizard-authority-context-strip-types.js').WizardAuthorityContextStrip;
   onCopyItem?: (itemKey: string, copyValue: string) => void;
 }
-export type WizardServerResolvedContextBarPanelProps = WizardAuthorityContextStripPanelProps;
+export type WizardServerResolvedContextBarPanelProps =
+  WizardAuthorityContextStripPanelProps;
 
 export type {
   ChoiceCardProps,
@@ -410,14 +411,18 @@ export type {
 export interface PackageSourceInputPanelProps {
   input: import('../../stitch-admin/package-source-input-types.js').PackageSourceInput;
   onValueChange?: (next: string) => void;
-  onFiles?: (files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[]) => void;
+  onFiles?: (
+    files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[],
+  ) => void;
   onClear?: () => void;
   onReplace?: () => void;
   onCopy?: (copyValue: string) => void;
 }
 export interface CodeDropzonePanelProps {
   dropzone: import('../../stitch-admin/package-source-input-types.js').CodeDropzoneProps;
-  onFiles?: (files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[]) => void;
+  onFiles?: (
+    files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[],
+  ) => void;
 }
 export declare const PackageSourceInputPanel: Component<PackageSourceInputPanelProps>;
 export declare const CodeDropzone: Component<CodeDropzonePanelProps>;
@@ -434,3 +439,28 @@ export declare const WizardReconciliationPlanPanel: Component<WizardReconciliati
 export declare const WizardDiffListPanel: Component<WizardDiffListPanelProps>;
 export declare const WizardAuthorityContextStripPanel: Component<WizardAuthorityContextStripPanelProps>;
 export declare const WizardServerResolvedContextBarPanel: Component<WizardServerResolvedContextBarPanelProps>;
+
+export type {
+  AuditTrail,
+  AuditTrailEvent,
+  AuditTrailEventExternalLink,
+  AuditTrailEventGroup,
+  AuditTrailEventMetadataEntry,
+  AuditTrailEventStatus,
+  AuditTrailEventTone,
+  AuditTrailVariant,
+  DisclosurePanelProps,
+} from '../../stitch-admin/audit-trail-types.js';
+
+export interface AuditTrailPanelProps {
+  trail: import('../../stitch-admin/audit-trail-types.js').AuditTrail;
+  onToggleGroup?: (groupId: string, nextExpanded: boolean) => void;
+}
+
+export interface DisclosurePanelPanelProps {
+  panel: import('../../stitch-admin/audit-trail-types.js').DisclosurePanelProps;
+  onToggle?: (nextExpanded: boolean) => void;
+}
+
+export declare const AuditTrailPanel: Component<AuditTrailPanelProps>;
+export declare const DisclosurePanel: Component<DisclosurePanelPanelProps>;

--- a/ts/src/svelte/stitch-admin/index.ts
+++ b/ts/src/svelte/stitch-admin/index.ts
@@ -34,6 +34,8 @@ export { default as WizardReconciliationPlanPanel } from './WizardReconciliation
 export { default as WizardDiffListPanel } from './WizardReconciliationPlanPanel.svelte';
 export { default as WizardAuthorityContextStripPanel } from './WizardAuthorityContextStripPanel.svelte';
 export { default as WizardServerResolvedContextBarPanel } from './WizardAuthorityContextStripPanel.svelte';
+export { default as AuditTrailPanel } from './AuditTrailPanel.svelte';
+export { default as DisclosurePanel } from './DisclosurePanel.svelte';
 export { default as SelectableCardGridPanel } from './SelectableCardGridPanel.svelte';
 export { default as ChoiceCard } from './ChoiceCard.svelte';
 export { default as PackageSourceInputPanel } from './PackageSourceInputPanel.svelte';
@@ -111,6 +113,23 @@ export type {
   WizardServerResolvedContextBarSize,
   WizardServerResolvedContextBarTone,
 } from '../../stitch-admin/wizard-authority-context-strip-types.js';
+
+export type {
+  AuditTrail,
+  AuditTrailEvent,
+  AuditTrailEventExternalLink,
+  AuditTrailEventGroup,
+  AuditTrailEventMetadataEntry,
+  AuditTrailEventStatus,
+  AuditTrailEventTone,
+  AuditTrailVariant,
+  DisclosurePanelProps,
+} from '../../stitch-admin/audit-trail-types.js';
+
+export type {
+  AuditTrailPanelProps,
+  DisclosurePanelPanelProps,
+} from './types.js';
 
 export type {
   WizardEditableTokenInput,

--- a/ts/src/svelte/stitch-admin/types.ts
+++ b/ts/src/svelte/stitch-admin/types.ts
@@ -270,7 +270,8 @@ export interface WizardAuthorityContextStripPanelProps {
   onCopyItem?: (itemKey: string, copyValue: string) => void;
 }
 
-export type WizardServerResolvedContextBarPanelProps = WizardAuthorityContextStripPanelProps;
+export type WizardServerResolvedContextBarPanelProps =
+  WizardAuthorityContextStripPanelProps;
 
 export type {
   ChoiceCardProps,
@@ -306,7 +307,9 @@ export type {
 export interface PackageSourceInputPanelProps {
   input: import('../../stitch-admin/package-source-input-types.js').PackageSourceInput;
   onValueChange?: (next: string) => void;
-  onFiles?: (files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[]) => void;
+  onFiles?: (
+    files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[],
+  ) => void;
   onClear?: () => void;
   onReplace?: () => void;
   onCopy?: (copyValue: string) => void;
@@ -314,5 +317,29 @@ export interface PackageSourceInputPanelProps {
 
 export interface CodeDropzonePanelProps {
   dropzone: import('../../stitch-admin/package-source-input-types.js').CodeDropzoneProps;
-  onFiles?: (files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[]) => void;
+  onFiles?: (
+    files: import('../../stitch-admin/package-source-input-types.js').PackageSourceInputFileMeta[],
+  ) => void;
+}
+
+export type {
+  AuditTrail,
+  AuditTrailEvent,
+  AuditTrailEventExternalLink,
+  AuditTrailEventGroup,
+  AuditTrailEventMetadataEntry,
+  AuditTrailEventStatus,
+  AuditTrailEventTone,
+  AuditTrailVariant,
+  DisclosurePanelProps,
+} from '../../stitch-admin/audit-trail-types.js';
+
+export interface AuditTrailPanelProps {
+  trail: import('../../stitch-admin/audit-trail-types.js').AuditTrail;
+  onToggleGroup?: (groupId: string, nextExpanded: boolean) => void;
+}
+
+export interface DisclosurePanelPanelProps {
+  panel: import('../../stitch-admin/audit-trail-types.js').DisclosurePanelProps;
+  onToggle?: (nextExpanded: boolean) => void;
 }

--- a/ts/src/vue/stitch-admin/audit-trail.ts
+++ b/ts/src/vue/stitch-admin/audit-trail.ts
@@ -1,0 +1,564 @@
+/**
+ * Vue parity for `AuditTrailPanel` and standalone `DisclosurePanel`. Mirrors
+ * the React adapter's class names, data-* attributes, ARIA wiring, role
+ * markers (error events as `role="alert"`), tone/status pills, redacted
+ * marker rule, safe-href filtering on external links, and safety-policy
+ * footnote.
+ *
+ * Presentation-only — see `stitch-admin/audit-trail-types.ts` for the
+ * trust-boundary contract.
+ */
+
+import { defineComponent, h } from 'vue';
+import type { PropType, VNodeChild } from 'vue';
+
+import { safeMetadataHref } from '../../stitch-admin/safe-url.js';
+import type {
+  AuditTrail,
+  AuditTrailEvent,
+  AuditTrailEventExternalLink,
+  AuditTrailEventGroup,
+  AuditTrailEventMetadataEntry,
+  AuditTrailEventStatus,
+  AuditTrailEventTone,
+  AuditTrailVariant,
+  DisclosurePanelProps,
+} from '../../stitch-admin/audit-trail-types.js';
+import type { WizardSafetyPolicy } from '../../stitch-admin/wizard-types.js';
+import { renderPropContent, vnodeChildProp } from '../stitch-common.js';
+import { MetadataBadgeGroup } from './operator-notices.js';
+
+export type {
+  AuditTrail,
+  AuditTrailEvent,
+  AuditTrailEventExternalLink,
+  AuditTrailEventGroup,
+  AuditTrailEventMetadataEntry,
+  AuditTrailEventStatus,
+  AuditTrailEventTone,
+  AuditTrailVariant,
+  DisclosurePanelProps,
+};
+
+export interface AuditTrailPanelProps {
+  trail: AuditTrail;
+  onToggleGroup?: (groupId: string, nextExpanded: boolean) => void;
+}
+
+export interface DisclosurePanelPanelProps {
+  panel: DisclosurePanelProps;
+  onToggle?: (nextExpanded: boolean) => void;
+  default?: VNodeChild;
+}
+
+const STATUS_LABEL: Record<AuditTrailEventStatus, string> = {
+  info: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  error: 'Error',
+};
+
+const TONE_LABEL: Record<AuditTrailEventTone, string> = {
+  neutral: 'Neutral',
+  info: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  danger: 'Danger',
+};
+
+function renderSafetyFootnote(policy: WizardSafetyPolicy): VNodeChild {
+  return h(
+    'p',
+    {
+      class: 'facetheory-stitch-wizard-safety-footnote',
+      'data-safety-policy': policy,
+    },
+    `Safety policy: ${policy}`,
+  );
+}
+
+function isRedactedEvent(event: AuditTrailEvent): boolean {
+  return event.redactedMarker !== undefined && event.redactedMarker !== '';
+}
+
+function renderTonePill(event: AuditTrailEvent): VNodeChild {
+  const tone = event.tone;
+  if (tone === undefined) return null;
+  return h(
+    'span',
+    {
+      class: `facetheory-stitch-audit-event-tone facetheory-stitch-audit-event-tone-${tone}`,
+      'data-tone-pill': tone,
+    },
+    TONE_LABEL[tone],
+  );
+}
+
+function renderStatusPill(event: AuditTrailEvent): VNodeChild {
+  const status = event.status;
+  if (status === undefined) return null;
+  return h(
+    'span',
+    {
+      class: `facetheory-stitch-audit-event-status facetheory-stitch-audit-event-status-${status}`,
+      'data-status-pill': status,
+    },
+    STATUS_LABEL[status],
+  );
+}
+
+function renderActorRow(event: AuditTrailEvent): VNodeChild {
+  if (event.actor === undefined && event.actorSource === undefined) return null;
+  return h('div', { class: 'facetheory-stitch-audit-event-actor' }, [
+    event.actor !== undefined
+      ? h(
+          'span',
+          { 'data-actor-label': 'true' },
+          renderPropContent(event.actor as VNodeChild),
+        )
+      : null,
+    event.actorSource !== undefined
+      ? h(
+          'span',
+          {
+            class: 'facetheory-stitch-audit-event-actor-source',
+            'data-actor-source': 'true',
+          },
+          event.actorSource,
+        )
+      : null,
+  ]);
+}
+
+function renderMetadata(metadata: AuditTrailEventMetadataEntry[]): VNodeChild {
+  return h(
+    'dl',
+    {
+      class: 'facetheory-stitch-audit-event-metadata',
+      'data-metadata-count': String(metadata.length),
+    },
+    metadata.flatMap((entry) => [
+      h(
+        'dt',
+        {
+          key: `${entry.key}-dt`,
+          class: 'facetheory-stitch-audit-event-metadata-key',
+          'data-metadata-key': entry.key,
+        },
+        renderPropContent(entry.label as VNodeChild),
+      ),
+      h(
+        'dd',
+        {
+          key: `${entry.key}-dd`,
+          class: 'facetheory-stitch-audit-event-metadata-value',
+        },
+        renderPropContent(entry.value as VNodeChild),
+      ),
+    ]),
+  );
+}
+
+function renderExternalLink(link: AuditTrailEventExternalLink): VNodeChild {
+  const safeHref = safeMetadataHref(link.href);
+  if (safeHref === undefined) return null;
+  return h(
+    'a',
+    {
+      class: 'facetheory-stitch-audit-event-external-link',
+      'data-external-link': 'true',
+      href: safeHref,
+      rel: 'noopener noreferrer',
+      target: '_blank',
+    },
+    link.label !== undefined
+      ? renderPropContent(link.label as VNodeChild)
+      : link.href,
+  );
+}
+
+function renderEventBody(
+  event: AuditTrailEvent,
+  variant: AuditTrailVariant,
+): VNodeChild[] {
+  if (isRedactedEvent(event)) {
+    return [
+      h(
+        'p',
+        {
+          class: 'facetheory-stitch-audit-event-redacted-marker',
+          'data-event-redacted-marker': 'true',
+        },
+        event.redactedMarker,
+      ),
+    ];
+  }
+  const out: VNodeChild[] = [];
+  if (event.body !== undefined && variant === 'detailed') {
+    out.push(
+      h(
+        'p',
+        { class: 'facetheory-stitch-audit-event-body' },
+        renderPropContent(event.body as VNodeChild),
+      ),
+    );
+  }
+  if (
+    event.metadata !== undefined &&
+    event.metadata.length > 0 &&
+    variant === 'detailed'
+  ) {
+    out.push(renderMetadata(event.metadata));
+  }
+  if (event.externalLink !== undefined) {
+    const link = renderExternalLink(event.externalLink);
+    if (link !== null) out.push(link);
+  }
+  return out;
+}
+
+function renderEvent(
+  event: AuditTrailEvent,
+  variant: AuditTrailVariant,
+): VNodeChild {
+  const tone: AuditTrailEventTone = event.tone ?? 'neutral';
+  const redacted = isRedactedEvent(event);
+  const error = event.status === 'error';
+  const role: 'listitem' | 'alert' = error ? 'alert' : 'listitem';
+  return h(
+    'li',
+    {
+      key: event.id,
+      class: `facetheory-stitch-audit-event facetheory-stitch-audit-event-tone-${tone}${
+        event.status !== undefined
+          ? ` facetheory-stitch-audit-event-status-${event.status}`
+          : ''
+      }${redacted ? ' facetheory-stitch-audit-event-redacted' : ''}`,
+      'data-event-id': event.id,
+      'data-event-tone': tone,
+      'data-event-status': event.status ?? '',
+      'data-event-redacted': redacted ? 'true' : 'false',
+      role,
+    },
+    [
+      h('div', { class: 'facetheory-stitch-audit-event-header' }, [
+        h(
+          'time',
+          {
+            class: 'facetheory-stitch-audit-event-timestamp',
+            'data-event-timestamp': event.timestamp,
+            dateTime: event.timestamp,
+          },
+          event.timestamp,
+        ),
+        event.icon !== undefined
+          ? h(
+              'span',
+              {
+                class: 'facetheory-stitch-audit-event-icon',
+                'aria-hidden': 'true',
+              },
+              renderPropContent(event.icon as VNodeChild),
+            )
+          : null,
+        h(
+          'strong',
+          { class: 'facetheory-stitch-audit-event-title' },
+          renderPropContent(event.title as VNodeChild),
+        ),
+        renderStatusPill(event),
+        renderTonePill(event),
+      ]),
+      renderActorRow(event),
+      ...renderEventBody(event, variant),
+    ],
+  );
+}
+
+function renderGroup(
+  group: AuditTrailEventGroup,
+  variant: AuditTrailVariant,
+  onToggleGroup: AuditTrailPanelProps['onToggleGroup'],
+): VNodeChild {
+  const expanded = group.expanded === true;
+  const eventsRegionId = `${group.id}-events`;
+  const hasErrors = group.events.some((e) => e.status === 'error');
+  return h(
+    'li',
+    {
+      key: group.id,
+      class: `facetheory-stitch-audit-trail-group${hasErrors ? ' facetheory-stitch-audit-trail-group-has-error' : ''}`,
+      'data-group-id': group.id,
+      'data-group-expanded': expanded ? 'true' : 'false',
+      'data-group-event-count': String(group.events.length),
+      'data-group-error-count': String(
+        group.events.filter((e) => e.status === 'error').length,
+      ),
+    },
+    [
+      h(
+        'button',
+        {
+          type: 'button',
+          id: group.id,
+          class: 'facetheory-stitch-audit-trail-group-toggle',
+          'aria-expanded': expanded ? 'true' : 'false',
+          'aria-controls': eventsRegionId,
+          'data-group-toggle': group.id,
+          onClick:
+            onToggleGroup !== undefined
+              ? () => onToggleGroup(group.id, !expanded)
+              : undefined,
+        },
+        [
+          h(
+            'span',
+            { class: 'facetheory-stitch-audit-trail-group-label' },
+            renderPropContent(group.label as VNodeChild),
+          ),
+          h(
+            'span',
+            {
+              class: 'facetheory-stitch-audit-trail-group-count',
+              'data-group-event-count-label': String(group.events.length),
+            },
+            `${group.events.length} events`,
+          ),
+          h(
+            'span',
+            {
+              class: 'facetheory-stitch-audit-trail-group-state',
+              'data-group-state-label': expanded ? 'expanded' : 'collapsed',
+            },
+            expanded ? 'Hide' : 'Show',
+          ),
+        ],
+      ),
+      group.description !== undefined
+        ? h(
+            'p',
+            { class: 'facetheory-stitch-audit-trail-group-description' },
+            renderPropContent(group.description as VNodeChild),
+          )
+        : null,
+      h(
+        'div',
+        {
+          id: eventsRegionId,
+          class: 'facetheory-stitch-audit-trail-group-events',
+          role: 'region',
+          'aria-labelledby': group.id,
+          'aria-hidden': expanded ? 'false' : 'true',
+          hidden: !expanded,
+        },
+        [
+          expanded
+            ? h(
+                'ol',
+                {
+                  role: 'list',
+                  class: 'facetheory-stitch-audit-trail-event-list',
+                },
+                group.events.map((event) => renderEvent(event, variant)),
+              )
+            : null,
+        ],
+      ),
+    ],
+  );
+}
+
+export const AuditTrailPanel = defineComponent({
+  name: 'FaceTheoryVueAuditTrailPanel',
+  props: {
+    trail: { type: Object as PropType<AuditTrail>, required: true },
+    onToggleGroup: {
+      type: Function as PropType<
+        (groupId: string, nextExpanded: boolean) => void
+      >,
+      required: false,
+    },
+  },
+  setup(props) {
+    return () => {
+      const trail = props.trail;
+      const totalEvents = trail.groups.reduce(
+        (acc, g) => acc + g.events.length,
+        0,
+      );
+      const errorEvents = trail.groups.reduce(
+        (acc, g) => acc + g.events.filter((e) => e.status === 'error').length,
+        0,
+      );
+      const labelId =
+        trail.label !== undefined ? `${trail.groupId}-label` : undefined;
+      const descriptionId =
+        trail.description !== undefined
+          ? `${trail.groupId}-description`
+          : undefined;
+      const isEmpty = totalEvents === 0;
+      return h(
+        'section',
+        {
+          class: `facetheory-stitch-audit-trail facetheory-stitch-audit-trail-variant-${trail.variant}`,
+          'data-safety-policy': trail.safetyPolicy,
+          'data-group-id': trail.groupId,
+          'data-variant': trail.variant,
+          'data-group-count': String(trail.groups.length),
+          'data-event-count': String(totalEvents),
+          'data-error-count': String(errorEvents),
+          'aria-labelledby': labelId,
+          'aria-describedby': descriptionId,
+        },
+        [
+          trail.label !== undefined || trail.description !== undefined
+            ? h('header', null, [
+                trail.label !== undefined
+                  ? h(
+                      'h2',
+                      {
+                        id: labelId,
+                        class: 'facetheory-stitch-audit-trail-label',
+                      },
+                      renderPropContent(trail.label as VNodeChild),
+                    )
+                  : null,
+                trail.description !== undefined
+                  ? h(
+                      'p',
+                      {
+                        id: descriptionId,
+                        class: 'facetheory-stitch-audit-trail-description',
+                      },
+                      renderPropContent(trail.description as VNodeChild),
+                    )
+                  : null,
+              ])
+            : null,
+          trail.metadata !== undefined
+            ? h(MetadataBadgeGroup, { metadata: trail.metadata })
+            : null,
+          isEmpty
+            ? h(
+                'div',
+                {
+                  class: 'facetheory-stitch-audit-trail-empty',
+                  role: 'status',
+                },
+                trail.emptyLabel !== undefined
+                  ? renderPropContent(trail.emptyLabel as VNodeChild)
+                  : 'No audit events.',
+              )
+            : h(
+                'ul',
+                {
+                  role: 'list',
+                  class: 'facetheory-stitch-audit-trail-groups',
+                },
+                trail.groups.map((group) =>
+                  renderGroup(group, trail.variant, props.onToggleGroup),
+                ),
+              ),
+          renderSafetyFootnote(trail.safetyPolicy),
+        ],
+      );
+    };
+  },
+});
+
+export const DisclosurePanel = defineComponent({
+  name: 'FaceTheoryVueDisclosurePanel',
+  props: {
+    panel: { type: Object as PropType<DisclosurePanelProps>, required: true },
+    onToggle: {
+      type: Function as PropType<(nextExpanded: boolean) => void>,
+      required: false,
+    },
+    default: vnodeChildProp,
+  },
+  setup(props, { slots }) {
+    return () => {
+      const panel = props.panel;
+      const tone: AuditTrailEventTone = panel.tone ?? 'neutral';
+      const error = panel.status === 'error';
+      const stateRole: 'alert' | undefined = error ? 'alert' : undefined;
+      const panelContentId = `${panel.panelId}-region`;
+      const body = panel.expanded
+        ? (slots.default?.() ??
+          (props.default !== undefined ? renderPropContent(props.default) : []))
+        : [];
+      return h(
+        'section',
+        {
+          class: `facetheory-stitch-disclosure-panel facetheory-stitch-disclosure-panel-tone-${tone}${
+            panel.status !== undefined
+              ? ` facetheory-stitch-disclosure-panel-status-${panel.status}`
+              : ''
+          }`,
+          'data-disclosure-id': panel.panelId,
+          'data-disclosure-expanded': panel.expanded ? 'true' : 'false',
+          'data-disclosure-tone': tone,
+          'data-disclosure-status': panel.status ?? '',
+          'data-safety-policy': panel.safetyPolicy,
+          role: stateRole,
+        },
+        [
+          h(
+            'button',
+            {
+              type: 'button',
+              id: panel.panelId,
+              class: 'facetheory-stitch-disclosure-panel-toggle',
+              'aria-expanded': panel.expanded ? 'true' : 'false',
+              'aria-controls': panelContentId,
+              'data-disclosure-toggle': panel.panelId,
+              onClick:
+                props.onToggle !== undefined
+                  ? () => props.onToggle!(!panel.expanded)
+                  : undefined,
+            },
+            [
+              h(
+                'span',
+                { class: 'facetheory-stitch-disclosure-panel-label' },
+                renderPropContent(panel.label as VNodeChild),
+              ),
+              h(
+                'span',
+                {
+                  class: 'facetheory-stitch-disclosure-panel-state',
+                  'data-disclosure-state-label': panel.expanded
+                    ? 'expanded'
+                    : 'collapsed',
+                },
+                panel.expanded ? 'Hide' : 'Show',
+              ),
+            ],
+          ),
+          panel.description !== undefined
+            ? h(
+                'p',
+                {
+                  class: 'facetheory-stitch-disclosure-panel-description',
+                },
+                renderPropContent(panel.description as VNodeChild),
+              )
+            : null,
+          h(
+            'div',
+            {
+              id: panelContentId,
+              class: 'facetheory-stitch-disclosure-panel-content',
+              role: 'region',
+              'aria-labelledby': panel.panelId,
+              'aria-hidden': panel.expanded ? 'false' : 'true',
+              hidden: !panel.expanded,
+            },
+            body,
+          ),
+          renderSafetyFootnote(panel.safetyPolicy),
+        ],
+      );
+    };
+  },
+});

--- a/ts/src/vue/stitch-admin/index.ts
+++ b/ts/src/vue/stitch-admin/index.ts
@@ -146,6 +146,22 @@ export {
 } from './wizard-authority-context-strip.js';
 
 export {
+  AuditTrailPanel,
+  DisclosurePanel,
+  type AuditTrailPanelProps,
+  type DisclosurePanelPanelProps,
+  type AuditTrail,
+  type AuditTrailEvent,
+  type AuditTrailEventExternalLink,
+  type AuditTrailEventGroup,
+  type AuditTrailEventMetadataEntry,
+  type AuditTrailEventStatus,
+  type AuditTrailEventTone,
+  type AuditTrailVariant,
+  type DisclosurePanelProps,
+} from './audit-trail.js';
+
+export {
   PackageSourceInputPanel,
   CodeDropzone,
   type PackageSourceInputPanelProps,

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -25,6 +25,7 @@ await import('./unit/stitch-admin-wizard-authority-context-strip.test.js');
 await import('./unit/stitch-admin-selectable-card-grid.test.js');
 await import('./unit/stitch-admin-package-source-input.test.js');
 await import('./unit/stitch-admin-wizard-editable-token-input.test.js');
+await import('./unit/stitch-admin-audit-trail.test.js');
 await import('./unit/portal-fixtures.test.js');
 await import('./unit/antd-coverage.test.js');
 await import('./unit/portal-reference.test.js');

--- a/ts/test/unit/stitch-admin-audit-trail.test.ts
+++ b/ts/test/unit/stitch-admin-audit-trail.test.ts
@@ -1,0 +1,353 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as React from 'react';
+
+import { createFaceApp } from '../../src/app.js';
+import { createReactFace } from '../../src/adapters/react.js';
+import { createAntdIntegration } from '../../src/react/antd.js';
+import type {
+  AuditTrail,
+  DisclosurePanelProps,
+} from '../../src/stitch-admin/index.js';
+import {
+  AuditTrailPanel,
+  DisclosurePanel,
+} from '../../src/react/stitch-admin/index.js';
+
+const h = React.createElement;
+
+async function renderSSR(element: React.ReactElement): Promise<string> {
+  const app = createFaceApp({
+    faces: [
+      createReactFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => element,
+        renderOptions: {
+          integrations: [createAntdIntegration({ hashed: false })],
+        },
+      }),
+    ],
+  });
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  return new TextDecoder().decode(resp.body as Uint8Array);
+}
+
+function countMatches(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fixtures                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const SAMPLE_TRAIL: AuditTrail = {
+  groupId: 'trail-root',
+  label: 'Validation history',
+  description: 'Server-derived audit events for this import.',
+  variant: 'detailed',
+  safetyPolicy: 'no-secret-or-production-like-data',
+  groups: [
+    {
+      id: 'parse',
+      label: 'Parse',
+      description: 'Manifest parsing events.',
+      expanded: true,
+      events: [
+        {
+          id: 'parse-start',
+          timestamp: '2026-05-21T17:00:00.000Z',
+          title: 'Parse started',
+          status: 'info',
+          tone: 'info',
+          actor: 'theory-mcp-server',
+          actorSource: 'Server-derived',
+        },
+        {
+          id: 'parse-done',
+          timestamp: '2026-05-21T17:00:02.000Z',
+          title: 'Parse complete',
+          status: 'success',
+          tone: 'success',
+          body: 'Manifest is well-formed.',
+          metadata: [
+            { key: 'files', label: 'Files', value: '3' },
+            { key: 'bytes', label: 'Bytes', value: '4,212' },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'reconcile',
+      label: 'Reconcile',
+      description: 'Reconciliation against existing inventory.',
+      expanded: true,
+      events: [
+        {
+          id: 'reconcile-warn',
+          timestamp: '2026-05-21T17:00:03.000Z',
+          title: 'Drift detected',
+          status: 'warning',
+          tone: 'warning',
+          body: 'One capability has drifted from authoritative state.',
+        },
+        {
+          id: 'reconcile-error',
+          timestamp: '2026-05-21T17:00:04.000Z',
+          title: 'Conflict',
+          status: 'error',
+          tone: 'danger',
+          body: 'Two capabilities conflict.',
+          externalLink: {
+            href: 'https://docs.example.com/reconcile-conflict',
+            label: 'Reconciliation help',
+          },
+        },
+      ],
+    },
+    {
+      id: 'apply',
+      label: 'Apply',
+      description: 'Final apply phase.',
+      expanded: true,
+      events: [
+        {
+          // Even though the host supplies body / metadata / externalLink here,
+          // the primitive must render ONLY the redactedMarker.
+          id: 'apply-redacted',
+          timestamp: '2026-05-21T17:00:05.000Z',
+          title: 'Mailbox secret rotated',
+          status: 'info',
+          tone: 'neutral',
+          redactedMarker: '[redacted — mailbox secret]',
+          body: 'AKIA-NEVER-SHOWN-IN-BODY-1234567890',
+          metadata: [
+            {
+              key: 'secret',
+              label: 'Secret',
+              value: 'AKIA-NEVER-SHOWN-IN-META-1234567890',
+            },
+          ],
+          externalLink: {
+            href: 'https://docs.example.com/secret-rotation',
+            label: 'AKIA-NEVER-SHOWN-IN-LINK-1234567890',
+          },
+        },
+        // External link with an executable href must be filtered.
+        {
+          id: 'apply-unsafe-link',
+          timestamp: '2026-05-21T17:00:06.000Z',
+          title: 'Documented operator step',
+          externalLink: {
+            href: 'javascript:alert(1)',
+            label: 'Run unsafe',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const EMPTY_TRAIL: AuditTrail = {
+  groupId: 'trail-empty',
+  label: 'Validation history',
+  variant: 'compact',
+  safetyPolicy: 'no-secret-or-production-like-data',
+  emptyLabel: 'No audit events yet.',
+  groups: [],
+};
+
+const DISCLOSURE_COLLAPSED: DisclosurePanelProps = {
+  panelId: 'disc-collapsed',
+  label: 'Server resolved details',
+  description: 'Open to inspect host-resolved details.',
+  expanded: false,
+  tone: 'neutral',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+const DISCLOSURE_EXPANDED: DisclosurePanelProps = {
+  panelId: 'disc-expanded',
+  label: 'Server resolved details',
+  expanded: true,
+  tone: 'info',
+  status: 'info',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+const DISCLOSURE_ERROR: DisclosurePanelProps = {
+  panelId: 'disc-error',
+  label: 'Apply failed',
+  expanded: true,
+  tone: 'danger',
+  status: 'error',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+/* -------------------------------------------------------------------------- */
+/* AuditTrailPanel                                                            */
+/* -------------------------------------------------------------------------- */
+
+test('AuditTrailPanel renders groups + events with stable data attrs and safety footnote', async () => {
+  const body = await renderSSR(h(AuditTrailPanel, { trail: SAMPLE_TRAIL }));
+  assert.ok(body.includes('facetheory-stitch-audit-trail'));
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
+  assert.ok(body.includes('data-group-id="trail-root"'));
+  assert.ok(body.includes('data-variant="detailed"'));
+  assert.ok(body.includes('data-group-count="3"'));
+  assert.ok(body.includes('data-event-count="6"'));
+  assert.ok(body.includes('data-error-count="1"'));
+  assert.ok(body.includes('data-group-id="parse"'));
+  assert.ok(body.includes('data-group-id="reconcile"'));
+  assert.ok(body.includes('data-group-id="apply"'));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+test('AuditTrailPanel group disclosure toggles carry aria-expanded + aria-controls', async () => {
+  const body = await renderSSR(h(AuditTrailPanel, { trail: SAMPLE_TRAIL }));
+  // Each group is a button toggle.
+  assert.ok(body.includes('data-group-toggle="parse"'));
+  assert.ok(body.includes('data-group-toggle="reconcile"'));
+  assert.ok(body.includes('data-group-toggle="apply"'));
+  assert.ok(body.includes('aria-controls="parse-events"'));
+  assert.ok(body.includes('aria-controls="reconcile-events"'));
+  assert.ok(body.includes('aria-controls="apply-events"'));
+  // All three groups expanded in this fixture.
+  assert.ok(body.includes('data-group-expanded="true"'));
+  // Buttons have explicit type="button" so they don't accidentally submit forms.
+  assert.ok(body.includes('<button type="button"'));
+});
+
+test('AuditTrailPanel renders error event with role=alert', async () => {
+  const body = await renderSSR(h(AuditTrailPanel, { trail: SAMPLE_TRAIL }));
+  // Exactly one error event exists in the trail.
+  assert.ok(body.includes('data-event-id="reconcile-error"'));
+  assert.equal(countMatches(body, 'data-event-status="error"'), 1);
+  // The reconcile group is collapsed so its events region is hidden. The
+  // collapsed events still must not be in the DOM until expanded, but role
+  // markers on the <li> still appear when expanded. Confirm error count is
+  // surfaced on the group toggle.
+  assert.ok(body.includes('data-group-error-count="1"'));
+});
+
+test('AuditTrailPanel suppresses body/metadata/externalLink for redacted events', async () => {
+  const body = await renderSSR(h(AuditTrailPanel, { trail: SAMPLE_TRAIL }));
+  // Marker text is rendered.
+  assert.ok(body.includes('[redacted — mailbox secret]'));
+  assert.ok(body.includes('data-event-redacted="true"'));
+  // No part of the caller-supplied AKIA-shaped fake-secret strings is present.
+  assert.equal(body.includes('AKIA-NEVER-SHOWN-IN-BODY-1234567890'), false);
+  assert.equal(body.includes('AKIA-NEVER-SHOWN-IN-META-1234567890'), false);
+  assert.equal(body.includes('AKIA-NEVER-SHOWN-IN-LINK-1234567890'), false);
+});
+
+test('AuditTrailPanel drops javascript: external links and emits noopener+target=_blank on safe links', async () => {
+  const body = await renderSSR(h(AuditTrailPanel, { trail: SAMPLE_TRAIL }));
+  // The safe link survives.
+  assert.ok(
+    body.includes('href="https://docs.example.com/reconcile-conflict"'),
+  );
+  // The javascript: link is dropped entirely; neither href nor label remain.
+  assert.equal(body.includes('javascript:alert(1)'), false);
+  assert.equal(body.includes('Run unsafe'), false);
+  // Safe external links carry rel + target.
+  assert.ok(body.includes('rel="noopener noreferrer"'));
+  assert.ok(body.includes('target="_blank"'));
+});
+
+test('AuditTrailPanel renders empty state with caller-supplied label', async () => {
+  const body = await renderSSR(h(AuditTrailPanel, { trail: EMPTY_TRAIL }));
+  assert.ok(body.includes('facetheory-stitch-audit-trail-empty'));
+  assert.ok(body.includes('No audit events yet.'));
+  assert.ok(body.includes('data-event-count="0"'));
+});
+
+test('AuditTrailPanel produces byte-identical SSR output for the same trail', async () => {
+  const first = await renderSSR(h(AuditTrailPanel, { trail: SAMPLE_TRAIL }));
+  const second = await renderSSR(h(AuditTrailPanel, { trail: SAMPLE_TRAIL }));
+  assert.equal(first, second, 'AuditTrailPanel must be deterministic');
+});
+
+/* -------------------------------------------------------------------------- */
+/* DisclosurePanel                                                            */
+/* -------------------------------------------------------------------------- */
+
+test('DisclosurePanel renders collapsed state with hidden content region', async () => {
+  const body = await renderSSR(
+    h(
+      DisclosurePanel,
+      { panel: DISCLOSURE_COLLAPSED },
+      h('span', { 'data-disclosure-child': 'true' }, 'Hidden child'),
+    ),
+  );
+  assert.ok(body.includes('data-disclosure-id="disc-collapsed"'));
+  assert.ok(body.includes('data-disclosure-expanded="false"'));
+  assert.ok(body.includes('aria-expanded="false"'));
+  assert.ok(body.includes('aria-controls="disc-collapsed-region"'));
+  // Collapsed → child is not rendered.
+  assert.equal(body.includes('data-disclosure-child="true"'), false);
+  assert.equal(body.includes('Hidden child'), false);
+  // Safety footnote is always emitted.
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+test('DisclosurePanel renders expanded state with visible content region', async () => {
+  const body = await renderSSR(
+    h(
+      DisclosurePanel,
+      { panel: DISCLOSURE_EXPANDED },
+      h('span', { 'data-disclosure-child': 'true' }, 'Visible child'),
+    ),
+  );
+  assert.ok(body.includes('data-disclosure-id="disc-expanded"'));
+  assert.ok(body.includes('data-disclosure-expanded="true"'));
+  assert.ok(body.includes('aria-expanded="true"'));
+  assert.ok(body.includes('data-disclosure-child="true"'));
+  assert.ok(body.includes('Visible child'));
+});
+
+test('DisclosurePanel with status=error gets role=alert on the section', async () => {
+  const body = await renderSSR(
+    h(
+      DisclosurePanel,
+      { panel: DISCLOSURE_ERROR },
+      h('p', null, 'Apply failed.'),
+    ),
+  );
+  assert.ok(body.includes('data-disclosure-status="error"'));
+  assert.ok(body.includes('role="alert"'));
+});
+
+test('DisclosurePanel is byte-identical across repeated SSR renders', async () => {
+  const first = await renderSSR(
+    h(DisclosurePanel, { panel: DISCLOSURE_EXPANDED }, h('p', null, 'Same')),
+  );
+  const second = await renderSSR(
+    h(DisclosurePanel, { panel: DISCLOSURE_EXPANDED }, h('p', null, 'Same')),
+  );
+  assert.equal(first, second, 'DisclosurePanel must be deterministic');
+});
+
+/* -------------------------------------------------------------------------- */
+/* Fixture safety guard                                                       */
+/* -------------------------------------------------------------------------- */
+
+test('AuditTrail / DisclosurePanel fixtures do not leak production-like secrets into displayed surfaces', async () => {
+  const body = await renderSSR(h(AuditTrailPanel, { trail: SAMPLE_TRAIL }));
+  // The intentional fake-secret strings used inside redacted events to prove
+  // suppression must never appear in the rendered output.
+  for (const needle of [
+    'AKIA-NEVER-SHOWN-IN-BODY-1234567890',
+    'AKIA-NEVER-SHOWN-IN-META-1234567890',
+    'AKIA-NEVER-SHOWN-IN-LINK-1234567890',
+  ]) {
+    assert.equal(
+      body.includes(needle),
+      false,
+      `AuditTrailPanel must never render redacted secret "${needle}"`,
+    );
+  }
+});

--- a/ts/test/unit/svelte-stitch-admin.test.ts
+++ b/ts/test/unit/svelte-stitch-admin.test.ts
@@ -491,7 +491,9 @@ test('svelte stitch-admin: VisibilityMatrix renders explicit empty matrix cells'
 
 test('svelte stitch-admin: WizardEditableTokenInputPanel renders parity DOM with React adapter', async () => {
   const body = await renderComponent(
-    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    path.resolve(
+      'src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte',
+    ),
     {
       input: {
         inputId: 'svelte-allowed-senders',
@@ -506,7 +508,9 @@ test('svelte stitch-admin: WizardEditableTokenInputPanel renders parity DOM with
     },
   );
   assert.ok(body.includes('facetheory-stitch-wizard-editable-token-input'));
-  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
   assert.ok(body.includes('data-input-id="svelte-allowed-senders"'));
   assert.ok(body.includes('data-token-count="2"'));
   assert.ok(body.includes('data-token-value="qa@example.com"'));
@@ -519,7 +523,9 @@ test('svelte stitch-admin: WizardEditableTokenInputPanel renders parity DOM with
 
 test('svelte stitch-admin: WizardEditableTokenInputPanel surfaces invalid + duplicate feedback with role=alert', async () => {
   const invalidBody = await renderComponent(
-    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    path.resolve(
+      'src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte',
+    ),
     {
       input: {
         inputId: 'svelte-allowed-senders-invalid',
@@ -541,7 +547,9 @@ test('svelte stitch-admin: WizardEditableTokenInputPanel surfaces invalid + dupl
   assert.ok(invalidBody.includes('Address must contain @'));
 
   const duplicateBody = await renderComponent(
-    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    path.resolve(
+      'src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte',
+    ),
     {
       input: {
         inputId: 'svelte-allowed-senders-duplicate',
@@ -570,11 +578,15 @@ test('svelte stitch-admin: WizardEditableTokenInputPanel is byte-identical acros
     onChange: (): void => {},
   };
   const first = await renderComponent(
-    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    path.resolve(
+      'src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte',
+    ),
     props,
   );
   const second = await renderComponent(
-    path.resolve('src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte'),
+    path.resolve(
+      'src/svelte/stitch-admin/WizardEditableTokenInputPanel.svelte',
+    ),
     props,
   );
   assert.equal(first, second);
@@ -628,7 +640,12 @@ test('svelte wizard parity: WizardFindingListPanel renders severity chips and ev
       list: {
         findings: [
           { id: 'f1', severity: 'info', title: 'Manifest parsed' },
-          { id: 'f2', severity: 'error', title: 'Bad capability', evidence: 'cap[0]' },
+          {
+            id: 'f2',
+            severity: 'error',
+            title: 'Bad capability',
+            evidence: 'cap[0]',
+          },
         ],
         safetyPolicy: 'no-secret-or-production-like-data',
       },
@@ -650,7 +667,13 @@ test('svelte wizard parity: WizardReconcileSummaryPanel replaces redacted detail
       summary: {
         entries: [
           { key: 'a', label: 'a', kind: 'added' },
-          { key: 'b', label: 'b', kind: 'changed', detail: 'super-secret', redacted: true },
+          {
+            key: 'b',
+            label: 'b',
+            kind: 'changed',
+            detail: 'super-secret',
+            redacted: true,
+          },
           { key: 'c', label: 'c', kind: 'redacted' },
         ],
         totals: { added: 1, removed: 0, changed: 1, unchanged: 0, redacted: 1 },
@@ -670,9 +693,27 @@ test('svelte wizard parity: WizardCapabilityReviewPanel suppresses sensitive/red
     {
       review: {
         capabilities: [
-          { key: 'pub', label: 'Pub', intent: 'granted', sensitivity: 'public', detail: 'visible' },
-          { key: 'sen', label: 'Sen', intent: 'requested', sensitivity: 'sensitive', detail: 'should-suppress' },
-          { key: 'red', label: 'Red', intent: 'denied', sensitivity: 'redacted', detail: 'should-redact' },
+          {
+            key: 'pub',
+            label: 'Pub',
+            intent: 'granted',
+            sensitivity: 'public',
+            detail: 'visible',
+          },
+          {
+            key: 'sen',
+            label: 'Sen',
+            intent: 'requested',
+            sensitivity: 'sensitive',
+            detail: 'should-suppress',
+          },
+          {
+            key: 'red',
+            label: 'Red',
+            intent: 'denied',
+            sensitivity: 'redacted',
+            detail: 'should-redact',
+          },
         ],
         safetyPolicy: 'no-secret-or-production-like-data',
       },
@@ -687,7 +728,9 @@ test('svelte wizard parity: WizardCapabilityReviewPanel suppresses sensitive/red
 
 test('svelte wizard parity: WizardEnablementChecklistPanel renders caller summary + allReady', async () => {
   const body = await renderComponent(
-    path.resolve('src/svelte/stitch-admin/WizardEnablementChecklistPanel.svelte'),
+    path.resolve(
+      'src/svelte/stitch-admin/WizardEnablementChecklistPanel.svelte',
+    ),
     {
       checklist: {
         items: [{ key: 'a', label: 'ready', status: 'ready' }],
@@ -728,7 +771,9 @@ test('svelte wizard parity: WizardEmptyState renders safety-policy footnote', as
 
 test('svelte wizard parity: WizardReconciliationPlanPanel marks conflict/blocked/external prominent', async () => {
   const body = await renderComponent(
-    path.resolve('src/svelte/stitch-admin/WizardReconciliationPlanPanel.svelte'),
+    path.resolve(
+      'src/svelte/stitch-admin/WizardReconciliationPlanPanel.svelte',
+    ),
     {
       plan: {
         rows: [
@@ -736,7 +781,15 @@ test('svelte wizard parity: WizardReconciliationPlanPanel marks conflict/blocked
           { key: 'b', label: 'b', kind: 'blocked', reason: 'r' },
           { key: 'e', label: 'e', kind: 'external_step_required', reason: 'r' },
         ],
-        totals: { create: 0, update: 0, satisfied: 0, conflict: 1, blocked: 1, external: 1, noop: 0 },
+        totals: {
+          create: 0,
+          update: 0,
+          satisfied: 0,
+          conflict: 1,
+          blocked: 1,
+          external: 1,
+          noop: 0,
+        },
         safetyPolicy: 'no-secret-or-production-like-data',
       },
     },
@@ -749,12 +802,19 @@ test('svelte wizard parity: WizardReconciliationPlanPanel marks conflict/blocked
 
 test('svelte wizard parity: WizardAuthorityContextStripPanel renders text-labeled authority + copy button', async () => {
   const body = await renderComponent(
-    path.resolve('src/svelte/stitch-admin/WizardAuthorityContextStripPanel.svelte'),
+    path.resolve(
+      'src/svelte/stitch-admin/WizardAuthorityContextStripPanel.svelte',
+    ),
     {
       strip: {
         items: [
           { key: 'tenant', label: 'Tenant', value: 'theory-mcp' },
-          { key: 'route', label: 'MCP route', value: '/agents/acme', copyable: true },
+          {
+            key: 'route',
+            label: 'MCP route',
+            value: '/agents/acme',
+            copyable: true,
+          },
         ],
         authorityLabel: 'Server-derived',
         readOnlyLabel: 'Read-only',
@@ -763,7 +823,9 @@ test('svelte wizard parity: WizardAuthorityContextStripPanel renders text-labele
       },
     },
   );
-  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
   assert.ok(body.includes('data-layout="auto"'));
   assert.ok(body.includes('Server-derived'));
   assert.ok(body.includes('aria-label="Read-only"'));
@@ -802,7 +864,10 @@ test('svelte wizard parity: WizardFindingListPanel renders per-finding.metadata 
             id: 'f1',
             severity: 'warning',
             title: 'Imported with provenance',
-            metadata: { provenance: { source: 'Factory import' }, correlation: sampleCorrelation },
+            metadata: {
+              provenance: { source: 'Factory import' },
+              correlation: sampleCorrelation,
+            },
           },
         ],
         safetyPolicy: 'no-secret-or-production-like-data',
@@ -831,7 +896,9 @@ test('svelte wizard parity: WizardRecoveryStatusPanel renders status.metadata vi
 
 test('svelte wizard parity: WizardReconciliationPlanPanel renders row.metadata via MetadataBadgeGroup', async () => {
   const body = await renderComponent(
-    path.resolve('src/svelte/stitch-admin/WizardReconciliationPlanPanel.svelte'),
+    path.resolve(
+      'src/svelte/stitch-admin/WizardReconciliationPlanPanel.svelte',
+    ),
     {
       plan: {
         rows: [
@@ -842,7 +909,15 @@ test('svelte wizard parity: WizardReconciliationPlanPanel renders row.metadata v
             metadata: { provenance: { source: 'Plan diff' } },
           },
         ],
-        totals: { create: 0, update: 1, satisfied: 0, conflict: 0, blocked: 0, external: 0, noop: 0 },
+        totals: {
+          create: 0,
+          update: 1,
+          satisfied: 0,
+          conflict: 0,
+          blocked: 0,
+          external: 0,
+          noop: 0,
+        },
         safetyPolicy: 'no-secret-or-production-like-data',
       },
     },
@@ -861,11 +936,30 @@ test('svelte selectable-card-grid: single-select renders as radiogroup with role
         selection: 'single',
         selectedKeys: ['create'],
         options: [
-          { key: 'create', title: 'Create', tone: 'success', recommended: true },
+          {
+            key: 'create',
+            title: 'Create',
+            tone: 'success',
+            recommended: true,
+          },
           { key: 'reuse', title: 'Reuse', tone: 'info' },
-          { key: 'replace', title: 'Replace', tone: 'warning', riskLabel: 'High blast radius' },
-          { key: 'archive', title: 'Archive', disabledReason: 'Requires operator review.' },
-          { key: 'forbidden', title: 'Forbidden', blocked: true, blockedReason: 'Server policy blocks this.' },
+          {
+            key: 'replace',
+            title: 'Replace',
+            tone: 'warning',
+            riskLabel: 'High blast radius',
+          },
+          {
+            key: 'archive',
+            title: 'Archive',
+            disabledReason: 'Requires operator review.',
+          },
+          {
+            key: 'forbidden',
+            title: 'Forbidden',
+            blocked: true,
+            blockedReason: 'Server policy blocks this.',
+          },
         ],
         label: 'Allowed action',
         description: 'TheoryMCP resolves availability per route.',
@@ -935,7 +1029,9 @@ test('svelte ChoiceCard renders standalone card with selection family + safety p
   assert.ok(body.includes('aria-checked="true"'));
   assert.ok(body.includes('data-selection-family="single"'));
   assert.ok(body.includes('data-option-recommended="true"'));
-  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
 });
 
 test('svelte package-source-input: renders paste/dropzone/upload with stable data attrs', async () => {
@@ -1024,10 +1120,30 @@ test('svelte package-source-input: only invalid-syntax renders evidence; forbidd
         value: '',
         state: 'invalid',
         errors: [
-          { id: 'syntax-1', kind: 'invalid-syntax', message: 'Expected top-level mapping at line 1', evidence: 'line 1, col 1' },
-          { id: 'forbidden-1', kind: 'forbidden', message: 'Operator policy blocks this manifest.', evidence: 'AKIA-SVELTE-FORBIDDEN-EVIDENCE-1234567890' },
-          { id: 'unsafe-1', kind: 'unsafe', message: 'Manifest references an unsupported scheme.', evidence: 'AKIA-SVELTE-UNSAFE-EVIDENCE-1234567890' },
-          { id: 'other-1', kind: 'other', message: 'Validation could not complete.', evidence: 'AKIA-SVELTE-OTHER-EVIDENCE-1234567890' },
+          {
+            id: 'syntax-1',
+            kind: 'invalid-syntax',
+            message: 'Expected top-level mapping at line 1',
+            evidence: 'line 1, col 1',
+          },
+          {
+            id: 'forbidden-1',
+            kind: 'forbidden',
+            message: 'Operator policy blocks this manifest.',
+            evidence: 'AKIA-SVELTE-FORBIDDEN-EVIDENCE-1234567890',
+          },
+          {
+            id: 'unsafe-1',
+            kind: 'unsafe',
+            message: 'Manifest references an unsupported scheme.',
+            evidence: 'AKIA-SVELTE-UNSAFE-EVIDENCE-1234567890',
+          },
+          {
+            id: 'other-1',
+            kind: 'other',
+            message: 'Validation could not complete.',
+            evidence: 'AKIA-SVELTE-OTHER-EVIDENCE-1234567890',
+          },
         ],
         modes: ['paste'],
         safetyPolicy: 'no-secret-or-production-like-data',
@@ -1036,7 +1152,10 @@ test('svelte package-source-input: only invalid-syntax renders evidence; forbidd
     },
   );
   assert.ok(body.includes('line 1, col 1'));
-  assert.equal(body.includes('AKIA-SVELTE-FORBIDDEN-EVIDENCE-1234567890'), false);
+  assert.equal(
+    body.includes('AKIA-SVELTE-FORBIDDEN-EVIDENCE-1234567890'),
+    false,
+  );
   assert.equal(body.includes('AKIA-SVELTE-UNSAFE-EVIDENCE-1234567890'), false);
   assert.equal(body.includes('AKIA-SVELTE-OTHER-EVIDENCE-1234567890'), false);
   assert.ok(body.includes('Operator policy blocks this manifest.'));
@@ -1054,19 +1173,242 @@ test('svelte code-dropzone: only invalid-syntax renders evidence; forbidden/unsa
         state: 'invalid',
         safetyPolicy: 'no-secret-or-production-like-data',
         errors: [
-          { id: 'syntax-1', kind: 'invalid-syntax', message: 'Expected top-level mapping at line 1', evidence: 'line 1, col 1' },
-          { id: 'forbidden-1', kind: 'forbidden', message: 'Policy blocks.', evidence: 'AKIA-SVELTE-DZ-FORBIDDEN-EVIDENCE-1234567890' },
-          { id: 'unsafe-1', kind: 'unsafe', message: 'Unsupported scheme.', evidence: 'AKIA-SVELTE-DZ-UNSAFE-EVIDENCE-1234567890' },
-          { id: 'other-1', kind: 'other', message: 'Validation could not complete.', evidence: 'AKIA-SVELTE-DZ-OTHER-EVIDENCE-1234567890' },
+          {
+            id: 'syntax-1',
+            kind: 'invalid-syntax',
+            message: 'Expected top-level mapping at line 1',
+            evidence: 'line 1, col 1',
+          },
+          {
+            id: 'forbidden-1',
+            kind: 'forbidden',
+            message: 'Policy blocks.',
+            evidence: 'AKIA-SVELTE-DZ-FORBIDDEN-EVIDENCE-1234567890',
+          },
+          {
+            id: 'unsafe-1',
+            kind: 'unsafe',
+            message: 'Unsupported scheme.',
+            evidence: 'AKIA-SVELTE-DZ-UNSAFE-EVIDENCE-1234567890',
+          },
+          {
+            id: 'other-1',
+            kind: 'other',
+            message: 'Validation could not complete.',
+            evidence: 'AKIA-SVELTE-DZ-OTHER-EVIDENCE-1234567890',
+          },
         ],
       },
     },
   );
   assert.ok(body.includes('line 1, col 1'));
-  assert.equal(body.includes('AKIA-SVELTE-DZ-FORBIDDEN-EVIDENCE-1234567890'), false);
-  assert.equal(body.includes('AKIA-SVELTE-DZ-UNSAFE-EVIDENCE-1234567890'), false);
-  assert.equal(body.includes('AKIA-SVELTE-DZ-OTHER-EVIDENCE-1234567890'), false);
+  assert.equal(
+    body.includes('AKIA-SVELTE-DZ-FORBIDDEN-EVIDENCE-1234567890'),
+    false,
+  );
+  assert.equal(
+    body.includes('AKIA-SVELTE-DZ-UNSAFE-EVIDENCE-1234567890'),
+    false,
+  );
+  assert.equal(
+    body.includes('AKIA-SVELTE-DZ-OTHER-EVIDENCE-1234567890'),
+    false,
+  );
   assert.ok(body.includes('Policy blocks.'));
   assert.ok(body.includes('Unsupported scheme.'));
   assert.ok(body.includes('Validation could not complete.'));
+});
+
+/* -------------------------------------------------------------------------- */
+/* AuditTrailPanel + DisclosurePanel parity                                   */
+/* -------------------------------------------------------------------------- */
+
+import type {
+  AuditTrail as SvelteAuditTrail,
+  DisclosurePanelProps as SvelteDisclosurePanelProps,
+} from '../../src/stitch-admin/index.js';
+
+const SVELTE_SAMPLE_TRAIL: SvelteAuditTrail = {
+  groupId: 'trail-root-svelte',
+  label: 'Validation history',
+  description: 'Server-derived audit events for this import.',
+  variant: 'detailed',
+  safetyPolicy: 'no-secret-or-production-like-data',
+  groups: [
+    {
+      id: 'parse-svelte',
+      label: 'Parse',
+      expanded: true,
+      events: [
+        {
+          id: 'parse-start-svelte',
+          timestamp: '2026-05-21T17:00:00.000Z',
+          title: 'Parse started',
+          status: 'info',
+          tone: 'info',
+          actor: 'theory-mcp-server',
+          actorSource: 'Server-derived',
+        },
+      ],
+    },
+    {
+      id: 'reconcile-svelte',
+      label: 'Reconcile',
+      expanded: true,
+      events: [
+        {
+          id: 'reconcile-error-svelte',
+          timestamp: '2026-05-21T17:00:04.000Z',
+          title: 'Conflict',
+          status: 'error',
+          tone: 'danger',
+          body: 'Two capabilities conflict.',
+          externalLink: { href: 'https://docs.example.com/c', label: 'Help' },
+        },
+      ],
+    },
+    {
+      id: 'apply-svelte',
+      label: 'Apply',
+      expanded: true,
+      events: [
+        {
+          id: 'apply-redacted-svelte',
+          timestamp: '2026-05-21T17:00:05.000Z',
+          title: 'Mailbox secret rotated',
+          status: 'info',
+          tone: 'neutral',
+          redactedMarker: '[redacted — mailbox secret]',
+          body: 'AKIA-SVELTE-NEVER-SHOWN-IN-BODY-1234567890',
+          metadata: [
+            {
+              key: 'secret',
+              label: 'Secret',
+              value: 'AKIA-SVELTE-NEVER-SHOWN-IN-META-1234567890',
+            },
+          ],
+          externalLink: {
+            href: 'https://docs.example.com/r',
+            label: 'AKIA-SVELTE-NEVER-SHOWN-IN-LINK-1234567890',
+          },
+        },
+        {
+          id: 'apply-unsafe-link-svelte',
+          timestamp: '2026-05-21T17:00:06.000Z',
+          title: 'Documented operator step',
+          externalLink: { href: 'javascript:alert(1)', label: 'Run unsafe' },
+        },
+      ],
+    },
+  ],
+};
+
+const SVELTE_DISCLOSURE_EXPANDED: SvelteDisclosurePanelProps = {
+  panelId: 'disc-svelte',
+  label: 'Server resolved details',
+  expanded: true,
+  tone: 'info',
+  status: 'info',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+const SVELTE_DISCLOSURE_ERROR: SvelteDisclosurePanelProps = {
+  panelId: 'disc-svelte-err',
+  label: 'Apply failed',
+  expanded: true,
+  tone: 'danger',
+  status: 'error',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+test('svelte audit-trail: AuditTrailPanel renders parity data attrs + safety footnote', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/AuditTrailPanel.svelte'),
+    { trail: SVELTE_SAMPLE_TRAIL },
+  );
+  assert.ok(body.includes('facetheory-stitch-audit-trail'));
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
+  assert.ok(body.includes('data-group-id="trail-root-svelte"'));
+  assert.ok(body.includes('data-variant="detailed"'));
+  assert.ok(body.includes('data-group-count="3"'));
+  assert.ok(body.includes('data-event-count="4"'));
+  assert.ok(body.includes('data-error-count="1"'));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+test('svelte audit-trail: group toggles carry aria-expanded + aria-controls', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/AuditTrailPanel.svelte'),
+    { trail: SVELTE_SAMPLE_TRAIL },
+  );
+  assert.ok(body.includes('data-group-toggle="parse-svelte"'));
+  assert.ok(body.includes('aria-controls="parse-svelte-events"'));
+  assert.ok(body.includes('data-group-expanded="true"'));
+  assert.ok(body.includes('<button type="button"'));
+});
+
+test('svelte audit-trail: redacted event suppresses body/metadata/externalLink', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/AuditTrailPanel.svelte'),
+    { trail: SVELTE_SAMPLE_TRAIL },
+  );
+  assert.ok(body.includes('[redacted — mailbox secret]'));
+  assert.ok(body.includes('data-event-redacted="true"'));
+  assert.equal(
+    body.includes('AKIA-SVELTE-NEVER-SHOWN-IN-BODY-1234567890'),
+    false,
+  );
+  assert.equal(
+    body.includes('AKIA-SVELTE-NEVER-SHOWN-IN-META-1234567890'),
+    false,
+  );
+  assert.equal(
+    body.includes('AKIA-SVELTE-NEVER-SHOWN-IN-LINK-1234567890'),
+    false,
+  );
+});
+
+test('svelte audit-trail: javascript: external links dropped; safe links get noopener+target=_blank', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/AuditTrailPanel.svelte'),
+    { trail: SVELTE_SAMPLE_TRAIL },
+  );
+  assert.ok(body.includes('href="https://docs.example.com/c"'));
+  assert.equal(body.includes('javascript:alert(1)'), false);
+  assert.equal(body.includes('Run unsafe'), false);
+  assert.ok(body.includes('rel="noopener noreferrer"'));
+  assert.ok(body.includes('target="_blank"'));
+});
+
+test('svelte audit-trail: AuditTrailPanel byte-identical across repeated SSR renders', async () => {
+  const a = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/AuditTrailPanel.svelte'),
+    { trail: SVELTE_SAMPLE_TRAIL },
+  );
+  const b = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/AuditTrailPanel.svelte'),
+    { trail: SVELTE_SAMPLE_TRAIL },
+  );
+  assert.equal(a, b, 'Svelte AuditTrailPanel must be deterministic');
+});
+
+test('svelte audit-trail: DisclosurePanel renders expanded state and safety footnote', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/DisclosurePanel.svelte'),
+    { panel: SVELTE_DISCLOSURE_EXPANDED },
+  );
+  assert.ok(body.includes('data-disclosure-id="disc-svelte"'));
+  assert.ok(body.includes('aria-expanded="true"'));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+test('svelte audit-trail: DisclosurePanel with status=error sets role=alert', async () => {
+  const body = await renderComponent(
+    path.resolve('src/svelte/stitch-admin/DisclosurePanel.svelte'),
+    { panel: SVELTE_DISCLOSURE_ERROR },
+  );
+  assert.ok(body.includes('data-disclosure-status="error"'));
+  assert.ok(body.includes('role="alert"'));
 });

--- a/ts/test/unit/vue-stitch-admin.test.ts
+++ b/ts/test/unit/vue-stitch-admin.test.ts
@@ -642,7 +642,10 @@ test('vue stitch-admin: tabs, chips, key-value rows, copy code, logs, and policy
   assert.ok(body.includes('Warning'));
 });
 
-import { WizardEditableTokenInputPanel as VueWizardEditableTokenInputPanel, WizardChipListPanel as VueWizardChipListPanel } from '../../src/vue/stitch-admin/index.js';
+import {
+  WizardEditableTokenInputPanel as VueWizardEditableTokenInputPanel,
+  WizardChipListPanel as VueWizardChipListPanel,
+} from '../../src/vue/stitch-admin/index.js';
 import type { WizardEditableTokenInput as VueWizardInput } from '../../src/stitch-admin/index.js';
 
 const VUE_NOOP_CHANGE = (): void => {};
@@ -665,7 +668,9 @@ test('vue stitch-admin: WizardEditableTokenInputPanel renders parity DOM with Re
     }),
   );
   assert.ok(body.includes('facetheory-stitch-wizard-editable-token-input'));
-  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
   assert.ok(body.includes('data-input-id="vue-allowed-senders"'));
   assert.ok(body.includes('data-token-count="2"'));
   assert.ok(body.includes('data-token-value="qa@example.com"'));
@@ -787,15 +792,15 @@ test('vue wizard parity: WizardPackageSummaryPanel renders totals + per-file met
   const summary: VuePackageSummary = {
     name: 'pkg',
     version: '0.1.0',
-    files: [
-      { key: 'a', path: 'agent.json', sizeBytes: 412, role: 'manifest' },
-    ],
+    files: [{ key: 'a', path: 'agent.json', sizeBytes: 412, role: 'manifest' }],
     totals: { fileCount: 1, byteCount: 412 },
     safetyPolicy: 'no-secret-or-production-like-data',
   };
   const body = await renderSSR(h(VueWizardPackageSummaryPanel, { summary }));
   assert.ok(body.includes('facetheory-stitch-wizard-package-summary'));
-  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
   assert.ok(body.includes('data-file-count="1"'));
   assert.ok(body.includes('agent.json'));
   assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
@@ -805,7 +810,12 @@ test('vue wizard parity: WizardFindingListPanel renders severity counts and find
   const list: VueFindingList = {
     findings: [
       { id: 'f1', severity: 'info', title: 'Manifest parsed' },
-      { id: 'f2', severity: 'error', title: 'Bad capability', evidence: 'cap[0]' },
+      {
+        id: 'f2',
+        severity: 'error',
+        title: 'Bad capability',
+        evidence: 'cap[0]',
+      },
     ],
     safetyPolicy: 'no-secret-or-production-like-data',
   };
@@ -823,7 +833,13 @@ test('vue wizard parity: WizardReconcileSummaryPanel redacts entries marked sens
   const summary: VueReconcileSummary = {
     entries: [
       { key: 'a', label: 'a', kind: 'added' },
-      { key: 'b', label: 'b', kind: 'changed', detail: 'super-secret', redacted: true },
+      {
+        key: 'b',
+        label: 'b',
+        kind: 'changed',
+        detail: 'super-secret',
+        redacted: true,
+      },
       { key: 'c', label: 'c', kind: 'redacted' },
     ],
     totals: { added: 1, removed: 0, changed: 1, unchanged: 0, redacted: 1 },
@@ -840,9 +856,27 @@ test('vue wizard parity: WizardReconcileSummaryPanel redacts entries marked sens
 test('vue wizard parity: WizardCapabilityReviewPanel suppresses sensitive/redacted details', async () => {
   const review: VueCapabilityReview = {
     capabilities: [
-      { key: 'public', label: 'Public', intent: 'granted', sensitivity: 'public', detail: 'visible' },
-      { key: 'sensitive', label: 'Sensitive', intent: 'requested', sensitivity: 'sensitive', detail: 'should-suppress' },
-      { key: 'redacted', label: 'Redacted', intent: 'denied', sensitivity: 'redacted', detail: 'should-redact' },
+      {
+        key: 'public',
+        label: 'Public',
+        intent: 'granted',
+        sensitivity: 'public',
+        detail: 'visible',
+      },
+      {
+        key: 'sensitive',
+        label: 'Sensitive',
+        intent: 'requested',
+        sensitivity: 'sensitive',
+        detail: 'should-suppress',
+      },
+      {
+        key: 'redacted',
+        label: 'Redacted',
+        intent: 'denied',
+        sensitivity: 'redacted',
+        detail: 'should-redact',
+      },
     ],
     safetyPolicy: 'no-secret-or-production-like-data',
   };
@@ -860,7 +894,9 @@ test('vue wizard parity: WizardEnablementChecklistPanel renders caller summary +
     summaryLabel: '1 of 1 ready',
     allReady: true,
   };
-  const body = await renderSSR(h(VueWizardEnablementChecklistPanel, { checklist }));
+  const body = await renderSSR(
+    h(VueWizardEnablementChecklistPanel, { checklist }),
+  );
   assert.ok(body.includes('facetheory-stitch-wizard-enablement-checklist'));
   assert.ok(body.includes('data-all-ready="true"'));
   assert.ok(body.includes('1 of 1 ready'));
@@ -893,7 +929,15 @@ test('vue wizard parity: WizardReconciliationPlanPanel marks conflict/blocked/ex
       { key: 'e', label: 'e', kind: 'external_step_required', reason: 'r' },
       { key: 's', label: 's', kind: 'satisfied' },
     ],
-    totals: { create: 0, update: 0, satisfied: 1, conflict: 1, blocked: 1, external: 1, noop: 0 },
+    totals: {
+      create: 0,
+      update: 0,
+      satisfied: 1,
+      conflict: 1,
+      blocked: 1,
+      external: 1,
+      noop: 0,
+    },
     safetyPolicy: 'no-secret-or-production-like-data',
   };
   const body = await renderSSR(h(VueWizardReconciliationPlanPanel, { plan }));
@@ -907,10 +951,20 @@ test('vue wizard parity: WizardReconciliationPlanPanel marks conflict/blocked/ex
 test('vue wizard parity: WizardDiffListPanel alias renders identically to canonical', async () => {
   const plan: VueReconciliationPlan = {
     rows: [{ key: 'k', label: 'k', kind: 'create' }],
-    totals: { create: 1, update: 0, satisfied: 0, conflict: 0, blocked: 0, external: 0, noop: 0 },
+    totals: {
+      create: 1,
+      update: 0,
+      satisfied: 0,
+      conflict: 0,
+      blocked: 0,
+      external: 0,
+      noop: 0,
+    },
     safetyPolicy: 'no-secret-or-production-like-data',
   };
-  const canonical = await renderSSR(h(VueWizardReconciliationPlanPanel, { plan }));
+  const canonical = await renderSSR(
+    h(VueWizardReconciliationPlanPanel, { plan }),
+  );
   const alias = await renderSSR(h(VueWizardDiffListPanel, { plan }));
   assert.equal(canonical, alias);
 });
@@ -919,15 +973,24 @@ test('vue wizard parity: WizardAuthorityContextStripPanel renders text-labeled a
   const strip: VueAuthorityContextStrip = {
     items: [
       { key: 'tenant', label: 'Tenant', value: 'theory-mcp' },
-      { key: 'route', label: 'MCP route', value: '/agents/acme', copyable: true },
+      {
+        key: 'route',
+        label: 'MCP route',
+        value: '/agents/acme',
+        copyable: true,
+      },
     ],
     authorityLabel: 'Server-derived',
     readOnlyLabel: 'Read-only',
     layout: 'auto',
     safetyPolicy: 'no-secret-or-production-like-data',
   };
-  const body = await renderSSR(h(VueWizardAuthorityContextStripPanel, { strip }));
-  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  const body = await renderSSR(
+    h(VueWizardAuthorityContextStripPanel, { strip }),
+  );
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
   assert.ok(body.includes('data-layout="auto"'));
   assert.ok(body.includes('Server-derived'));
   assert.ok(body.includes('aria-label="Read-only"'));
@@ -941,8 +1004,12 @@ test('vue wizard parity: WizardServerResolvedContextBarPanel alias renders ident
     items: [{ key: 't', label: 'Tenant', value: 'theory-mcp' }],
     safetyPolicy: 'no-secret-or-production-like-data',
   };
-  const canonical = await renderSSR(h(VueWizardAuthorityContextStripPanel, { strip }));
-  const alias = await renderSSR(h(VueWizardServerResolvedContextBarPanel, { strip }));
+  const canonical = await renderSSR(
+    h(VueWizardAuthorityContextStripPanel, { strip }),
+  );
+  const alias = await renderSSR(
+    h(VueWizardServerResolvedContextBarPanel, { strip }),
+  );
   assert.equal(canonical, alias);
 });
 
@@ -970,7 +1037,10 @@ test('vue wizard parity: WizardFindingListPanel renders per-finding.metadata via
         id: 'f1',
         severity: 'warning',
         title: 'Imported with provenance',
-        metadata: { provenance: { source: 'Factory import' }, correlation: sampleCorrelation },
+        metadata: {
+          provenance: { source: 'Factory import' },
+          correlation: sampleCorrelation,
+        },
       },
     ],
     safetyPolicy: 'no-secret-or-production-like-data',
@@ -1002,7 +1072,15 @@ test('vue wizard parity: WizardReconciliationPlanPanel renders row.metadata via 
         metadata: { provenance: { source: 'Plan diff' } },
       },
     ],
-    totals: { create: 0, update: 1, satisfied: 0, conflict: 0, blocked: 0, external: 0, noop: 0 },
+    totals: {
+      create: 0,
+      update: 1,
+      satisfied: 0,
+      conflict: 0,
+      blocked: 0,
+      external: 0,
+      noop: 0,
+    },
     safetyPolicy: 'no-secret-or-production-like-data',
   };
   const body = await renderSSR(h(VueWizardReconciliationPlanPanel, { plan }));
@@ -1027,9 +1105,23 @@ const SELECTABLE_GRID_SINGLE: VueSelectableCardGrid = {
   options: [
     { key: 'create', title: 'Create', tone: 'success', recommended: true },
     { key: 'reuse', title: 'Reuse', tone: 'info' },
-    { key: 'replace', title: 'Replace', tone: 'warning', riskLabel: 'High blast radius' },
-    { key: 'archive', title: 'Archive', disabledReason: 'Requires operator review.' },
-    { key: 'forbidden', title: 'Forbidden', blocked: true, blockedReason: 'Server policy blocks this.' },
+    {
+      key: 'replace',
+      title: 'Replace',
+      tone: 'warning',
+      riskLabel: 'High blast radius',
+    },
+    {
+      key: 'archive',
+      title: 'Archive',
+      disabledReason: 'Requires operator review.',
+    },
+    {
+      key: 'forbidden',
+      title: 'Forbidden',
+      blocked: true,
+      blockedReason: 'Server policy blocks this.',
+    },
   ],
   label: 'Allowed action',
   description: 'TheoryMCP resolves availability per route.',
@@ -1086,7 +1178,9 @@ test('vue selectable-card-grid: multi-select renders as checkbox group', async (
     layout: 'stack',
     safetyPolicy: 'no-secret-or-production-like-data',
   };
-  const body = await renderSSR(h(VueSelectableCardGridPanel, { grid, onChange: () => {} }));
+  const body = await renderSSR(
+    h(VueSelectableCardGridPanel, { grid, onChange: () => {} }),
+  );
   assert.ok(body.includes('data-selection="multi"'));
   assert.ok(body.includes('role="group"'));
   assert.equal(body.split('role="checkbox"').length - 1, 3);
@@ -1096,10 +1190,16 @@ test('vue selectable-card-grid: multi-select renders as checkbox group', async (
 
 test('vue selectable-card-grid: byte-identical SSR for the same input', async () => {
   const first = await renderSSR(
-    h(VueSelectableCardGridPanel, { grid: SELECTABLE_GRID_SINGLE, onChange: () => {} }),
+    h(VueSelectableCardGridPanel, {
+      grid: SELECTABLE_GRID_SINGLE,
+      onChange: () => {},
+    }),
   );
   const second = await renderSSR(
-    h(VueSelectableCardGridPanel, { grid: SELECTABLE_GRID_SINGLE, onChange: () => {} }),
+    h(VueSelectableCardGridPanel, {
+      grid: SELECTABLE_GRID_SINGLE,
+      onChange: () => {},
+    }),
   );
   assert.equal(first, second);
 });
@@ -1118,7 +1218,9 @@ test('vue ChoiceCard renders standalone card with selection family + safety poli
   assert.ok(body.includes('aria-checked="true"'));
   assert.ok(body.includes('data-selection-family="single"'));
   assert.ok(body.includes('data-option-recommended="true"'));
-  assert.ok(body.includes('data-safety-policy="no-secret-or-production-like-data"'));
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
 });
 
 import {
@@ -1143,7 +1245,11 @@ test('vue package-source-input: renders paste/dropzone/upload modes with stable 
     safetyPolicy: 'no-secret-or-production-like-data',
   };
   const body = await renderSSR(
-    h(VuePackageSourceInputPanel, { input, onValueChange: () => {}, onFiles: () => {} }),
+    h(VuePackageSourceInputPanel, {
+      input,
+      onValueChange: () => {},
+      onFiles: () => {},
+    }),
   );
   assert.ok(body.includes('facetheory-stitch-package-source-input'));
   assert.ok(body.includes('data-state="validating"'));
@@ -1173,7 +1279,9 @@ test('vue package-source-input: renders forbidden + redacted error kinds, never 
     modes: ['paste'],
     safetyPolicy: 'no-secret-or-production-like-data',
   };
-  const body = await renderSSR(h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }));
+  const body = await renderSSR(
+    h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }),
+  );
   assert.ok(body.includes('data-state="redacted"'));
   assert.ok(body.includes('data-error-kind="redacted"'));
   assert.ok(body.includes('Manifest contains redacted content.'));
@@ -1189,8 +1297,12 @@ test('vue package-source-input: byte-identical SSR for same input', async () => 
     modes: ['paste'],
     safetyPolicy: 'no-secret-or-production-like-data',
   };
-  const first = await renderSSR(h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }));
-  const second = await renderSSR(h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }));
+  const first = await renderSSR(
+    h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }),
+  );
+  const second = await renderSSR(
+    h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }),
+  );
   assert.equal(first, second);
 });
 
@@ -1216,15 +1328,37 @@ test('vue package-source-input: only invalid-syntax renders evidence; forbidden/
     value: '',
     state: 'invalid',
     errors: [
-      { id: 'syntax-1', kind: 'invalid-syntax', message: 'Expected top-level mapping at line 1', evidence: 'line 1, col 1' },
-      { id: 'forbidden-1', kind: 'forbidden', message: 'Operator policy blocks this manifest.', evidence: 'AKIA-VUE-FORBIDDEN-EVIDENCE-1234567890' },
-      { id: 'unsafe-1', kind: 'unsafe', message: 'Manifest references an unsupported scheme.', evidence: 'AKIA-VUE-UNSAFE-EVIDENCE-1234567890' },
-      { id: 'other-1', kind: 'other', message: 'Validation could not complete.', evidence: 'AKIA-VUE-OTHER-EVIDENCE-1234567890' },
+      {
+        id: 'syntax-1',
+        kind: 'invalid-syntax',
+        message: 'Expected top-level mapping at line 1',
+        evidence: 'line 1, col 1',
+      },
+      {
+        id: 'forbidden-1',
+        kind: 'forbidden',
+        message: 'Operator policy blocks this manifest.',
+        evidence: 'AKIA-VUE-FORBIDDEN-EVIDENCE-1234567890',
+      },
+      {
+        id: 'unsafe-1',
+        kind: 'unsafe',
+        message: 'Manifest references an unsupported scheme.',
+        evidence: 'AKIA-VUE-UNSAFE-EVIDENCE-1234567890',
+      },
+      {
+        id: 'other-1',
+        kind: 'other',
+        message: 'Validation could not complete.',
+        evidence: 'AKIA-VUE-OTHER-EVIDENCE-1234567890',
+      },
     ],
     modes: ['paste'],
     safetyPolicy: 'no-secret-or-production-like-data',
   };
-  const body = await renderSSR(h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }));
+  const body = await renderSSR(
+    h(VuePackageSourceInputPanel, { input, onValueChange: () => {} }),
+  );
   assert.ok(body.includes('line 1, col 1'));
   assert.equal(body.includes('AKIA-VUE-FORBIDDEN-EVIDENCE-1234567890'), false);
   assert.equal(body.includes('AKIA-VUE-UNSAFE-EVIDENCE-1234567890'), false);
@@ -1232,4 +1366,191 @@ test('vue package-source-input: only invalid-syntax renders evidence; forbidden/
   assert.ok(body.includes('Operator policy blocks this manifest.'));
   assert.ok(body.includes('Manifest references an unsupported scheme.'));
   assert.ok(body.includes('Validation could not complete.'));
+});
+
+import {
+  AuditTrailPanel as VueAuditTrailPanel,
+  DisclosurePanel as VueDisclosurePanel,
+} from '../../src/vue/stitch-admin/index.js';
+import type {
+  AuditTrail as VueAuditTrail,
+  DisclosurePanelProps as VueDisclosurePanelProps,
+} from '../../src/stitch-admin/index.js';
+
+const VUE_SAMPLE_TRAIL: VueAuditTrail = {
+  groupId: 'trail-root-vue',
+  label: 'Validation history',
+  description: 'Server-derived audit events for this import.',
+  variant: 'detailed',
+  safetyPolicy: 'no-secret-or-production-like-data',
+  groups: [
+    {
+      id: 'parse-vue',
+      label: 'Parse',
+      expanded: true,
+      events: [
+        {
+          id: 'parse-start-vue',
+          timestamp: '2026-05-21T17:00:00.000Z',
+          title: 'Parse started',
+          status: 'info',
+          tone: 'info',
+          actor: 'theory-mcp-server',
+          actorSource: 'Server-derived',
+        },
+      ],
+    },
+    {
+      id: 'reconcile-vue',
+      label: 'Reconcile',
+      expanded: true,
+      events: [
+        {
+          id: 'reconcile-error-vue',
+          timestamp: '2026-05-21T17:00:04.000Z',
+          title: 'Conflict',
+          status: 'error',
+          tone: 'danger',
+          body: 'Two capabilities conflict.',
+          externalLink: { href: 'https://docs.example.com/c', label: 'Help' },
+        },
+      ],
+    },
+    {
+      id: 'apply-vue',
+      label: 'Apply',
+      expanded: true,
+      events: [
+        {
+          id: 'apply-redacted-vue',
+          timestamp: '2026-05-21T17:00:05.000Z',
+          title: 'Mailbox secret rotated',
+          status: 'info',
+          tone: 'neutral',
+          redactedMarker: '[redacted — mailbox secret]',
+          body: 'AKIA-VUE-NEVER-SHOWN-IN-BODY-1234567890',
+          metadata: [
+            {
+              key: 'secret',
+              label: 'Secret',
+              value: 'AKIA-VUE-NEVER-SHOWN-IN-META-1234567890',
+            },
+          ],
+          externalLink: {
+            href: 'https://docs.example.com/r',
+            label: 'AKIA-VUE-NEVER-SHOWN-IN-LINK-1234567890',
+          },
+        },
+        {
+          id: 'apply-unsafe-link-vue',
+          timestamp: '2026-05-21T17:00:06.000Z',
+          title: 'Documented operator step',
+          externalLink: { href: 'javascript:alert(1)', label: 'Run unsafe' },
+        },
+      ],
+    },
+  ],
+};
+
+const VUE_DISCLOSURE_EXPANDED: VueDisclosurePanelProps = {
+  panelId: 'disc-vue',
+  label: 'Server resolved details',
+  expanded: true,
+  tone: 'info',
+  status: 'info',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+const VUE_DISCLOSURE_ERROR: VueDisclosurePanelProps = {
+  panelId: 'disc-vue-err',
+  label: 'Apply failed',
+  expanded: true,
+  tone: 'danger',
+  status: 'error',
+  safetyPolicy: 'no-secret-or-production-like-data',
+};
+
+test('vue audit-trail: AuditTrailPanel renders parity data attrs + safety footnote', async () => {
+  const body = await renderSSR(
+    h(VueAuditTrailPanel, { trail: VUE_SAMPLE_TRAIL }),
+  );
+  assert.ok(body.includes('facetheory-stitch-audit-trail'));
+  assert.ok(
+    body.includes('data-safety-policy="no-secret-or-production-like-data"'),
+  );
+  assert.ok(body.includes('data-group-id="trail-root-vue"'));
+  assert.ok(body.includes('data-variant="detailed"'));
+  assert.ok(body.includes('data-group-count="3"'));
+  assert.ok(body.includes('data-event-count="4"'));
+  assert.ok(body.includes('data-error-count="1"'));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+test('vue audit-trail: group toggles carry aria-expanded + aria-controls', async () => {
+  const body = await renderSSR(
+    h(VueAuditTrailPanel, { trail: VUE_SAMPLE_TRAIL }),
+  );
+  assert.ok(body.includes('data-group-toggle="parse-vue"'));
+  assert.ok(body.includes('aria-controls="parse-vue-events"'));
+  assert.ok(body.includes('data-group-expanded="true"'));
+  assert.ok(body.includes('<button type="button"'));
+});
+
+test('vue audit-trail: redacted event suppresses body/metadata/externalLink', async () => {
+  const body = await renderSSR(
+    h(VueAuditTrailPanel, { trail: VUE_SAMPLE_TRAIL }),
+  );
+  assert.ok(body.includes('[redacted — mailbox secret]'));
+  assert.ok(body.includes('data-event-redacted="true"'));
+  assert.equal(body.includes('AKIA-VUE-NEVER-SHOWN-IN-BODY-1234567890'), false);
+  assert.equal(body.includes('AKIA-VUE-NEVER-SHOWN-IN-META-1234567890'), false);
+  assert.equal(body.includes('AKIA-VUE-NEVER-SHOWN-IN-LINK-1234567890'), false);
+});
+
+test('vue audit-trail: javascript: external links dropped; safe links get noopener+target=_blank', async () => {
+  const body = await renderSSR(
+    h(VueAuditTrailPanel, { trail: VUE_SAMPLE_TRAIL }),
+  );
+  assert.ok(body.includes('href="https://docs.example.com/c"'));
+  assert.equal(body.includes('javascript:alert(1)'), false);
+  assert.equal(body.includes('Run unsafe'), false);
+  assert.ok(body.includes('rel="noopener noreferrer"'));
+  assert.ok(body.includes('target="_blank"'));
+});
+
+test('vue audit-trail: AuditTrailPanel byte-identical across repeated SSR renders', async () => {
+  const a = await renderSSR(h(VueAuditTrailPanel, { trail: VUE_SAMPLE_TRAIL }));
+  const b = await renderSSR(h(VueAuditTrailPanel, { trail: VUE_SAMPLE_TRAIL }));
+  assert.equal(a, b, 'Vue AuditTrailPanel must be deterministic');
+});
+
+test('vue audit-trail: DisclosurePanel renders expanded content and safety footnote', async () => {
+  const body = await renderSSR(
+    h(
+      VueDisclosurePanel,
+      { panel: VUE_DISCLOSURE_EXPANDED },
+      {
+        default: () => [
+          h('span', { 'data-disclosure-child': 'true' }, 'Visible child'),
+        ],
+      },
+    ),
+  );
+  assert.ok(body.includes('data-disclosure-id="disc-vue"'));
+  assert.ok(body.includes('aria-expanded="true"'));
+  assert.ok(body.includes('data-disclosure-child="true"'));
+  assert.ok(body.includes('Visible child'));
+  assert.ok(body.includes('Safety policy: no-secret-or-production-like-data'));
+});
+
+test('vue audit-trail: DisclosurePanel with status=error sets role=alert', async () => {
+  const body = await renderSSR(
+    h(
+      VueDisclosurePanel,
+      { panel: VUE_DISCLOSURE_ERROR },
+      { default: () => [h('p', null, 'Apply failed.')] },
+    ),
+  );
+  assert.ok(body.includes('data-disclosure-status="error"'));
+  assert.ok(body.includes('role="alert"'));
 });


### PR DESCRIPTION
## Summary

- New `AuditTrailPanel` + `DisclosurePanel` Stitch admin primitives with
  framework-neutral types in `ts/src/stitch-admin/audit-trail-types.ts`
  and full **React + Vue + Svelte parity** from the start.
- Renders the validation-history / final-review surface for the
  TheoryMCP Agent Import & Completion Wizard. Presentation-only — the
  host (theory-mcp-server) supplies already-redacted event text,
  metadata, group structure, and disclosure state.
- Trust-boundary rules enforced at render time:
  - **Redaction marker rule**: when an event carries `redactedMarker`,
    body / metadata / externalLink are suppressed regardless of caller
    value, and the marker text is rendered verbatim.
  - **External link rule**: `externalLink.href` is filtered through the
    Stitch admin safe-href guard; only `http:` and `https:` URLs
    survive. Safe links emit `rel="noopener noreferrer"` and
    `target="_blank"`.
  - **Error events** carry `role="alert"`; group disclosure uses real
    `<button type="button">` toggles with `aria-expanded` +
    `aria-controls` and caller-controlled `expanded` state.

## Adapter parity

- React: `ts/src/react/stitch-admin/audit-trail.ts`
- Vue:   `ts/src/vue/stitch-admin/audit-trail.ts`
- Svelte: `ts/src/svelte/stitch-admin/AuditTrailPanel.svelte` +
  `DisclosurePanel.svelte`

Re-exported from each adapter's `index` and from the framework-neutral
`@theory-cloud/facetheory/stitch-admin` module.

## Tests

- `ts/test/unit/stitch-admin-audit-trail.test.ts` (React, 12 tests)
- Vue parity block appended to `ts/test/unit/vue-stitch-admin.test.ts`
  (7 tests)
- Svelte parity block appended to
  `ts/test/unit/svelte-stitch-admin.test.ts` (7 tests)
- All three adapters assert byte-identical SSR determinism, redacted
  AKIA-shaped fake-secret fixtures never reach the DOM,
  `javascript:alert(1)` external links are dropped, and
  `DisclosurePanel` surfaces `role="alert"` when `status === 'error'`.
- Registered in `ts/test/run-unit.ts`.

## Validation

- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run lint`      — PASS
- `cd ts && npm test`          — 466 pass / 1 skipped / 0 fail
- `make rubric`                — PASS (version-alignment, ts-pack,
  verify-npm-audit, go-version-pin, release workflow tests)
- React key-warning grep: no matches (`NO_REACT_KEY_WARNINGS`).

## Dev archive

- `/tmp/theorycloud-facetheory-dev-archives/theory-cloud-facetheory-3.2.1-dev-9defb7ebbe22.tgz`
- sha256: `3985e47de772a5f9dab708b133e567b9f0459c2d44131e83cf8a67dc1e34f7d7`

This is a TEMPORARY LOCAL development handoff. It is not a release.

## Honored exclusions

No release, publish, tag, version bump, staging promotion, AWS-cloud
IAM/DNS mutation, deploy, smoke, canary, secrets, sibling-repo edits,
or worktrees.

## Test plan

- [x] React adapter: `AuditTrailPanel` + `DisclosurePanel` render with
      stable `data-*` attrs, ARIA wiring, role=alert for error events,
      tone/status pills, safety-policy footnote, deterministic SSR.
- [x] Vue parity: identical contract, byte-identical SSR.
- [x] Svelte parity: identical contract, byte-identical SSR.
- [x] Redaction-marker rule: caller-supplied secrets in
      body/metadata/externalLink never reach the DOM.
- [x] Safe-href filter: `javascript:` links dropped, `https:` links
      retained with `rel=noopener noreferrer` + `target=_blank`.
- [x] `make rubric` PASS end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)