### PR TITLE
fix(security): bound strict CSP stream buffering

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -84,6 +84,10 @@ pair:
 - SSR: confirm the response carries `content-security-policy` from the Face and the external hydration `dataUrl` is
   same-origin. If the data is request-time, route the sidecar URL to Lambda/AppTheory or another host-owned same-origin
   endpoint that can reproduce the exact render data.
+- Streaming strict-CSP SSR is intentionally buffered for whole-document validation. FaceTheory enforces
+  `createFaceApp({ strictCsp: { maxStreamingBodyBytes } })` while reading raw stream chunks and defaults to 5 MiB. If the
+  limit is exceeded, the route fails closed with a bounded `413 Payload Too Large` response instead of validating or
+  returning a truncated partial document. Non-strict streaming remains streaming and is not collected by this limit.
 - SSG: confirm HTML and `/_facetheory/data/*` sidecars are uploaded together and routed to S3 through CloudFront. Cache
   headers and invalidations should keep the HTML and sidecar from different builds from being mixed.
 - ISR: confirm `x-facetheory-isr` behavior stays normal and hydration sidecar URLs with

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -117,7 +117,7 @@ These contracts shape every adapter and delivery mode. If you change one of thes
 | `FaceResponse`     | Runtime response                     | Includes normalized headers, cookies array, status, body, and `isBase64`.                                                                                                                                                                                |
 | `FaceRenderResult` | Render output before HTTP conversion | Supports document-shell attrs (`lang`, `htmlAttrs`, `bodyAttrs`), `head`, `headTags`, `styleTags`, `csp`, `html`, cookies, headers, and hydration payload. `head.html` is legacy escaped head text; prefer structured `headTags` / `styleTags` for actual tags. |
 | `FaceContext`      | Per-request context                  | Exposes normalized request, route params, and proxy match.                                                                                                                                                                                               |
-| `FaceAppOptions`   | App constructor options              | Accepts `faces`, optional ISR config, and optional observability hooks.                                                                                                                                                                                  |
+| `FaceAppOptions`   | App constructor options              | Accepts `faces`, optional ISR config, optional observability hooks, and optional strict-CSP runtime limits.                                                                                                                                               |
 | `FaceIsrOptions`   | ISR runtime tuning                   | Configures HTML store, metadata store, lease timing, contention policy, cache key, tenant key, and cache-control generation.                                                                                                                             |
 
 Structured head/style emission is the supported default:
@@ -275,6 +275,8 @@ FaceTheory supports two CSP-compatible rendering styles:
 
 Core strict-CSP exports:
 
+- `DEFAULT_STRICT_CSP_STREAMING_BODY_LIMIT_BYTES` is the default maximum raw body size FaceTheory will collect from a
+  strict no-inline streaming render result before whole-document validation. The default is 5 MiB.
 - `FaceCspPolicy` is the route-level render policy surface. `inlineScripts:false` rejects inline script bodies,
   inline hydration JSON, inline event-handler attributes, and cross-origin bootstrap/data URLs. `inlineStyles:false`
   rejects inline style tags and `style` attributes. `rawHead:false` rejects caller-owned raw head HTML.
@@ -320,6 +322,30 @@ renderOptions: async (_ctx, data) => {
     ),
   };
 };
