### PR TITLE
THE-1470: Bind ISR hydration sidecars to tenant/auth variants

### DIFF
--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -109,9 +109,12 @@ ISR sidecars:
 - The sidecar pointer is derived from the HTML pointer by replacing `.html` with `.hydration.json`, so stale HTML and
   stale hydration data remain paired through the same metadata pointer lifecycle.
 - The browser-facing data URL stays on the page route and uses the opaque `__facetheory_isr_hydration` query parameter.
-  That request must route to Lambda/FaceTheory, not directly to S3, so the runtime can validate and serve the pointer.
+  That request must route to Lambda/FaceTheory, not directly to S3, so the runtime can resolve the tenant/cache-key
+  variant, validate the pointer binding, and serve the sidecar only for an equivalent request context.
 - Do not create public CloudFront behaviors that expose arbitrary ISR sidecar object keys. The runtime validates the
-  pointer token and returns `404` for invalid or missing sidecars.
+  pointer token and request-variant binding, then returns `404` for invalid, missing, or cross-variant sidecars. The
+  sidecar URL is not a bearer credential; tenant, authorization-like headers, cookies, and query variants must still
+  match the HTML generation boundary.
 
 SSR sidecars:
 
@@ -204,13 +207,14 @@ Notes:
 
 1. Request reaches Lambda URL behavior.
 2. FaceTheory verifies tenant partition safety. Requests carrying known tenant boundary headers (`x-tenant-id` or `x-facetheory-tenant`) fail closed unless `tenantKey` or a custom `cacheKey` is configured.
-3. FaceTheory computes cache key (`tenant + route + params + query` by default).
+3. FaceTheory computes cache key (`tenant + route + params + query + authorization-like header/cookie digests` by default).
 4. Metadata lookup in DynamoDB:
    - fresh -> serve cached HTML pointer from S3
    - stale/miss -> attempt lease lock and regenerate
 5. Strict-CSP regeneration writes the pointer-derived hydration sidecar before the HTML metadata commit.
 6. Regeneration writes HTML to S3, then atomically updates metadata pointer.
 7. On regeneration failure, previous pointer stays valid; stale HTML and stale hydration data stay paired.
+8. Hydration sidecar reads resolve the same tenant/cache-key request variant before serving JSON.
 
 Default tenant note:
 - FaceTheory uses the `default` tenant unless `tenantKey` is configured.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -87,8 +87,10 @@ pair:
 - SSG: confirm HTML and `/_facetheory/data/*` sidecars are uploaded together and routed to S3 through CloudFront. Cache
   headers and invalidations should keep the HTML and sidecar from different builds from being mixed.
 - ISR: confirm `x-facetheory-isr` behavior stays normal and hydration sidecar URLs with
-  `__facetheory_isr_hydration=...` route to Lambda/FaceTheory. The runtime validates the opaque pointer token and serves
-  the pointer-derived `.hydration.json` object from the same `S3HtmlStore` used for HTML.
+  `__facetheory_isr_hydration=...` route to Lambda/FaceTheory. The runtime validates the opaque pointer token against
+  the current tenant/cache-key request variant before serving the pointer-derived `.hydration.json` object from the same
+  `S3HtmlStore` used for HTML. Treat copied sidecar URLs as insufficient on their own; mismatched tenant, auth-like
+  headers, cookies, or query variants should fail closed with `404`.
 - SPA navigation: confirm `startFaceNavigation()` or non-CSP `startAwsOacFormTransport({ navigationPolicy: "spa" })`
   responses load external hydration data before mutating the document. Use `navigationPolicy: "full-page"` when fetched
   CSP-protected HTML should become a real browser navigation instead of a document-write or SPA DOM replacement.

--- a/docs/cdk/aws-deployment.md
+++ b/docs/cdk/aws-deployment.md
@@ -83,8 +83,10 @@ ISR:
 - Hydration sidecars are stored in the same `S3HtmlStore` namespace as generated HTML, with `.hydration.json` derived
   from the HTML pointer.
 - The browser URL is the route URL plus `__facetheory_isr_hydration=<opaque-token>`. Route that request to
-  Lambda/FaceTheory so the runtime can validate and serve the sidecar.
+  Lambda/FaceTheory so the runtime can resolve the same tenant/cache-key request variant before serving the sidecar.
 - Do not add a public S3 behavior for arbitrary ISR object keys or expose the raw pointer as a stable client contract.
