### PR TITLE
THE-1469: Block SPA OAC form navigation for CSP HTML

### DIFF
--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -124,7 +124,8 @@ OAC and navigation:
 - `startAwsOacFormTransport({ navigationPolicy: "full-page" })` is the strict-CSP default because fetched CSP headers
   cannot become the active document policy during `document.write()` replacement.
 - Choose `navigationPolicy: "spa"` only when the returned HTML is a FaceTheory document, the host accepts the SPA
-  navigation contract, and external hydration data is loaded before DOM mutation.
+  navigation contract, external hydration data is loaded before DOM mutation, and the fetched HTML does not carry
+  `Content-Security-Policy`; use full-page navigation or caller-owned handling for CSP-protected HTML.
 - Route mutating action paths through `ssrPathPatterns`; do not let S3 static behaviors intercept form actions from SSG
   or ISR pages.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -89,9 +89,9 @@ pair:
 - ISR: confirm `x-facetheory-isr` behavior stays normal and hydration sidecar URLs with
   `__facetheory_isr_hydration=...` route to Lambda/FaceTheory. The runtime validates the opaque pointer token and serves
   the pointer-derived `.hydration.json` object from the same `S3HtmlStore` used for HTML.
-- SPA navigation: confirm `startFaceNavigation()` or `startAwsOacFormTransport({ navigationPolicy: "spa" })` loads
-  external hydration data before mutating the document. Use `navigationPolicy: "full-page"` when fetched CSP-protected
-  HTML should become a real browser navigation instead of a document-write replacement.
+- SPA navigation: confirm `startFaceNavigation()` or non-CSP `startAwsOacFormTransport({ navigationPolicy: "spa" })`
+  responses load external hydration data before mutating the document. Use `navigationPolicy: "full-page"` when fetched
+  CSP-protected HTML should become a real browser navigation instead of a document-write or SPA DOM replacement.
 
 Evidence boundary:
 - A local strict-CSP test or example build proves repository behavior only.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -352,7 +352,7 @@ Core exports:
 - `createAwsOacUrlEncodedFormPayload(form, options)` returns the encoded body, content type, fields, and lowercase SHA256 hex digest over those bytes.
 - `sha256HexForAwsOacPayload(body, digest?)` exposes the Web Crypto digest path with a test-injectable digest.
 - `startAwsOacFormTransport(options)` intercepts only forms carrying the marker, resolves action/method/encoding from the form and submitter, enforces same-origin actions, preserves constraint validation, and sends the encoded body through `fetch` with `credentials: "same-origin"`, `redirect: "error"`, `content-type`, and `x-amz-content-sha256`.
-- `onNavigate(context)` lets a host coordinate successful form outcomes with `startFaceNavigation()` or another caller-owned navigation layer. If the hook returns anything other than `false`, FaceTheory treats the outcome as handled.
+- `onNavigate(context)` lets a host coordinate successful form outcomes with `startFaceNavigation()` or another caller-owned navigation layer. If the hook returns anything other than `false`, FaceTheory treats the outcome as handled; for CSP-protected HTML responses, that hook is the caller-owned boundary where the host must choose a full browser navigation or another CSP-safe handling path.
 
 Example client bootstrap:
 
@@ -380,7 +380,7 @@ Default navigation policy after a successful fetch is deliberately full-document
 
 - HTTP redirects fail closed at the fetch boundary so a preserving 307/308 cannot replay the signed body to another origin; hosts that want post-submit navigation should return a direct response and then choose a safe same-origin browser navigation in `onResponse` or `onNavigate`
 - non-redirect HTML responses, including server-rendered validation/error pages, replace the current document through `document.open()` / `document.write()` / `document.close()` and update history to the response URL when needed, unless the response carries `Content-Security-Policy` or `Content-Security-Policy-Report-Only`
