### PR TITLE
test(release): guard release JSON env handoff

### DIFF
--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -103,6 +103,65 @@ grep -Fq 'RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}'
 grep -Fq 'RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}' .github/workflows/release.yml ||
   fail "release.yml existing-tag path must pass resolved release metadata without a token"
 
+python3 - <<'PY' || fail "release_json outputs must enter shell steps only through workflow env mappings"
+import re
+from pathlib import Path
+
+release_json_expression = re.compile(
+    r"\$\{\{"
+    r"[^}]*"
+    r"outputs\s*(?:\.\s*release_json|\[\s*['\"]release_json['\"]\s*\])"
+    r"[^}]*"
+    r"\}\}",
+    re.S,
+)
+
+
+def run_blocks(lines: list[str]):
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.lstrip(" ")
+        indent = len(line) - len(stripped)
+        if stripped.startswith("run:"):
+            run_prefix = "run:"
+        elif stripped.startswith("- run:"):
+            run_prefix = "- run:"
+        else:
+            index += 1
+            continue
+
+        rest = stripped[len(run_prefix):].strip()
+        start_line = index + 1
+        if rest in {"|", "|-", "|+", ">", ">-", ">+"}:
+            block_lines = []
+            block_start_line = index + 2
+            index += 1
+            while index < len(lines):
+                candidate = lines[index]
+                candidate_indent = len(candidate) - len(candidate.lstrip(" "))
+                if candidate.strip() and candidate_indent <= indent:
+                    break
+                block_lines.append(candidate)
+                index += 1
+            yield start_line, block_start_line, "\n".join(block_lines)
+            continue
+
+        index += 1
+        yield start_line, start_line, rest
+
+
+for workflow in (Path(".github/workflows/release.yml"), Path(".github/workflows/prerelease.yml")):
+    lines = workflow.read_text(encoding="utf-8").splitlines()
+    for run_line, block_line, script in run_blocks(lines):
+        match = release_json_expression.search(script)
+        if match is None:
+            continue
+        prefix = script[: match.start()]
+        line_offset = prefix.count("\n")
+        raise SystemExit(f"{workflow}:{block_line + line_offset} raw release_json expression in run block opened at line {run_line}")
+PY
+
 python3 - <<'PY' || fail "release draft verification steps must not receive GitHub tokens"
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

- Remediates THE-1465 by adding a release workflow invariant that fails if any `run:` block directly interpolates a GitHub Actions expression for `outputs.release_json`.
- Confirms the existing runtime handoff pattern remains env-only: `RELEASE_JSON` is populated via workflow `env:` mappings, then read as a shell environment variable.
- Keeps scope limited to the FaceTheory release provenance test surface; no workflow logic, release assets, cloud state, or secrets changed.

## Evidence

Runtime vulnerable pattern is absent on the project branch plus this commit:

```text
$ rg -n 'RELEASE_JSON\s*=\s*["'"']?\s*\$\{\{[^}]*outputs(\.|\[["'"'])release_json' .github/workflows || true
raw release_json expression handoff: absent
```

Expected safe env mappings remain:

```text
.github/workflows/prerelease.yml:241:          RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
.github/workflows/release.yml:117:          RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}
.github/workflows/release.yml:582:          RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}
```

## Validation

```text
$ bash -n scripts/test-release-workflow-changelog-preservation.sh scripts/verify-release-draft-target.sh scripts/test-verify-release-draft-target.sh
bash -n: PASS

$ scripts/test-release-workflow-changelog-preservation.sh
test-release-workflow-changelog-preservation: PASS

$ scripts/test-verify-release-draft-target.sh
test-verify-release-draft-target: PASS

$ python3 - <<'PY'
import yaml
from pathlib import Path
for path in [Path('.github/workflows/release.yml'), Path('.github/workflows/prerelease.yml')]:
    with path.open('r', encoding='utf-8') as handle:
        yaml.safe_load(handle)
    print(f'{path}: YAML parse PASS')
PY
.github/workflows/release.yml: YAML parse PASS
.github/workflows/prerelease.yml: YAML parse PASS

$ git diff --check origin/codex-security-2026-05-21...HEAD
git diff --check: PASS
```

## Risks / notes

- Test-only change because the project branch already contains the env-based runtime remediation from prior release hardening work.
- The guard is intentionally narrow to release metadata handoff: it scans release/prerelease workflow `run:` blocks for direct expressions referencing `outputs.release_json` while allowing safe workflow `env:` mappings.