+  A copied ISR sidecar URL is not a bearer credential; mismatched tenant, authorization-like headers, cookies, or query
+  variants fail closed with `404`.
 
 SSR:
 
@@ -149,6 +151,7 @@ ISR:
 - observe `x-facetheory-isr` on responses
 - do not treat ISR HTML as immutable static content
 - treat pointer-derived hydration sidecars as part of the ISR HTML generation result, not as independent static assets
+- keep ISR hydration sidecar requests on the same tenant/auth/cookie/query variant boundary as the HTML that emitted them
 
 ## ISR Storage Notes
 

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -414,24 +414,37 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
         input.ctx.request.query,
         runtimeOptions.htmlPointerPrefix,
       );
-      if (hydrationSidecarPointer.present) {
-        return hydrationSidecarPointer.pointer
-          ? cachedHydrationSidecarResponse(
-              runtimeOptions,
-              hydrationSidecarPointer.pointer,
-            )
-          : hydrationSidecarNotFoundResponse();
-      }
 
       const tenant = resolveTenant(runtimeOptions, input.ctx);
+      const query = hydrationSidecarPointer.present
+        ? queryWithoutHydrationSidecar(input.ctx.request.query)
+        : input.ctx.request.query;
       const cacheKey = runtimeOptions.cacheKey({
         tenant,
         routePattern: normalizePath(input.routePattern),
         params: input.ctx.params,
-        query: input.ctx.request.query,
+        query,
         headers: input.ctx.request.headers,
         cookies: input.ctx.request.cookies,
       });
+
+      if (hydrationSidecarPointer.present) {
+        if (
+          !hydrationSidecarPointer.pointer ||
+          !hydrationSidecarPointerMatchesCacheKey(
+            hydrationSidecarPointer.pointer,
+            cacheKey,
+            runtimeOptions.htmlPointerPrefix,
+          )
+        ) {
+          return hydrationSidecarNotFoundResponse();
+        }
+        return cachedHydrationSidecarResponse(
+          runtimeOptions,
+          hydrationSidecarPointer.pointer,
+        );
+      }
+
       const currentNow = runtimeOptions.now();
       const existing = await runtimeOptions.metaStore.get(cacheKey);
 