-- CSP-protected HTML responses fail closed by default because fetch cannot install response CSP headers as the active document policy during `document.write()` replacement
+- CSP-protected HTML responses fail closed for fetched document replacement and explicit `navigationPolicy: "spa"` because fetch cannot install response CSP headers as the active document policy during `document.write()` replacement or SPA DOM mutation; use `navigationPolicy: "full-page"` or handle the response with `onNavigate` / `onResponse` when the host intentionally owns that boundary
 - non-HTML non-OK responses throw to `onError`
 - `onResponse` remains a full override for hosts that want to own response handling themselves
 

--- a/docs/cdk/aws-deployment.md
+++ b/docs/cdk/aws-deployment.md
@@ -96,7 +96,8 @@ OAC navigation policy:
 - Use `startAwsOacFormTransport()`'s default full-page navigation for strict-CSP form outcomes unless the host has
   explicitly chosen the SPA navigation contract.
 - Use `navigationPolicy: "spa"` only when the response is a FaceTheory document and external hydration can be loaded
-  before DOM mutation.
+  before DOM mutation, and do not use it as an escape hatch for HTML responses carrying `Content-Security-Policy`;
+  choose `navigationPolicy: "full-page"` or a caller-owned `onNavigate` / `onResponse` path for those responses.
 
 ## CloudFront Behavior Options
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -428,7 +428,7 @@ Why this is correct:
 - FaceTheory proceeds only when the resolved form encoding is `application/x-www-form-urlencoded`, computes the SHA256 hash over the exact URL-encoded bytes it sends, and sets `x-amz-content-sha256` for CloudFront's Lambda URL OAC signing path.
 - The action must stay same-origin, and FaceTheory forces `redirect: "error"` on the mutating fetch so a 307/308 open redirect cannot replay the signed form body to another origin.
 - Cookies and same-origin credentials remain on the CloudFront/AppTheory path, while AppTheory's `AWS_IAM` Lambda URL hardening stays intact.
-- Same-origin HTML validation/error responses may replace the whole document instead of inventing a partial DOM patching contract, but the default replacement fails closed when the response carries a `Content-Security-Policy` header because fetch cannot install response CSP headers into a `document.write()` navigation. Use `onNavigate` or `onResponse` for CSP-protected HTML responses and for intentional post-submit redirects to safe GET URLs.
+- Same-origin HTML validation/error responses may replace the whole document instead of inventing a partial DOM patching contract, but fetched document replacement and explicit SPA DOM navigation fail closed when the response carries a `Content-Security-Policy` header because fetch cannot install response CSP headers into the active document policy. Use `navigationPolicy: "full-page"`, `onNavigate`, or `onResponse` for CSP-protected HTML responses and for intentional post-submit redirects to safe GET URLs.
 
 **INCORRECT**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -259,8 +259,9 @@ runtime.post("/control/items/new", actionFace);
 The helper sends the exact URL-encoded bytes that it hashes, sets `x-amz-content-sha256`, and includes same-origin
 credentials. Marked forms that resolve to `multipart/form-data`, `text/plain`, or another unsupported encoding fail
 closed before a request is sent; file uploads need a separately scoped transport. If the HTML response carries a
-`Content-Security-Policy` header, handle the result explicitly through `onResponse` or `onNavigate` because fetched CSP
-headers cannot become the active document policy during default document replacement.
+`Content-Security-Policy` header, use `navigationPolicy: "full-page"` or handle the result explicitly through
+`onResponse` / `onNavigate` because fetched CSP headers cannot become the active document policy during document-write
+replacement or explicit SPA DOM navigation.
 
 ## Add Stitch Control-Plane Primitives
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -200,9 +200,9 @@ Navigation behavior:
 
 - the mutating fetch forces `redirect: "error"`, so HTTP redirects fail closed before a 307/308 can replay the URL-encoded body to another origin
 - server-rendered HTML validation/error responses may replace the whole document when they are not protected by response CSP headers
