### PR TITLE
fix(release): pin asset provenance to event commit

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -227,27 +227,11 @@ jobs:
           trusted_dir="${RUNNER_TEMP}/facetheory-release-scripts"
           mkdir -p "${trusted_dir}"
           cp \
-            scripts/checkout-release-source.sh \
-            scripts/resolve-release-source-ref.sh \
             scripts/verify-release-branch.sh \
             scripts/verify-release-draft-target.sh \
             "${trusted_dir}/"
           chmod +x "${trusted_dir}"/*.sh
 
-      - name: Resolve release source ref
-        id: source
-        env:
-          RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
-
-      - name: Checkout release source
-        run: |
-          # Draft GitHub Releases do not guarantee a git tag exists until the
-          # release is published. Build from the draft release source ref and
-          # verify the draft's target before uploading immutable assets.
-          "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh" "${{ steps.source.outputs.source_ref }}"
 
       - name: Fetch main + premain (release branch verification)
         run: git fetch origin main premain --force
@@ -257,7 +241,7 @@ jobs:
           RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
         run: |
           REPO_ROOT="${GITHUB_WORKSPACE}" \
-            "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" HEAD
+            "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    outputs:
-      release_id: ${{ steps.source.outputs.release_id }}
     steps:
       - name: Checkout release workflow scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,8 +33,6 @@ jobs:
           mkdir -p "${trusted_dir}"
           cp \
             scripts/release-json-by-tag.sh \
-            scripts/checkout-release-source.sh \
-            scripts/resolve-release-source-ref.sh \
             scripts/verify-release-branch.sh \
             scripts/verify-release-draft-target.sh \
             "${trusted_dir}/"
@@ -105,17 +101,6 @@ jobs:
             echo "__FACETHEORY_RELEASE_JSON__"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Resolve release source ref
-        id: source
-        env:
-          RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}
-          TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
-        run: |
-          "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
-
-      - name: Checkout release source
-        run: |
-          "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh" "${{ steps.source.outputs.source_ref }}"
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
@@ -129,9 +114,7 @@ jobs:
       - name: Build assets for existing tag release
         env:
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
-          RELEASE_IS_DRAFT: ${{ steps.source.outputs.release_is_draft }}
-          RELEASE_TARGET: ${{ steps.source.outputs.release_target }}
-          RELEASE_SOURCE_COMMIT: ${{ steps.source.outputs.release_source_commit }}
+          RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}
         run: |
           set -euo pipefail
 
@@ -172,15 +155,23 @@ jobs:
           update_manifest(".release-please-manifest.premain.json")
           PY
 
-          if [[ "${RELEASE_IS_DRAFT}" == "true" ]]; then
-            actual_commit="$(git rev-parse HEAD)"
-            if [[ -n "${RELEASE_SOURCE_COMMIT}" && "${actual_commit}" != "${RELEASE_SOURCE_COMMIT}" ]]; then
-              echo "release-assets: FAIL (${TAG_NAME} source resolved to ${RELEASE_SOURCE_COMMIT}, checked out ${actual_commit})"
-              exit 1
-            fi
-            RELEASE_JSON="${{ steps.metadata.outputs.release_json }}" \
+          release_is_draft="false"
+          if [[ -n "${RELEASE_JSON}" ]]; then
+            release_is_draft="$(
+              python3 - <<'PY'
+          import json
+          import os
+
+          data = json.loads(os.environ["RELEASE_JSON"])
+          print("true" if data.get("isDraft", data.get("draft")) is True else "false")
+          PY
+            )"
+          fi
+
+          if [[ "${release_is_draft}" == "true" ]]; then
+            RELEASE_JSON="${RELEASE_JSON}" \
               REPO_ROOT="${GITHUB_WORKSPACE}" \
-              "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${TAG_NAME}" HEAD
+              "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${TAG_NAME}" "${{ github.sha }}"
           fi
 
           REPO_ROOT="${GITHUB_WORKSPACE}" \
@@ -575,27 +566,11 @@ jobs:
           trusted_dir="${RUNNER_TEMP}/facetheory-release-scripts"
           mkdir -p "${trusted_dir}"
           cp \
-            scripts/checkout-release-source.sh \
-            scripts/resolve-release-source-ref.sh \
             scripts/verify-release-branch.sh \
             scripts/verify-release-draft-target.sh \
             "${trusted_dir}/"
           chmod +x "${trusted_dir}"/*.sh
 
-      - name: Resolve release source ref
-        id: source
-        env:
-          RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" >> "${GITHUB_OUTPUT}"
-
-      - name: Checkout release source
-        run: |
-          # Draft GitHub Releases do not guarantee a git tag exists until the
-          # release is published. Build from the draft release source ref and
-          # verify the draft's target before uploading immutable assets.
-          "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh" "${{ steps.source.outputs.source_ref }}"
 
       - name: Fetch main + premain (release branch verification)
         run: |
@@ -607,7 +582,7 @@ jobs:
           RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
         run: |
           REPO_ROOT="${GITHUB_WORKSPACE}" \
-            "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" HEAD
+            "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"
 
       - name: Verify release source branch
         run: |

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -38,19 +38,27 @@ if grep -R -F 'gh release create' .github/workflows scripts | grep -v 'scripts/t
 fi
 
 grep -Fq 'facetheory-release-scripts' .github/workflows/release.yml ||
-  fail "release.yml must stage trusted release provenance scripts before checking out release source code"
+  fail "release.yml must stage trusted release provenance scripts before asset provenance checks"
 
-grep -Fq 'scripts/checkout-release-source.sh' .github/workflows/release.yml ||
-  fail "release.yml must stage the tokenless release source checkout helper"
+if grep -R -Fq 'resolve-release-source-ref.sh' .github/workflows/release.yml .github/workflows/prerelease.yml; then
+  fail "release/prerelease asset workflows must not resolve draft release branches to mutable remote HEADs"
+fi
 
-grep -Fq 'resolve-release-source-ref.sh" "${TAG_NAME}"' .github/workflows/release.yml ||
-  fail "release.yml must resolve existing draft source refs from trusted staged scripts before checkout"
+if grep -R -Fq 'checkout-release-source.sh' .github/workflows/release.yml .github/workflows/prerelease.yml; then
+  fail "release/prerelease asset workflows must not replace github.sha with a resolved draft source ref"
+fi
 
-grep -Fq 'RELEASE_SOURCE_COMMIT' .github/workflows/release.yml ||
-  fail "release.yml must carry immutable release source identity into the build job"
+grep -Fq 'verify-release-draft-target.sh" "${TAG_NAME}" "${{ github.sha }}"' .github/workflows/release.yml ||
+  fail "release.yml existing-tag path must compare draft target identity to github.sha"
 
-grep -Fq 'verify-release-draft-target.sh" "${TAG_NAME}" HEAD' .github/workflows/release.yml ||
-  fail "release.yml must revalidate existing draft target identity after checkout and before build"
+if grep -Fq 'verify-release-draft-target.sh" "${TAG_NAME}" HEAD' .github/workflows/release.yml; then
+  fail "release.yml existing-tag path must not verify draft targets against mutable workspace HEAD"
+fi
+
+for workflow in .github/workflows/prerelease.yml .github/workflows/release.yml; do
+  grep -Fq 'verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"' "${workflow}" ||
+    fail "${workflow} build-release-assets must compare draft target identity to github.sha"
+done
 
 if grep -R -Fq 'run: scripts/publish-draft-release-assets.sh' .github/workflows; then
   fail "release-capable publish tokens must not be exposed to mutable repo publish scripts"
@@ -80,6 +88,9 @@ for workflow in .github/workflows/prerelease.yml .github/workflows/release.yml; 
     fail "${workflow} must tolerate delayed GitHub draft release visibility"
   if grep -Fq 'ref: ${{ steps.source.outputs.source_ref }}' "${workflow}"; then
     fail "${workflow} must not use actions/checkout with a dynamic release source ref"
+  fi
+  if grep -Fq 'verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" HEAD' "${workflow}"; then
+    fail "${workflow} must not verify draft targets against mutable workspace HEAD"
   fi
 done
 
@@ -210,12 +221,9 @@ for required in (
     "    permissions:\n      contents: read\n",
     "      - name: Checkout release workflow scripts\n",
     "      - name: Stage trusted release provenance scripts\n",
-    "      - name: Resolve release source ref\n",
-    "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh",
-    "      - name: Checkout release source\n",
-    "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh",
     "RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}",
     "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh",
+    'verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"',
     "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-branch.sh",
 ):
     if required not in build:
@@ -224,7 +232,11 @@ for forbidden in (
     "GH_TOKEN:",
     "GITHUB_TOKEN:",
     "secrets.RELEASE_PLEASE_TOKEN",
-    'verify-release-draft-target.sh "${{ needs.release-please.outputs.tag_name }}" "${{ github.sha }}"',
+    "      - name: Resolve release source ref\n",
+    "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh",
+    "      - name: Checkout release source\n",
+    "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh",
+    'verify-release-draft-target.sh" "${{ needs.release-please.outputs.tag_name }}" HEAD',
 ):
     if forbidden in build:
         raise SystemExit(f"build-release-assets must not receive {forbidden} in {workflow}")


### PR DESCRIPTION
## Summary
- Removes the release/prerelease asset-build checkout path that resolved draft `target_commitish` branches to current remote branch HEAD.
- Keeps stable, existing-tag, and prerelease asset builds on the immutable workflow event commit (`github.sha`).
- Verifies draft release target identity against `github.sha` so branch movement after draft creation fails instead of being accepted.
- Updates the release workflow provenance test to forbid the mutable resolver/checkout pattern in release asset workflows.

## Issue
Remediates Linear THE-1464: Release assets can drift to latest branch HEAD.

## Validation
- `bash -n scripts/test-release-workflow-changelog-preservation.sh`
- `bash -n scripts/verify-release-draft-target.sh`
- `python3` YAML parse of `.github/workflows/release.yml` and `.github/workflows/prerelease.yml`: PASS
- `scripts/test-release-workflow-changelog-preservation.sh`: PASS
- `scripts/test-verify-release-draft-target.sh`: PASS
- `scripts/verify-version-alignment.sh`: PASS (`3.2.1`)
- `git diff --check`: PASS
- `scripts/test-resolve-release-source-ref.sh`: PASS
- `bash -n scripts/verify-release-readiness.sh`

`actionlint` was not installed in the local environment, so YAML syntax was checked with PyYAML instead.

## Scope notes
Changed files are limited to FaceTheory release/prerelease workflows and the release workflow provenance test.