@@ -655,6 +668,7 @@ async function regenerateAndCommit(
     buildHydrationSidecarPointerFromHtmlPointer(htmlPointer);
   const hydrationDataUrl = buildHydrationSidecarDataUrl(
     input.ctx.request.path,
+    input.ctx.request.query,
     hydrationSidecarPointer,
   );
   const hydrationSidecarRef: { current: IsrHydrationSidecar | null } = {
@@ -906,11 +920,11 @@ function buildHtmlPointer(
   generatedAt: number,
   prefix: string,
 ): string {
-  const digest = createHash('sha256')
-    .update(cacheKey)
-    .digest('hex')
-    .slice(0, 24);
-  return `${prefix}${digest}/${generatedAt}-${randomUUID()}.html`;
+  return `${prefix}${cacheKeyDigest(cacheKey)}/${generatedAt}-${randomUUID()}.html`;
+}
+
+function cacheKeyDigest(cacheKey: string): string {
+  return createHash('sha256').update(cacheKey).digest('hex').slice(0, 24);
 }
 
 function buildHydrationSidecarPointerFromHtmlPointer(
@@ -923,10 +937,19 @@ function buildHydrationSidecarPointerFromHtmlPointer(
 
 function buildHydrationSidecarDataUrl(
   routePath: string,
+  query: Query,
   sidecarPointer: string,
 ): string {
   const token = Buffer.from(sidecarPointer, 'utf8').toString('base64url');
-  return `${normalizePath(routePath)}?${ISR_HYDRATION_QUERY_PARAM}=${encodeURIComponent(token)}`;
+  const params = new URLSearchParams();
+  for (const [key, values] of Object.entries(query)) {
+    if (key === ISR_HYDRATION_QUERY_PARAM) continue;
+    for (const value of values ?? []) {
+      params.append(key, String(value));
+    }
+  }
+  params.append(ISR_HYDRATION_QUERY_PARAM, token);
+  return `${normalizePath(routePath)}?${params.toString()}`;
 }
 
 function hydrationSidecarPointerFromRequest(
@@ -983,6 +1006,27 @@ function isValidHydrationSidecarPointer(
   }
 
   return true;
+}
+
+function hydrationSidecarPointerMatchesCacheKey(
+  pointer: string,
+  cacheKey: string,
+  htmlPointerPrefix: string,
+): boolean {
+  const relative = htmlPointerPrefix
+    ? pointer.slice(htmlPointerPrefix.length)
+    : pointer;
+  const pointerDigest = relative.split('/')[0] ?? '';
+  return pointerDigest.toLowerCase() === cacheKeyDigest(cacheKey);
+}
+
+function queryWithoutHydrationSidecar(query: Query): Query {
+  const out: Query = {};
+  for (const [key, values] of Object.entries(query)) {
+    if (key === ISR_HYDRATION_QUERY_PARAM) continue;
+    out[key] = [...(values ?? [])];
+  }
+  return out;
 }
 
 async function cachedHydrationSidecarResponse(

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -28,7 +28,7 @@ function externalHydrationHref(html: string): string {
   assert.ok(tag, 'expected external hydration link tag');
   const href = /\bhref="([^"]+)"/i.exec(tag)?.[1];
   assert.ok(href, 'expected external hydration href');
-  return href;
+  return href.replace(/&amp;/g, '&');
 }
 
 function delay(ms: number): Promise<void> {
@@ -398,8 +398,7 @@ for (const variant of [
           revalidateSeconds: 60,
           render: async (ctx) => {
             const seq = ++renderCount;
-            const tenant =
-              ctx.request.headers['x-tenant-id']?.[0] ?? 'missing';
+            const tenant = ctx.request.headers['x-tenant-id']?.[0] ?? 'missing';
             return { html: `<main>${tenant}-${seq}</main>` };
           },
         },
@@ -427,15 +426,11 @@ for (const variant of [
     assert.equal(renderCount, 0);
     assert.deepEqual(metaStore.debugSnapshot(), []);
     assert.equal(
-      decodeBody(tenantAHeader.body as Uint8Array).includes(
-        'TENANT_SECRET_A',
-      ),
+      decodeBody(tenantAHeader.body as Uint8Array).includes('TENANT_SECRET_A'),
       false,
     );
     assert.equal(
-      decodeBody(tenantBHeader.body as Uint8Array).includes(
-        'TENANT_SECRET_B',
-      ),
+      decodeBody(tenantBHeader.body as Uint8Array).includes('TENANT_SECRET_B'),
       false,
     );
   });
@@ -748,7 +743,10 @@ test('isr: strict CSP hydration writes and serves pointer-derived sidecars', asy
 
   const sidecar = await app.handle({ method: 'GET', path: sidecarHref });
   assert.equal(sidecar.status, 200);
-  assert.equal(sidecar.headers['content-type']?.[0], 'application/json; charset=utf-8');
+  assert.equal(
+    sidecar.headers['content-type']?.[0],
+    'application/json; charset=utf-8',
+  );
   assert.equal(renderCount, 1);
 
   const sidecarJson = decodeBody(sidecar.body as Uint8Array);
@@ -769,6 +767,119 @@ test('isr: strict CSP hydration writes and serves pointer-derived sidecars', asy
   const serializedMeta = JSON.stringify(metaStore.debugSnapshot());
   assert.equal(serializedMeta.includes(secret), false);
   assert.equal(serializedMeta.includes('terminator'), false);
+});
+
+test('isr: strict CSP hydration sidecars are bound to tenant and auth variants', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/accounts/{id}',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: (ctx) => {
+          const seq = ++renderCount;
+          return {
+            csp: {
+              inlineScripts: false,
+              inlineStyles: false,
+              rawHead: false,
+            },
+            html: `<main>${ctx.params.id}-${seq}</main>`,
+            hydration: {
+              data: {
+                id: ctx.params.id,
+                seq,
+                tenant: ctx.request.headers['x-tenant-id']?.[0] ?? 'missing',
+                view: ctx.request.query.view?.[0] ?? 'missing',
+              },
+              bootstrapModule: '/assets/account-entry.js',
+            },
+          };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => 1_000,
+      tenantKey: tenantKeyFromTrustedHeader('x-tenant-id'),
+    },
+  });
+
+  const matchingHeaders = {
+    'x-tenant-id': ['tenant-a'],
+    authorization: ['Bearer SECRET_TOKEN_A'],
+    cookie: ['session=COOKIE_SECRET_A; theme=light'],
+  };
+  const miss = await app.handle({
+    method: 'GET',
+    path: '/accounts/42?view=summary',
+    headers: matchingHeaders,
+  });
+  const missHtml = decodeBody(miss.body as Uint8Array);
+  const sidecarHref = externalHydrationHref(missHtml);
+
+  assert.equal(miss.status, 200);
+  assert.equal(miss.headers['x-facetheory-isr']?.[0], 'miss');
+  assert.match(
+    sidecarHref,
+    /^\/accounts\/42\?view=summary&__facetheory_isr_hydration=/,
+  );
+
+  const matchingSidecar = await app.handle({
+    method: 'GET',
+    path: sidecarHref,
+    headers: matchingHeaders,
+  });
+  assert.equal(matchingSidecar.status, 200);
+  assert.deepEqual(JSON.parse(decodeBody(matchingSidecar.body as Uint8Array)), {
+    id: '42',
+    seq: 1,
+    tenant: 'tenant-a',
+    view: 'summary',
+  });
+
+  const leakedWithoutOriginalContext = await app.handle({
+    method: 'GET',
+    path: sidecarHref,
+  });
+  const leakedMissingAuthCookie = await app.handle({
+    method: 'GET',
+    path: sidecarHref,
+    headers: { 'x-tenant-id': ['tenant-a'] },
+  });
+  const leakedDifferentTenant = await app.handle({
+    method: 'GET',
+    path: sidecarHref,
+    headers: {
+      ...matchingHeaders,
+      'x-tenant-id': ['tenant-b'],
+    },
+  });
+  const leakedDifferentCookie = await app.handle({
+    method: 'GET',
+    path: sidecarHref,
+    headers: {
+      ...matchingHeaders,
+      cookie: ['session=COOKIE_SECRET_B; theme=light'],
+    },
+  });
+  const leakedWithoutQueryVariant = await app.handle({
+    method: 'GET',
+    path: sidecarHref.replace('view=summary&', ''),
+    headers: matchingHeaders,
+  });
+
+  assert.equal(leakedWithoutOriginalContext.status, 404);
+  assert.equal(leakedMissingAuthCookie.status, 404);
+  assert.equal(leakedDifferentTenant.status, 404);
+  assert.equal(leakedDifferentCookie.status, 404);
+  assert.equal(leakedWithoutQueryVariant.status, 404);
+  assert.equal(renderCount, 1);
 });
 
 class FailingSidecarHtmlStore extends InMemoryHtmlStore {


### PR DESCRIPTION
## Issue summary

THE-1470 reported that strict-CSP ISR hydration sidecars were served from the `__facetheory_isr_hydration` pointer token before tenant resolution and before the normal ISR cache-key calculation. A leaked sidecar URL could therefore act as a bearer credential across tenant, authorization-like header, cookie, and query variants.

## Remediation summary

- Move ISR hydration sidecar reads behind tenant resolution and cache-key calculation.
- Strip only the sidecar query parameter before computing the request-variant cache key for a sidecar fetch.
- Validate that the pointer-derived cache-key digest matches the current tenant/route/query/auth-header/cookie variant before reading sidecar JSON.
- Preserve original page query parameters in generated sidecar URLs so matching request variants can still fetch the sidecar.
- Keep sidecar JSON responses `no-store` and preserve existing pointer syntax validation.
- Document that ISR hydration sidecar URLs are request-variant-bound and are not bearer credentials.

## Changed files

- `ts/src/isr.ts` — binds sidecar reads to current cache-key digest and preserves original query params in sidecar URLs.
- `ts/test/unit/isr.test.ts` — adds regression coverage for matching context success and leaked sidecar URL denial across missing auth/cookie/tenant, different tenant, different cookie, and missing query variant.
- `docs/AWS_DEPLOYMENT_SHAPE.md` — documents tenant/cache-key variant validation for ISR sidecars.
- `docs/cdk/aws-deployment.md` — documents ISR sidecar variant-bound deployment routing.
- `docs/OPERATIONS.md` — updates strict-CSP operations checks for request-variant-bound sidecars.

## Validation

- `cd ts && npx tsx test/unit/isr.test.ts` — PASS (16 tests passed)
- `cd ts && npm test` — PASS (474 tests: 473 passed, 1 skipped)
- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run lint` — PASS
- `scripts/verify-version-alignment.sh` — PASS (`version-alignment: PASS (3.2.1)`)
- `git diff --check` — PASS

## Risks

- Query-varied ISR HTML generated before this fix may contain sidecar URLs that omitted the original query string; those stale sidecar fetches can now fail closed with `404` until the HTML regenerates.
- Custom `cacheKey` remains the consumer-owned partition contract. If a custom key intentionally omits tenant/auth/cookie variance, sidecar authorization follows that custom boundary.

## Blockers

None.