-- HTML responses with `Content-Security-Policy` headers fail closed by default because fetched response headers cannot become the active document policy for `document.write()` replacement
+- HTML responses with `Content-Security-Policy` headers fail closed for fetched document replacement and explicit SPA DOM navigation because fetched response headers cannot become the active document policy
 - marked forms that resolve to `multipart/form-data`, `text/plain`, or another unsupported encoding fail closed through `onError` before sending
-- use `onNavigate(context)` or `onResponse(response, context)` when a host intentionally coordinates CSP-protected responses, post-submit redirects to safe GET URLs, `startFaceNavigation()`, or another caller-owned navigation layer
+- use `navigationPolicy: "full-page"`, `onNavigate(context)`, or `onResponse(response, context)` when a host intentionally coordinates CSP-protected responses, post-submit redirects to safe GET URLs, `startFaceNavigation()`, or another caller-owned navigation layer
 
 Verification:
 

--- a/ts/src/oac-form.ts
+++ b/ts/src/oac-form.ts
@@ -438,14 +438,14 @@ async function applyDefaultNavigationPolicy(
       input.window.location.assign(finalUrl.toString());
       return;
     }
+    if (responseHasCsp) {
+      throw new Error(
+        'FaceTheory OAC form transport refused to apply an HTML response protected by Content-Security-Policy because fetch cannot install response CSP headers during document.write or SPA DOM navigation; use navigationPolicy:"full-page" or handle the response with onNavigate/onResponse instead',
+      );
+    }
     if (policy === 'spa') {
       await applySpaNavigationPolicy(input, context, finalUrl, html);
       return;
-    }
-    if (responseHasCsp) {
-      throw new Error(
-        'FaceTheory OAC form transport refused to replace the current document with an HTML response protected by Content-Security-Policy because fetch cannot install response CSP headers during document.write navigation; use navigationPolicy:"full-page", navigationPolicy:"spa", or handle the response with onNavigate instead',
-      );
     }
     replaceDocument(input.form.ownerDocument, input.window, html, finalUrl);
     return;