+```
+
+Strict streaming limit:
+
+- Strict no-inline streaming responses are buffered before validation because bytes must not flush before the final
+  document is known to satisfy the route policy.
+- During that buffer step, FaceTheory counts raw `Uint8Array` bytes as each chunk arrives and fails closed with a
+  deterministic `413 Payload Too Large` response when `strictCsp.maxStreamingBodyBytes` is exceeded.
+- The failed response does not validate or return a truncated partial document. Non-strict streaming responses are not
+  collected by this limit and still preflight only the first render chunk before returning an `AsyncIterable`.
+
+```ts
+import {
+  DEFAULT_STRICT_CSP_STREAMING_BODY_LIMIT_BYTES,
+  createFaceApp,
+} from "@theory-cloud/facetheory";
+
+const app = createFaceApp({
+  faces,
+  strictCsp: {
+    // Optional: tune if a strict streaming route has a larger validated body budget.
+    maxStreamingBodyBytes: DEFAULT_STRICT_CSP_STREAMING_BODY_LIMIT_BYTES,
+  },
+});
 ```
 
 Adapter notes:

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -45,12 +45,27 @@ export interface FaceAppOptions {
   faces: FaceModule[];
   isr?: FaceIsrOptions;
   observability?: FaceObservabilityHooks;
+  strictCsp?: FaceStrictCspOptions;
+}
+
+export interface FaceStrictCspOptions {
+  /**
+   * Maximum raw stream bytes FaceTheory will collect for strict no-inline CSP
+   * document validation. Strict streaming responses must be buffered before
+   * validation so this limit prevents unbounded body collection.
+   */
+  maxStreamingBodyBytes?: number;
 }
 
 const HTML_CONTENT_TYPE = 'text/html; charset=utf-8';
+export const DEFAULT_STRICT_CSP_STREAMING_BODY_LIMIT_BYTES = 5 * 1024 * 1024;
 const SAFE_INTERNAL_ERROR_HTML = renderHTMLDocument({
   head: '<title>Internal Server Error</title>',
   body: '<h1>Internal Server Error</h1><template data-facetheory-error="true"></template>',
+});
+const SAFE_PAYLOAD_TOO_LARGE_HTML = renderHTMLDocument({
+  head: '<title>Payload Too Large</title>',
+  body: '<h1>Payload Too Large</h1><template data-facetheory-error="strict-csp-stream-body-too-large"></template>',
 });
 
 const REQUEST_ID_HEADER = 'x-request-id';
@@ -63,16 +78,33 @@ class StreamPreflightError extends Error {
   }
 }
 
+class StrictCspStreamBodyTooLargeError extends Error {
+  constructor(
+    readonly limitBytes: number,
+    readonly receivedBytes: number,
+  ) {
+    super(
+      `strict CSP streaming body exceeded ${String(limitBytes)} byte limit after ${String(receivedBytes)} bytes`,
+    );
+    this.name = 'StrictCspStreamBodyTooLargeError';
+  }
+}
+
 export class FaceApp {
   private readonly router: Router;
   private readonly faceByPattern: Map<string, FaceModule>;
   private readonly isrRuntime: IsrRuntime | null;
   private readonly observability: FaceObservabilityHooks | null;
+  private readonly strictCspMaxStreamingBodyBytes: number;
 
   constructor(options: FaceAppOptions) {
     this.router = new Router();
     this.faceByPattern = new Map();
     this.observability = options.observability ?? null;
+    this.strictCspMaxStreamingBodyBytes =
+      normalizeStrictCspMaxStreamingBodyBytes(
+        options.strictCsp?.maxStreamingBodyBytes,
+      );
 
     for (const face of options.faces) {
       const pattern = normalizePath(face.route);
@@ -153,7 +185,11 @@ export class FaceApp {
             await face.render(ctx, data),
             isrOptions,
           );
-          return await toHTTPResponse(out, normalizedReq);
+          return await toHTTPResponse(
+            out,
+            normalizedReq,
+            this.strictCspMaxStreamingBodyBytes,
+          );
         } finally {
           renderMs = Math.max(0, now() - renderStartedAt);
         }
@@ -182,8 +218,11 @@ export class FaceApp {
         mode,
         renderMs,
       });
-    } catch {
-      response = internalErrorResponse();
+    } catch (err) {
+      response =
+        err instanceof StrictCspStreamBodyTooLargeError
+          ? strictCspStreamBodyTooLargeResponse()
+          : internalErrorResponse();
       return finishResponse(hooks, now, startedAt, requestId, normalizedReq, response, {
         routePattern,
         mode,
@@ -375,6 +414,7 @@ function externalizeHydrationForIsr(
 async function toHTTPResponse(
   out: FaceRenderResult,
   req: Readonly<Required<FaceRequest>>,
+  strictCspMaxStreamingBodyBytes: number,
 ): Promise<FaceResponse> {
   const status = out.status ?? 200;
   const headers = toHeaders(out.headers, out.cookies);
@@ -405,7 +445,10 @@ async function toHTTPResponse(
   }
 
   if (requiresStrictCspDocumentValidation(out.csp)) {
-    const strictBody = await collectStreamAsUtf8Text(out.html);
+    const strictBody = await collectStreamAsUtf8Text(
+      out.html,
+      strictCspMaxStreamingBodyBytes,
+    );
     const documentHtml = renderHTMLDocument({
       ...documentParts,
       head,
@@ -433,16 +476,29 @@ async function toHTTPResponse(
 
 async function collectStreamAsUtf8Text(
   input: AsyncIterable<Uint8Array>,
+  maxBytes: number,
 ): Promise<string> {
-  const decoder = new TextDecoder('utf-8', { fatal: true });
-  let out = '';
+  const chunks: Uint8Array[] = [];
+  let total = 0;
 
   for await (const chunk of input) {
-    out += decoder.decode(chunk, { stream: true });
+    const normalizedChunk =
+      chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+    total += normalizedChunk.byteLength;
+    if (total > maxBytes) {
+      throw new StrictCspStreamBodyTooLargeError(maxBytes, total);
+    }
+    chunks.push(normalizedChunk);
   }
 
-  out += decoder.decode();
-  return out;
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
 }
 
 function withDocumentShell(
@@ -492,4 +548,31 @@ function internalErrorResponse(): FaceResponse {
     body: utf8(SAFE_INTERNAL_ERROR_HTML),
     isBase64: false,
   };
+}
+
+function strictCspStreamBodyTooLargeResponse(): FaceResponse {
+  return {
+    status: 413,
+    headers: { 'content-type': [HTML_CONTENT_TYPE] },
+    cookies: [],
+    body: utf8(SAFE_PAYLOAD_TOO_LARGE_HTML),
+    isBase64: false,
+  };
+}
+
+function normalizeStrictCspMaxStreamingBodyBytes(
+  value: number | undefined,
+): number {
+  if (value === undefined) {
+    return DEFAULT_STRICT_CSP_STREAMING_BODY_LIMIT_BYTES;
+  }
+
+  const normalized = Math.trunc(Number(value));
+  if (!Number.isSafeInteger(normalized) || normalized < 0) {
+    throw new Error(
+      'strictCsp.maxStreamingBodyBytes must be a non-negative safe integer',
+    );
+  }
+
+  return normalized;
 }

--- a/ts/test/unit/streaming.test.ts
+++ b/ts/test/unit/streaming.test.ts
@@ -8,7 +8,10 @@ import * as React from 'react';
 import { assertDocumentTagNonces } from '../helpers/csp.js';
 
 import { streamFromString, utf8 } from '../../src/bytes.js';
-import { createFaceApp } from '../../src/app.js';
+import {
+  createFaceApp,
+  DEFAULT_STRICT_CSP_STREAMING_BODY_LIMIT_BYTES,
+} from '../../src/app.js';
 import { createReactStreamFace } from '../../src/adapters/react.js';
 import { createAntdEmotionTokenIntegration } from '../../src/react/antd-emotion.js';
 import { createAntdIntegration } from '../../src/react/antd.js';
@@ -154,7 +157,35 @@ test('FaceApp: streaming emits document shell attrs before the body stream', asy
   assert.ok(!first.includes('streamed'));
 });
 
+test('FaceApp: non-strict streaming preflights without buffering the full body', async () => {
+  let streamChunksRead = 0;
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/',
+        mode: 'ssr',
+        render: () => ({
+          html: (async function* () {
+            streamChunksRead += 1;
+            yield utf8('<main>first</main>');
+            streamChunksRead += 1;
+            yield utf8('<footer>second</footer>');
+          })(),
+        }),
+      },
+    ],
+  });
 
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 200);
+  assert.ok(!(resp.body instanceof Uint8Array));
+  assert.equal(streamChunksRead, 1);
+
+  const full = new TextDecoder().decode(await collectBody(resp.body));
+  assert.ok(full.includes('<main>first</main>'));
+  assert.ok(full.includes('<footer>second</footer>'));
+  assert.equal(streamChunksRead, 2);
+});
 
 test('FaceApp: strict CSP streaming responses are coerced to validated buffered HTML', async () => {
   const app = createFaceApp({
@@ -188,6 +219,81 @@ test('FaceApp: strict CSP streaming responses are coerced to validated buffered 
   assert.ok(full.includes('<main>strict streamed</main>'));
   assert.ok(full.includes('rel="facetheory-hydration"'));
   assert.equal(full.includes('__FACETHEORY_DATA__'), false);
+});
+
+test('FaceApp: strict CSP streaming uses a default bounded collector', async () => {
+  const oversized = new Uint8Array(
+    DEFAULT_STRICT_CSP_STREAMING_BODY_LIMIT_BYTES + 1,
+  );
+  oversized.fill('a'.charCodeAt(0));
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/',
+        mode: 'ssr',
+        render: () => ({
+          csp: {
+            inlineScripts: false,
+            inlineStyles: false,
+            rawHead: false,
+          },
+          html: (async function* () {
+            yield oversized;
+          })(),
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 413);
+  assert.ok(resp.body instanceof Uint8Array);
+
+  const full = new TextDecoder().decode(resp.body);
+  assert.ok(full.includes('<h1>Payload Too Large</h1>'));
+  assert.ok(full.includes('strict-csp-stream-body-too-large'));
+  assert.equal(full.includes('<main>'), false);
+  assert.ok(resp.body.byteLength < 512);
+});
+
+test('FaceApp: strict CSP streaming limit counts raw bytes and fails closed', async () => {
+  let streamChunksRead = 0;
+  const app = createFaceApp({
+    strictCsp: { maxStreamingBodyBytes: 4 },
+    faces: [
+      {
+        route: '/',
+        mode: 'ssr',
+        render: () => ({
+          csp: {
+            inlineScripts: false,
+            inlineStyles: false,
+            rawHead: false,
+          },
+          html: (async function* () {
+            streamChunksRead += 1;
+            yield utf8('ab');
+            streamChunksRead += 1;
+            yield utf8('€');
+            streamChunksRead += 1;
+            yield utf8('<button onclick="bad()">unsafe</button>');
+          })(),
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.equal(resp.status, 413);
+  assert.ok(resp.body instanceof Uint8Array);
+  assert.equal(streamChunksRead, 2);
+
+  const full = new TextDecoder().decode(resp.body);
+  assert.ok(full.includes('<h1>Payload Too Large</h1>'));
+  assert.equal(full.includes('ab'), false);
+  assert.equal(full.includes('€'), false);
+  assert.equal(full.includes('onclick'), false);
 });
 
 test('FaceApp: strict CSP streaming violations fail before bytes flush', async () => {


### PR DESCRIPTION
## Issue

THE-1471 — Strict-CSP streaming routes collected the full `AsyncIterable<Uint8Array>` into one UTF-8 string before validation, without a byte/chunk/time bound. A public strict-CSP streaming route could force unbounded memory/CPU work before fail-closed validation.

Linear: https://linear.app/theorycloud/issue/THE-1471/strict-csp-streaming-buffers-bodies-without-a-limit

## Remediation

- Added `strictCsp.maxStreamingBodyBytes` on `createFaceApp(...)`, defaulting to `DEFAULT_STRICT_CSP_STREAMING_BODY_LIMIT_BYTES` (5 MiB).
- Strict-CSP streaming collection now counts raw `Uint8Array` bytes as each chunk is read and throws before decoding/string construction once the limit is exceeded.
- Over-limit strict streams fail closed through a deterministic bounded `413 Payload Too Large` HTML response; no truncated partial document is validated or returned.
- Non-strict streaming remains streaming: it preflights only the first body chunk and returns an `AsyncIterable`.
- Existing strict-CSP streaming validation still runs for under-limit bodies.

## Changed files

- `ts/src/app.ts`
- `ts/test/unit/streaming.test.ts`
- `docs/api-reference.md`
- `docs/OPERATIONS.md`

## Validation

- `cd ts && node --import tsx test/unit/streaming.test.ts` — PASS (15 pass)
- `cd ts && npm test` — PASS (476 pass, 1 skip)
- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run lint` — PASS
- `scripts/verify-version-alignment.sh` — PASS (`version-alignment: PASS (3.2.1)`)
- `git diff --check` — PASS

## Residual risks / backwards compatibility

- Strict-CSP streaming responses are still intentionally buffered for whole-document validation; the new limit bounds that buffering instead of converting strict validation to true streaming.
- Very large strict-CSP streaming pages over the 5 MiB default will now return 413 unless consumers explicitly raise `strictCsp.maxStreamingBodyBytes`.
- Non-strict streaming behavior is preserved and covered by regression testing.

## Blockers

None.