### PR TITLE
fix(react): preserve strict CSP hydration sidecars

### DIFF
--- a/ts/src/adapters/react.ts
+++ b/ts/src/adapters/react.ts
@@ -71,6 +71,19 @@ export async function renderReact(
   node: React.ReactNode,
   options: RenderReactOptions = {},
 ): Promise<FaceRenderResult> {
+  return renderReactInternal(ctx, node, options);
+}
+
+interface ReactRenderValidationOptions {
+  deferStrictCspHydrationValidation?: boolean;
+}
+
+async function renderReactInternal(
+  ctx: FaceContext,
+  node: React.ReactNode,
+  options: RenderReactOptions,
+  validationOptions: ReactRenderValidationOptions = {},
+): Promise<FaceRenderResult> {
   const integrations = await prepareUIIntegrations<
     React.ReactElement,
     UIIntegration<React.ReactElement>
@@ -120,7 +133,11 @@ export async function renderReact(
     }
   }
 
-  enforceAdapterStrictCspResult(out, { adapterName: 'React adapter' });
+  enforceAdapterStrictCspResult(out, {
+    adapterName: 'React adapter',
+    deferHydrationValidation:
+      validationOptions.deferStrictCspHydrationValidation === true,
+  });
 
   return out;
 }
@@ -129,6 +146,15 @@ export async function renderReactStream(
   ctx: FaceContext,
   node: React.ReactNode,
   options: RenderReactStreamOptions = {},
+): Promise<FaceRenderResult> {
+  return renderReactStreamInternal(ctx, node, options);
+}
+
+async function renderReactStreamInternal(
+  ctx: FaceContext,
+  node: React.ReactNode,
+  options: RenderReactStreamOptions,
+  validationOptions: ReactRenderValidationOptions = {},
 ): Promise<FaceRenderResult> {
   const integrations = await prepareUIIntegrations<
     React.ReactElement,
@@ -295,9 +321,17 @@ export async function renderReactStream(
     }
   }
 
-  enforceAdapterStrictCspResult(out, { adapterName: 'React adapter' });
+  enforceAdapterStrictCspResult(out, {
+    adapterName: 'React adapter',
+    deferHydrationValidation:
+      validationOptions.deferStrictCspHydrationValidation === true,
+  });
 
   return out;
+}
+
+function modeUsesRuntimeHydrationSidecars(mode: FaceMode): boolean {
+  return mode === 'isr' || mode === 'ssg';
 }
 
 export interface ReactFaceOptions<Data = unknown> {
@@ -328,7 +362,11 @@ export function createReactFace<Data = unknown>(
         typeof options.renderOptions === 'function'
           ? await options.renderOptions(ctx, data as Data)
           : (options.renderOptions ?? {});
-      return renderReact(ctx, tree, renderOptions);
+      return renderReactInternal(ctx, tree, renderOptions, {
+        deferStrictCspHydrationValidation: modeUsesRuntimeHydrationSidecars(
+          options.mode,
+        ),
+      });
     },
   };
 
@@ -369,7 +407,11 @@ export function createReactStreamFace<Data = unknown>(
         typeof options.renderOptions === 'function'
           ? await options.renderOptions(ctx, data as Data)
           : (options.renderOptions ?? {});
-      return renderReactStream(ctx, tree, renderOptions);
+      return renderReactStreamInternal(ctx, tree, renderOptions, {
+        deferStrictCspHydrationValidation: modeUsesRuntimeHydrationSidecars(
+          options.mode,
+        ),
+      });
     },
   };
 

--- a/ts/test/unit/react.test.ts
+++ b/ts/test/unit/react.test.ts
@@ -1,10 +1,20 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import * as React from 'react';
 
 import { createFaceApp } from '../../src/app.js';