@@ -464,11 +464,7 @@ async function applySpaNavigationPolicy(
   finalUrl: URL,
   html: string | null,
 ): Promise<void> {
-  const snapshot = await resolveSpaNavigationSnapshot(
-    input,
-    finalUrl,
-    html,
-  );
+  const snapshot = await resolveSpaNavigationSnapshot(input, finalUrl, html);
   const options = input.options.spaNavigation ?? {};
   const viewSelector = options.viewSelector ?? DEFAULT_FACE_VIEW_SELECTOR;
 

--- a/ts/test/unit/oac-form.test.ts
+++ b/ts/test/unit/oac-form.test.ts
@@ -1088,7 +1088,7 @@ test('oac form transport: refuses default document replacement when response CSP
     assert.equal(errors.length, 1);
     assert.match(
       String(errors[0]),
-      /refused to replace.*Content-Security-Policy/,
+      /refused to apply.*Content-Security-Policy/,
     );
   } finally {
     dom.window.close();
@@ -1137,6 +1137,68 @@ test('oac form transport: strict CSP defaults to full same-origin browser naviga
           'https://example.test/save',
         ),
       strictCsp: true,
+      window: fakeNavigationWindow(dom, assigned, replaced),
+    });
+
+    const event = new dom.window.SubmitEvent('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+    form.dispatchEvent(event);
+    await flushEventLoop();
+
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(dom.window.document.title, 'Edit');
+    assert.equal(writeCount, 0);
+    assert.deepEqual(assigned, ['https://example.test/save']);
+    assert.deepEqual(replaced, []);
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('oac form transport: explicit full-page policy navigates CSP-protected HTML through the browser', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html>
+        <head><title>Edit</title></head>
+        <body>
+          <form action="/save" method="post" data-facetheory-oac-form>
+            <input name="title" value="">
+          </form>
+        </body>
+      </html>`,
+    { url: 'https://example.test/edit' },
+  );
+
+  try {
+    const form = dom.window.document.querySelector('form');
+    assert.ok(form instanceof dom.window.HTMLFormElement);
+
+    let writeCount = 0;
+    dom.window.document.write = () => {
+      writeCount += 1;
+    };
+
+    const assigned: string[] = [];
+    const replaced: string[] = [];
+    startAwsOacFormTransport({
+      document: dom.window.document,
+      fetcher: async () =>
+        responseWithUrl(
+          new Response(
+            '<!doctype html><html><head><title>Invalid</title></head><body><main>Title is required</main></body></html>',
+            {
+              headers: {
+                'content-security-policy': "script-src 'self'",
+                'content-type': 'text/html; charset=utf-8',
+              },
+              status: 422,
+            },
+          ),
+          'https://example.test/save',
+        ),
+      navigationPolicy: 'full-page',
       window: fakeNavigationWindow(dom, assigned, replaced),
     });
 
@@ -1211,7 +1273,6 @@ test('oac form transport: SPA navigation policy loads external hydration before 
                 </html>`,
               {
                 headers: {
-                  'content-security-policy': "script-src 'self'",
                   'content-type': 'text/html; charset=utf-8',
                 },
                 status: 200,
@@ -1273,6 +1334,105 @@ test('oac form transport: SPA navigation policy loads external hydration before 
   }
 });
 
+test('oac form transport: refuses explicit SPA policy when response CSP is present', async () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <html>
+        <head><title>Edit</title></head>
+        <body>
+          <form action="/save" method="post" data-facetheory-oac-form>
+            <input name="title" value="Draft">
+          </form>
+          <main data-facetheory-view>Editing</main>
+        </body>
+      </html>`,
+    { url: 'https://example.test/edit' },
+  );
+
+  try {
+    const form = dom.window.document.querySelector('form');
+    assert.ok(form instanceof dom.window.HTMLFormElement);
+
+    let writeCount = 0;
+    dom.window.document.write = () => {
+      writeCount += 1;
+    };
+
+    const fetched: string[] = [];
+    const errors: unknown[] = [];
+    const replaced: string[] = [];
+    const errored = new Promise<void>((resolve) => {
+      startAwsOacFormTransport({
+        document: dom.window.document,
+        fetcher: async (input) => {
+          fetched.push(String(input));
+          if (String(input).endsWith('/_facetheory/hydration/save.json')) {
+            throw new Error('hydration must not be fetched after response CSP');
+          }
+          return responseWithUrl(
+            new Response(
+              `<!doctype html>
+                <html>
+                  <head>
+                    <title>Saved</title>
+                    <base href="https://evil.test/">
+                    <link rel="facetheory-hydration" href="/_facetheory/hydration/save.json" type="application/json">
+                    <script src="/assets/entry-client.js" type="module"></script>
+                  </head>
+                  <body>
+                    <main data-facetheory-view onclick="window.__ran = true">Saved view</main>
+                  </body>
+                </html>`,
+              {
+                headers: {
+                  'content-security-policy': "script-src 'none'",
+                  'content-type': 'text/html; charset=utf-8',
+                },
+                status: 200,
+              },
+            ),
+            'https://example.test/save',
+          );
+        },
+        navigationPolicy: 'spa',
+        onError: (error) => {
+          errors.push(error);
+          resolve();
+        },
+        spaNavigation: {
+          parser: new dom.window.DOMParser(),
+        },
+        window: fakeNavigationWindow(dom, [], replaced),
+      });
+    });
+
+    const event = new dom.window.SubmitEvent('submit', {
+      bubbles: true,
+      cancelable: true,
+    });
+    form.dispatchEvent(event);
+    await errored;
+
+    assert.equal(event.defaultPrevented, true);
+    assert.deepEqual(fetched, ['https://example.test/save']);
+    assert.equal(dom.window.document.title, 'Edit');
+    assert.equal(
+      dom.window.document.querySelector('[data-facetheory-view]')?.textContent,
+      'Editing',
+    );
+    assert.equal(dom.window.document.querySelector('base'), null);
+    assert.equal(writeCount, 0);
+    assert.deepEqual(replaced, []);
+    assert.equal(errors.length, 1);
+    assert.match(
+      String(errors[0]),
+      /refused to apply.*Content-Security-Policy/,
+    );
+  } finally {
+    dom.window.close();
+  }
+});
+
 test('oac form transport: SPA policy rejects unsafe hydration targets before mutation', async () => {
   const dom = new JSDOM(
     `<!doctype html>
@@ -1318,7 +1478,6 @@ test('oac form transport: SPA policy rejects unsafe hydration targets before mut
                 </html>`,
               {
                 headers: {
-                  'content-security-policy': "script-src 'self'",
                   'content-type': 'text/html; charset=utf-8',
                 },
                 status: 200,
@@ -1392,11 +1551,15 @@ test('oac form transport: lets hosts override navigation outcomes', async () => 
         fetcher: async () =>
           responseWithUrl(
             new Response('<!doctype html><title>Saved</title><p>Saved</p>', {
-              headers: { 'content-type': 'text/html' },
+              headers: {
+                'content-security-policy': "default-src 'self'",
+                'content-type': 'text/html',
+              },
               status: 200,
             }),
             'https://example.test/save',
           ),
+        navigationPolicy: 'spa',
         onNavigate: (context) => {
           navigations.push({
             html: context.html,
@@ -1420,7 +1583,7 @@ test('oac form transport: lets hosts override navigation outcomes', async () => 
     assert.equal(event.defaultPrevented, true);
     assert.equal(dom.window.document.title, 'Edit');
     assert.equal(navigations.length, 1);
-    assert.equal(navigations[0]?.navigation, 'replace-document');
+    assert.equal(navigations[0]?.navigation, 'spa');
     assert.equal(navigations[0]?.url, 'https://example.test/save');
     assert.match(navigations[0]?.html ?? '', /Saved/);
   } finally {


### PR DESCRIPTION
## Issue summary

THE-1469 reported that OAC form transport computed response CSP but let explicit `navigationPolicy: "spa"` apply the fetched HTML through the SPA snapshot path before the existing CSP refusal. That could mutate the current document through `innerHTML`/head synchronization without installing the fetched response CSP.

## Remediation summary

- Move the response-CSP refusal ahead of the OAC SPA DOM mutation path while keeping caller-owned `onNavigate` handling and `navigationPolicy: "full-page"` browser navigation supported.
- Update the refusal text so `navigationPolicy: "spa"` is no longer presented as a CSP escape hatch.
- Add regression coverage for explicit SPA refusal, explicit full-page behavior, custom `onNavigate` handling, and non-CSP SPA hydration behavior.
- Refresh OAC form navigation docs to state that CSP-protected fetched HTML requires full-page/browser navigation or caller-owned handling.

## Changed files

- `ts/src/oac-form.ts`
- `ts/test/unit/oac-form.test.ts`
- `docs/api-reference.md`
- `docs/cdk/aws-deployment.md`
- `docs/AWS_DEPLOYMENT_SHAPE.md`
- `docs/OPERATIONS.md`
- `docs/getting-started.md`
- `docs/core-patterns.md`
- `docs/troubleshooting.md`

## Validation

- `cd ts && npx tsx test/unit/oac-form.test.ts` — PASS (29 pass)
- `cd ts && npm test` — PASS (472 pass, 1 skip)
- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run lint` — PASS
- `scripts/verify-version-alignment.sh` — PASS (`version-alignment: PASS (3.2.1)`)
- `git diff --check` — PASS

## Risks

- Hosts that depended on explicit `navigationPolicy: "spa"` for CSP-protected fetched HTML will now receive the intended fail-closed error and must switch to full-page navigation or a caller-owned `onNavigate`/`onResponse` path.
- `onResponse` remains a full override; hosts using it still own the CSP boundary.

## Blockers

None.