### PR TITLE
fix(vue): preserve strict CSP ISR hydration sidecars

### DIFF
--- a/ts/src/adapter-csp.ts
+++ b/ts/src/adapter-csp.ts
@@ -2,6 +2,13 @@ import type { FaceCspPolicy, FaceHeadTag, FaceRenderResult } from './types.js';
 
 export interface AdapterStrictCspValidationOptions {
   adapterName: string;
+  /**
+   * Some Face-level render modes externalize legacy/inline hydration after the
+   * adapter returns, before final head emission. Keep all other strict-CSP
+   * adapter checks active, but let those runtime sidecar paths validate the
+   * final external hydration shape after conversion.
+   */
+  deferHydrationValidation?: boolean;
 }
 
 export function enforceAdapterStrictCspResult(
@@ -14,7 +21,11 @@ export function enforceAdapterStrictCspResult(
   const adapterName = normalizeAdapterName(options.adapterName);
 
   if (policy.inlineScripts === false) {
-    if (out.hydration && out.hydration.type !== 'external') {
+    if (
+      out.hydration &&
+      out.hydration.type !== 'external' &&
+      options.deferHydrationValidation !== true
+    ) {
       throw new Error(
         `FaceTheory ${adapterName} strict CSP requires external hydration data`,
       );

--- a/ts/src/vue/index.ts
+++ b/ts/src/vue/index.ts
@@ -40,6 +40,19 @@ export async function renderVue(
   vnode: VNode,
   options: RenderVueOptions = {},
 ): Promise<FaceRenderResult> {
+  return renderVueInternal(ctx, vnode, options);
+}
+
+interface VueRenderValidationOptions {
+  deferStrictCspHydrationValidation?: boolean;
+}
+
+async function renderVueInternal(
+  ctx: FaceContext,
+  vnode: VNode,
+  options: RenderVueOptions,
+  validationOptions: VueRenderValidationOptions = {},
+): Promise<FaceRenderResult> {
   const integrations = await prepareUIIntegrations<VNode, VueUIIntegration>(
     options.integrations ?? [],
     ctx,
@@ -88,9 +101,17 @@ export async function renderVue(
     out = await integration.finalize(out, ctx, state);
   }
 
-  enforceAdapterStrictCspResult(out, { adapterName: 'Vue adapter' });
+  enforceAdapterStrictCspResult(out, {
+    adapterName: 'Vue adapter',
+    deferHydrationValidation:
+      validationOptions.deferStrictCspHydrationValidation === true,
+  });
 
   return out;
+}
+
+function modeUsesRuntimeHydrationSidecars(mode: FaceMode): boolean {
+  return mode === 'isr' || mode === 'ssg';
 }
 
 export interface VueFaceOptions<Data = unknown> {
@@ -118,7 +139,11 @@ export function createVueFace<Data = unknown>(
         typeof options.renderOptions === 'function'
           ? await options.renderOptions(ctx, data as Data)
           : (options.renderOptions ?? {});
-      return renderVue(ctx, vnode, renderOptions);
+      return renderVueInternal(ctx, vnode, renderOptions, {
+        deferStrictCspHydrationValidation: modeUsesRuntimeHydrationSidecars(
+          options.mode,
+        ),
+      });
     },
   };
 

--- a/ts/test/unit/vue.test.ts
+++ b/ts/test/unit/vue.test.ts
@@ -1,9 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import { assertDocumentTagNonces } from '../helpers/csp.js';
 
 import { createFaceApp } from '../../src/app.js';
+import { InMemoryHtmlStore, InMemoryIsrMetaStore } from '../../src/isr.js';
+import { buildSsgSite } from '../../src/ssg.js';
 import { createVueFace, h, renderVue } from '../../src/vue/index.js';
 import type { FaceContext } from '../../src/types.js';
 
@@ -21,6 +27,18 @@ const baseCtx: FaceContext = {
   params: {},
   proxy: null,
 };
+
+function decodeBody(body: Uint8Array): string {
+  return new TextDecoder().decode(body);
+}
+
+function externalHydrationHref(html: string): string {
+  const tag = /<link\b[^>]*__FACETHEORY_DATA_URL__[^>]*>/i.exec(html)?.[0];
+  assert.ok(tag, 'expected external hydration link tag');
+  const href = /\bhref="([^"]+)"/i.exec(tag)?.[1];
+  assert.ok(href, 'expected external hydration href');
+  return href;
+}
 
 test('vue adapter: renders VNode + head tags', async () => {
   const app = createFaceApp({
@@ -190,6 +208,121 @@ test('vue adapter: strict CSP emits external hydration without inline data', asy
   );
   assert.ok(!body.includes('id="__FACETHEORY_DATA__"'));
   assert.ok(!body.includes('<strict-vue>'));
+});
+
+test('vue adapter: ISR strict CSP lets runtime externalize legacy hydration sidecars', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  const secret = 'VUE_ISR_HYDRATION_SECRET';
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      createVueFace({
+        route: '/vue-isr',
+        mode: 'isr',
+        render: () => h('main', null, `Vue ISR ${++renderCount}`),
+        renderOptions: {
+          csp: {
+            inlineScripts: false,
+            inlineStyles: false,
+            rawHead: false,
+          },
+          hydration: {
+            data: {
+              secret,
+              terminator: '</script>',
+            },
+            bootstrapModule: '/assets/vue-entry.js',
+          },
+        },
+      }),
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => 1_000,
+    },
+  });
+
+  const response = await app.handle({ method: 'GET', path: '/vue-isr' });
+  assert.equal(response.status, 200);
+  assert.equal(response.headers['x-facetheory-isr']?.[0], 'miss');
+
+  const html = decodeBody(response.body as Uint8Array);
+  const sidecarHref = externalHydrationHref(html);
+  assert.ok(html.includes('<main>Vue ISR 1</main>'));
+  assert.ok(html.includes('src="/assets/vue-entry.js"'));
+  assert.equal(html.includes('id="__FACETHEORY_DATA__"'), false);
+  assert.equal(html.includes(secret), false);
+  assert.match(sidecarHref, /^\/vue-isr\?__facetheory_isr_hydration=/);
+
+  const sidecar = await app.handle({ method: 'GET', path: sidecarHref });
+  assert.equal(sidecar.status, 200);
+  assert.equal(
+    sidecar.headers['content-type']?.[0],
+    'application/json; charset=utf-8',
+  );
+  assert.equal(renderCount, 1);
+  assert.deepEqual(JSON.parse(decodeBody(sidecar.body as Uint8Array)), {
+    secret,
+    terminator: '</script>',
+  });
+});
+
+test('vue adapter: SSG strict CSP lets build externalize legacy hydration sidecars', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-vue-ssg-'));
+  const outDir = path.resolve(tempRoot, 'out');
+
+  try {
+    const result = await buildSsgSite({
+      faces: [
+        createVueFace({
+          route: '/',
+          mode: 'ssg',
+          render: () => h('main', null, 'Vue SSG strict'),
+          renderOptions: {
+            csp: {
+              inlineScripts: false,
+              inlineStyles: false,
+              rawHead: false,
+            },
+            hydration: {
+              data: {
+                message: '</script><script>alert("vue")</script>',
+              },
+              bootstrapModule: '/assets/vue-entry.js',
+            },
+          },
+        }),
+      ],
+      outDir,
+    });
+
+    assert.equal(
+      result.pages[0]?.hydrationDataFile,
+      '_facetheory/data/index.json',
+    );
+
+    const html = await readFile(path.resolve(outDir, 'index.html'), 'utf8');
+    assert.ok(html.includes('<main>Vue SSG strict</main>'));
+    assert.ok(html.includes('id="__FACETHEORY_DATA_URL__"'));
+    assert.ok(html.includes('href="/_facetheory/data/index.json"'));
+    assert.ok(html.includes('src="/assets/vue-entry.js"'));
+    assert.equal(html.includes('id="__FACETHEORY_DATA__"'), false);
+    assert.equal(html.includes('</script><script>alert'), false);
+
+    const hydrationJson = await readFile(
+      path.resolve(outDir, '_facetheory/data/index.json'),
+      'utf8',
+    );
+    assert.equal(
+      hydrationJson,
+      '{"message":"\\u003c/script\\u003e\\u003cscript\\u003ealert(\\"vue\\")\\u003c/script\\u003e"}\n',
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test('vue adapter: strict CSP rejects inline hydration and styles', async () => {


### PR DESCRIPTION
Remediates Linear THE-1467.

## Summary
- Adds a targeted strict-CSP validation deferral for Vue Faces in SSG/ISR modes, where FaceTheory runtime/build sidecar externalization rewrites legacy inline hydration before final head emission.
- Keeps direct `renderVue` strict-CSP validation intact, including rejection of inline hydration and inline adapter styles where no runtime sidecar path is known.
- Adds Vue regression coverage for ISR strict-CSP legacy hydration producing an external hydration sidecar instead of a 500, plus SSG strict-CSP sidecar coverage.

## Root cause
`renderVue` enforced strict-CSP hydration shape immediately after copying `options.hydration` into the adapter result. For Vue ISR/SSG Faces that intentionally returned legacy/inline hydration under `inlineScripts: false`, this threw before `prepareRenderResultForIsr` / SSG sidecar externalization could convert hydration to the external sidecar contract.

## Validation
- Reproduced THE-1467 before the fix with a local Vue ISR strict-CSP legacy hydration Face: response was HTTP 500.
- `cd ts && npx tsx --test test/unit/vue.test.ts` — PASS (6 tests)
- `cd ts && npx tsx --test test/unit/isr.test.ts test/unit/ssg.test.ts` — PASS (21 tests)
- `cd ts && npx prettier --check src/adapter-csp.ts src/vue/index.ts test/unit/vue.test.ts` — PASS
- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run lint` — PASS
- `cd ts && npm run build` — PASS
- `cd ts && npm test` — PASS (468 passed, 1 skipped)
- `scripts/verify-version-alignment.sh` — PASS (3.2.1)
- `cd ts && npm run check` — unavailable in this branch (`Missing script: "check"`), so lint/typecheck/test/build were run individually.

## Scope check
Changed files are limited to FaceTheory Vue strict-CSP validation/helper behavior and targeted Vue ISR/SSG tests:
- `ts/src/adapter-csp.ts`
- `ts/src/vue/index.ts`
- `ts/test/unit/vue.test.ts`

No AWS/cloud state, secrets, or other repositories were touched.