-import { createReactFace, renderReact } from '../../src/adapters/react.js';
+import {
+  createReactFace,
+  createReactStreamFace,
+  renderReact,
+} from '../../src/adapters/react.js';
+import { InMemoryHtmlStore, InMemoryIsrMetaStore } from '../../src/isr.js';
+import { buildSsgSite } from '../../src/ssg.js';
 import type { FaceContext } from '../../src/types.js';
 
 const baseCtx: FaceContext = {
@@ -21,6 +31,18 @@ const baseCtx: FaceContext = {
   params: {},
   proxy: null,
 };
+
+function decodeBody(body: Uint8Array): string {
+  return new TextDecoder().decode(body);
+}
+
+function externalHydrationHref(html: string): string {
+  const tag = /<link\b[^>]*__FACETHEORY_DATA_URL__[^>]*>/i.exec(html)?.[0];
+  assert.ok(tag, 'expected external hydration link tag');
+  const href = /\bhref="([^"]+)"/i.exec(tag)?.[1];
+  assert.ok(href, 'expected external hydration href');
+  return href;
+}
 
 test('react adapter: renders ReactNode + head tags + hydration', async () => {
   const app = createFaceApp({
@@ -113,6 +135,123 @@ test('react adapter: strict CSP emits external hydration without inline data', a
   );
   assert.ok(!body.includes('id="__FACETHEORY_DATA__"'));
   assert.ok(!body.includes('<strict-react>'));
+});
+
+test('react adapter: ISR strict CSP lets runtime externalize legacy hydration sidecars', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  const secret = 'REACT_ISR_HYDRATION_SECRET';
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      createReactFace({
+        route: '/react-isr',
+        mode: 'isr',
+        render: () =>
+          React.createElement('main', null, `React ISR ${++renderCount}`),
+        renderOptions: {
+          csp: {
+            inlineScripts: false,
+            inlineStyles: false,
+            rawHead: false,
+          },
+          hydration: {
+            data: {
+              secret,
+              terminator: '</script>',
+            },
+            bootstrapModule: '/assets/react-entry.js',
+          },
+        },
+      }),
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => 1_000,
+    },
+  });
+
+  const response = await app.handle({ method: 'GET', path: '/react-isr' });
+  assert.equal(response.status, 200);
+  assert.equal(response.headers['x-facetheory-isr']?.[0], 'miss');
+
+  const html = decodeBody(response.body as Uint8Array);
+  const sidecarHref = externalHydrationHref(html);
+  assert.ok(html.includes('<main>React ISR 1</main>'));
+  assert.ok(html.includes('src="/assets/react-entry.js"'));
+  assert.equal(html.includes('id="__FACETHEORY_DATA__"'), false);
+  assert.equal(html.includes(secret), false);
+  assert.match(sidecarHref, /^\/react-isr\?__facetheory_isr_hydration=/);
+
+  const sidecar = await app.handle({ method: 'GET', path: sidecarHref });
+  assert.equal(sidecar.status, 200);
+  assert.equal(
+    sidecar.headers['content-type']?.[0],
+    'application/json; charset=utf-8',
+  );
+  assert.equal(renderCount, 1);
+  assert.deepEqual(JSON.parse(decodeBody(sidecar.body as Uint8Array)), {
+    secret,
+    terminator: '</script>',
+  });
+});
+
+test('react adapter: SSG strict CSP lets build externalize legacy streaming hydration sidecars', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-react-ssg-'));
+  const outDir = path.resolve(tempRoot, 'out');
+
+  try {
+    const result = await buildSsgSite({
+      faces: [
+        createReactStreamFace({
+          route: '/',
+          mode: 'ssg',
+          render: () =>
+            React.createElement('main', null, 'React SSG strict stream'),
+          renderOptions: {
+            csp: {
+              inlineScripts: false,
+              inlineStyles: false,
+              rawHead: false,
+            },
+            hydration: {
+              data: {
+                message: '</script><script>alert("react")</script>',
+              },
+              bootstrapModule: '/assets/react-entry.js',
+            },
+          },
+        }),
+      ],
+      outDir,
+    });
+
+    assert.equal(
+      result.pages[0]?.hydrationDataFile,
+      '_facetheory/data/index.json',
+    );
+
+    const html = await readFile(path.resolve(outDir, 'index.html'), 'utf8');
+    assert.ok(html.includes('<main>React SSG strict stream</main>'));
+    assert.ok(html.includes('id="__FACETHEORY_DATA_URL__"'));
+    assert.ok(html.includes('href="/_facetheory/data/index.json"'));
+    assert.ok(html.includes('src="/assets/react-entry.js"'));
+    assert.equal(html.includes('id="__FACETHEORY_DATA__"'), false);
+    assert.equal(html.includes('</script><script>alert'), false);
+
+    const hydrationJson = await readFile(
+      path.resolve(outDir, '_facetheory/data/index.json'),
+      'utf8',
+    );
+    assert.equal(
+      hydrationJson,
+      '{"message":"\\u003c/script\\u003e\\u003cscript\\u003ealert(\\"react\\")\\u003c/script\\u003e"}\n',
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test('react adapter: strict CSP rejects inline hydration before head emission', async () => {


### PR DESCRIPTION
## Summary
- Defer only React adapter hydration-shape strict-CSP validation for Face-level `isr` and `ssg` wrapper paths that externalize legacy inline hydration before final HTML emission.
- Keep all other adapter strict-CSP checks active, including raw head, inline script/style head tags, inline adapter style output, and React streaming shell strategy restrictions.
- Add React regression coverage for ISR and SSG strict-CSP legacy hydration sidecars, with SSG coverage using `createReactStreamFace` so both React face factories are exercised.

## Root cause
`createReactFace` and `createReactStreamFace` called the public adapter renderers, which enforced `csp.inlineScripts === false` before the app/runtime ISR and SSG sidecar wrappers could convert legacy inline hydration into external hydration metadata. That made React ISR requests fail closed as 500s and React SSG builds abort even though the final emitted document would be strict-CSP-safe after sidecar externalization.

## Validation
- `cd ts && npx tsx test/unit/react.test.ts` — pass (6 tests)
- `cd ts && npx tsx test/unit/react-stream.test.ts` — pass (4 tests)
- `cd ts && npx tsx test/unit/isr.test.ts && npx tsx test/unit/ssg.test.ts` — pass (15 ISR tests, 6 SSG tests)
- `cd ts && npm run typecheck` — pass
- `cd ts && npm run lint` — pass
- `cd ts && npx prettier --check src/adapters/react.ts test/unit/react.test.ts` — pass
- `cd ts && npm test` — pass (470 pass, 1 skipped)
- `git diff --check` — pass

Note: `cd ts && npm run format:check` still reports pre-existing repository-wide formatting drift in 121 files; the two changed files pass targeted Prettier check.

## Scope confirmation
Changed files stay inside the requested FaceTheory React adapter/test scope:
- `ts/src/adapters/react.ts`
- `ts/test/unit/react.test.ts`

## Risks / blockers
No known blockers. The deferral is limited to adapter hydration-shape validation for `isr`/`ssg`; direct React adapter renders still reject inline hydration under strict CSP where no runtime sidecar path is known.