### PR TITLE
test(release): guard source ref run interpolation

### DIFF
--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -103,18 +103,21 @@ grep -Fq 'RELEASE_JSON: ${{ needs.resolve-draft-release.outputs.release_json }}'
 grep -Fq 'RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}' .github/workflows/release.yml ||
   fail "release.yml existing-tag path must pass resolved release metadata without a token"
 
-python3 - <<'PY' || fail "release_json outputs must enter shell steps only through workflow env mappings"
+python3 - <<'PY' || fail "release metadata outputs must not be interpolated directly into workflow run blocks"
 import re
 from pathlib import Path
 
-release_json_expression = re.compile(
-    r"\$\{\{"
-    r"[^}]*"
-    r"outputs\s*(?:\.\s*release_json|\[\s*['\"]release_json['\"]\s*\])"
-    r"[^}]*"
-    r"\}\}",
-    re.S,
-)
+guarded_output_expressions = {
+    output_name: re.compile(
+        r"\$\{\{"
+        r"[^}]*"
+        rf"outputs\s*(?:\.\s*{output_name}|\[\s*['\"]{output_name}['\"]\s*\])"
+        r"[^}]*"
+        r"\}\}",
+        re.S,
+    )
+    for output_name in ("release_json", "source_ref")
+}
 
 
 def run_blocks(lines: list[str]):
@@ -154,12 +157,16 @@ def run_blocks(lines: list[str]):
 for workflow in (Path(".github/workflows/release.yml"), Path(".github/workflows/prerelease.yml")):
     lines = workflow.read_text(encoding="utf-8").splitlines()
     for run_line, block_line, script in run_blocks(lines):
-        match = release_json_expression.search(script)
-        if match is None:
-            continue
-        prefix = script[: match.start()]
-        line_offset = prefix.count("\n")
-        raise SystemExit(f"{workflow}:{block_line + line_offset} raw release_json expression in run block opened at line {run_line}")
+        for output_name, expression in guarded_output_expressions.items():
+            match = expression.search(script)
+            if match is None:
+                continue
+            prefix = script[: match.start()]
+            line_offset = prefix.count("\n")
+            raise SystemExit(
+                f"{workflow}:{block_line + line_offset} raw {output_name} expression "
+                f"in run block opened at line {run_line}; pass it through env or action inputs"
+            )
 PY
 
 python3 - <<'PY' || fail "release draft verification steps must not receive GitHub tokens"


### PR DESCRIPTION
## Summary
- Adds a release workflow regression guard for raw `outputs.source_ref` GitHub Actions expressions inside `run:` blocks.
- Keeps the project-branch runtime remediation intact: release/prerelease workflows no longer invoke the checkout-source path or interpolate `source_ref` into shell source.
- Allows future safe handoff outside shell `run:` blocks, such as env mappings or action inputs.

## Root cause
GitHub Actions expressions inside `run:` blocks are expanded into shell source before Bash receives argv. Direct interpolation of `steps.source.outputs.source_ref` could therefore execute command substitution before `checkout-release-source.sh` validated the argument.

## Validation
- `bash -n scripts/test-release-workflow-changelog-preservation.sh` — PASS
- `scripts/test-release-workflow-changelog-preservation.sh` — PASS
- YAML parse for `.github/workflows/release.yml` and `.github/workflows/prerelease.yml` via PyYAML — PASS
- `git diff --check` — PASS
- `git diff --check origin/codex-security-2026-05-21...HEAD` — PASS
- Raw source_ref workflow expression absence check over `.github/workflows/*.yml` — PASS (`no raw outputs.source_ref expressions in .github/workflows`)

## Scope
Changed files are limited to FaceTheory and THE-1466 release provenance test scope:
- `scripts/test-release-workflow-changelog-preservation.sh`