### PR TITLE
fix(security): scan slash-separated csp attributes

### DIFF
--- a/ts/src/security.ts
+++ b/ts/src/security.ts
@@ -40,8 +40,12 @@ const STRICT_CSP_DIRECTIVES: Array<[name: string, values: string[]]> = [
   ['form-action', ["'self'"]],
 ];
 
-const START_TAG_RE = /<([a-zA-Z][a-zA-Z0-9:-]*)(\s[^<>]*?)?>/g;
 const SCRIPT_PAIR_RE = /<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi;
+
+interface HtmlStartTag {
+  attrs: string;
+  tagName: string;
+}
 
 /**
  * Builds FaceTheory's canonical strict CSP header value.
@@ -109,14 +113,11 @@ function normalizeCspNonce(nonce: string | null): string | null {
 }
 
 function validateNoInlineScriptElements(html: string): void {
-  START_TAG_RE.lastIndex = 0;
-  let startMatch: RegExpExecArray | null;
-  while ((startMatch = START_TAG_RE.exec(html)) !== null) {
-    const tagName = String(startMatch[1] ?? '').toLowerCase();
+  for (const startTag of scanHtmlStartTags(html)) {
+    const tagName = startTag.tagName.toLowerCase();
     if (tagName !== 'script') continue;
 
-    const attrs = String(startMatch[2] ?? '');
-    if (!hasHtmlAttribute(attrs, 'src')) {
+    if (!hasHtmlAttribute(startTag.attrs, 'src')) {
       throw new Error('FaceTheory strict CSP rejects inline script tags in document');
     }
   }
@@ -132,11 +133,8 @@ function validateNoInlineScriptElements(html: string): void {
 }
 
 function validateNoInlineStyleElements(html: string): void {
-  START_TAG_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = START_TAG_RE.exec(html)) !== null) {
-    const tagName = String(match[1] ?? '').toLowerCase();
-    if (tagName === 'style') {
+  for (const startTag of scanHtmlStartTags(html)) {
+    if (startTag.tagName.toLowerCase() === 'style') {
       throw new Error('FaceTheory strict CSP rejects inline style tags in document');
     }
   }
@@ -146,10 +144,8 @@ function validateNoUnsafeAttributes(
   html: string,
   policy: FaceCspPolicy | undefined,
 ): void {
-  START_TAG_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = START_TAG_RE.exec(html)) !== null) {
-    const attrs = String(match[2] ?? '');
+  for (const startTag of scanHtmlStartTags(html)) {
+    const attrs = startTag.attrs;
     if (!attrs) continue;
 
     if (policy?.inlineScripts === false) {
@@ -167,15 +163,121 @@ function validateNoUnsafeAttributes(
   }
 }
 
+function* scanHtmlStartTags(html: string): Generator<HtmlStartTag> {
+  let cursor = 0;
+  while (cursor < html.length) {
+    const tagStart = html.indexOf('<', cursor);
+    if (tagStart === -1) return;
+
+    const nameStart = tagStart + 1;
+    const firstNameChar = html.charCodeAt(nameStart);
+    if (!isAsciiAlpha(firstNameChar)) {
+      cursor = nameStart;
+      continue;
+    }
+
+    let nameEnd = nameStart + 1;
+    while (nameEnd < html.length && isHtmlTagNameChar(html.charCodeAt(nameEnd))) {
+      nameEnd += 1;
+    }
+
+    const tagEnd = html.indexOf('>', nameEnd);
+    if (tagEnd === -1) return;
+
+    yield {
+      attrs: html.slice(nameEnd, tagEnd),
+      tagName: html.slice(nameStart, nameEnd),
+    };
+    cursor = tagEnd + 1;
+  }
+}
+
 function hasHtmlAttribute(attrs: string, name: string): boolean {
-  return new RegExp(`(?:^|\\s)${escapeRegExp(name)}(?:\\s*=|\\s|$)`, 'i').test(attrs);
+  const expectedName = name.toLowerCase();
+  for (const attributeName of scanHtmlAttributeNames(attrs)) {
+    if (attributeName.toLowerCase() === expectedName) return true;
+  }
+  return false;
 }
 
 function findInlineEventAttribute(attrs: string): string | null {
-  const match = /(?:^|\s)(on[a-z][\w:-]*)(?:\s*=|\s|$)/i.exec(attrs);
-  return match?.[1] ?? null;
+  for (const attributeName of scanHtmlAttributeNames(attrs)) {
+    if (/^on[a-z][\w:-]*$/i.test(attributeName)) return attributeName;
+  }
+  return null;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function* scanHtmlAttributeNames(attrs: string): Generator<string> {
+  let cursor = 0;
+  while (cursor < attrs.length) {
+    cursor = skipHtmlAttributeDelimiters(attrs, cursor);
+    if (cursor >= attrs.length) return;
+
+    const nameStart = cursor;
+    while (cursor < attrs.length && !isHtmlAttributeNameDelimiter(attrs.charCodeAt(cursor))) {
+      cursor += 1;
+    }
+
+    const attributeName = attrs.slice(nameStart, cursor);
+    if (attributeName) yield attributeName;
+
+    cursor = skipHtmlWhitespace(attrs, cursor);
+    if (attrs[cursor] !== '=') continue;
+
+    cursor = skipHtmlWhitespace(attrs, cursor + 1);
+    if (attrs[cursor] === '"' || attrs[cursor] === "'") {
+      const quote = attrs[cursor] ?? '';
+      cursor += 1;
+      while (cursor < attrs.length && attrs[cursor] !== quote) cursor += 1;
+      if (cursor < attrs.length) cursor += 1;
+      continue;
+    }
+
+    while (cursor < attrs.length && !isHtmlWhitespace(attrs.charCodeAt(cursor))) {
+      cursor += 1;
+    }
+  }
+}
+
+function skipHtmlAttributeDelimiters(value: string, start: number): number {
+  let cursor = start;
+  while (cursor < value.length) {
+    const next = skipHtmlWhitespace(value, cursor);
+    // Browser parsers treat an unexpected solidus before an attribute name as
+    // a parse error, then continue in the before-attribute-name state. Mirror
+    // that boundary so `<button/onclick=...>` is scanned as an onclick attr
+    // without making `/` unsafe inside unquoted attribute values.
+    if (value[next] !== '/') return next;
+    cursor = next + 1;
+  }
+  return cursor;
+}
+
+function skipHtmlWhitespace(value: string, start: number): number {
+  let cursor = start;
+  while (cursor < value.length && isHtmlWhitespace(value.charCodeAt(cursor))) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function isAsciiAlpha(code: number): boolean {
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+function isHtmlTagNameChar(code: number): boolean {
+  return (
+    isAsciiAlpha(code) ||
+    (code >= 48 && code <= 57) ||
+    code === 45 ||
+    code === 58
+  );
+}
+
+function isHtmlAttributeNameDelimiter(code: number): boolean {
+  return isHtmlWhitespace(code) || code === 47 || code === 61 || code === 62;
+}
+
+function isHtmlWhitespace(code: number): boolean {
+  return code === 9 || code === 10 || code === 12 || code === 13 || code === 32;
 }

--- a/ts/test/unit/html.test.ts
+++ b/ts/test/unit/html.test.ts
@@ -126,3 +126,39 @@ test('security: strict CSP document validator rejects inline body attributes', (
     }),
   );
 });
+
+test('security: strict CSP document validator rejects slash-separated unsafe attributes', () => {
+  const scriptsOnlyPolicy = { inlineScripts: false, rawHead: false } as const;
+  const stylesOnlyPolicy = { inlineStyles: false, rawHead: false } as const;
+  const fullPolicy = { inlineScripts: false, inlineStyles: false, rawHead: false } as const;
+
+  assert.throws(
+    () =>
+      validateStrictCspDocument('<!doctype html><html><body><button/onclick=alert(1)>x</button></body></html>', {
+        policy: scriptsOnlyPolicy,
+      }),
+    /inline event handler attribute "onclick" in document/,
+  );
+  assert.throws(
+    () =>
+      validateStrictCspDocument('<!doctype html><html><body><main/style=color:red>x</main></body></html>', {
+        policy: stylesOnlyPolicy,
+      }),
+    /inline style attributes in document/,
+  );
+  assert.throws(
+    () =>
+      validateStrictCspDocument('<!doctype html><html><body><style/x>body{color:red}</style></body></html>', {
+        policy: stylesOnlyPolicy,
+      }),
+    /inline style tags in document/,
+  );
+  assert.doesNotThrow(() =>
+    validateStrictCspDocument(
+      '<!doctype html><html><body><main><br/><img src="/logo.png" alt="safe" /><a href=/style=color:red>safe</a></main></body></html>',
+      {
+        policy: fullPolicy,
+      },
+    ),
+  );
+});


### PR DESCRIPTION
## Issue summary
THE-1472: `validateStrictCspDocument` used regex start-tag detection that only captured attributes when the post-tag-name attribute section began with whitespace. Browser-like HTML parsers accept a solidus before attributes, so forms like `<button/onclick=...>`, `<main/style=...>`, and `<style/x>` could bypass strict CSP document validation.

Linear: https://linear.app/theorycloud/issue/THE-1472/regex-csp-validator-misses-unsafe-slash-attributes

## Remediation summary
- Replaced the whitespace-dependent start-tag regex path in `ts/src/security.ts` with a deterministic scanner for start tags and attribute names.
- Mirrored browser parser handling for an unexpected solidus before an attribute name while preserving `/` inside unquoted attribute values.
- Strict CSP validation now rejects slash-separated inline event handler attributes when `inlineScripts:false` and slash-separated `style` attributes / `<style/...>` elements when `inlineStyles:false`.
- Preserved canonical unsafe-form rejection and safe-document handling, including ordinary safe self-closing/void syntax.

## Changed files
- `ts/src/security.ts`
- `ts/test/unit/html.test.ts`

## Validation
- `cd ts && npx tsx --test test/unit/html.test.ts` — PASS (9 passed)
  - Includes targeted coverage for `<button/onclick=alert(1)>`, `<main/style=color:red>`, `<style/x>...`, and safe self-closing / slash-in-attribute-value cases.
- `cd ts && npm test` — PASS (477 passed, 1 skipped: optional portal reference fixture absent)
- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run lint` — PASS
- `scripts/verify-version-alignment.sh` — PASS (`version-alignment: PASS (3.2.1)`)
- `git diff --check` — PASS

## Residual risks / backwards compatibility
- Backwards-compatible for safe documents and canonical strict-CSP violations.
- Documents that intentionally relied on slash-separated inline event/style syntax passing strict CSP validation will now fail closed, which is the intended security behavior.
- The scanner remains a bounded validator helper, not a full browser HTML parser; it specifically closes the solidus-before-attribute differential relevant to strict CSP enforcement.

## Blockers
None.