### PR TITLE
fix(vite): reject backslash hydration data urls

### DIFF
--- a/ts/src/vite.ts
+++ b/ts/src/vite.ts
@@ -128,11 +128,13 @@ function isAbsoluteOrProtocolRelativeUrl(value: string): boolean {
   return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value) || value.startsWith('//');
 }
 
+const SAME_ORIGIN_DATA_URL_SENTINEL = 'https://facetheory.invalid';
+
 function originFromAbsoluteHttpUrl(value: string | URL | undefined): string | null {
   if (value === undefined) return null;
   const normalized = String(value);
   if (!isAbsoluteOrProtocolRelativeUrl(normalized)) return null;
-  const parsed = new URL(normalized, 'https://facetheory.invalid');
+  const parsed = new URL(normalized, SAME_ORIGIN_DATA_URL_SENTINEL);
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
   return parsed.origin;
 }
@@ -146,9 +148,13 @@ function assertSameOriginDataUrl(
     throw new Error('external hydration dataUrl must not be empty');
   }
 
+  // Resolve against the real allowed origin when available so WHATWG/browser
+  // network-path forms such as `/\host` and `\\host` cannot hide behind a
+  // string-prefix relative-url classifier.
+  const parseBase = allowedOrigin ?? SAME_ORIGIN_DATA_URL_SENTINEL;
   let parsed: URL;
   try {
-    parsed = new URL(trimmed, 'https://facetheory.invalid');
+    parsed = new URL(trimmed, parseBase);
   } catch {
     throw new Error(`external hydration dataUrl is invalid: ${trimmed}`);
   }
@@ -159,9 +165,13 @@ function assertSameOriginDataUrl(
     );
   }
 
-  if (!isAbsoluteOrProtocolRelativeUrl(trimmed)) return trimmed;
-
   if (!allowedOrigin) {
+    if (
+      !isAbsoluteOrProtocolRelativeUrl(trimmed) &&
+      parsed.origin === SAME_ORIGIN_DATA_URL_SENTINEL
+    ) {
+      return trimmed;
+    }
     throw new Error(
       `external hydration dataUrl must be same-origin or relative: ${trimmed}`,
     );

--- a/ts/test/unit/vite.test.ts
+++ b/ts/test/unit/vite.test.ts
@@ -209,6 +209,24 @@ test('vite: external hydration helper accepts same-origin absolute dataUrl', () 
   );
 });
 
+test('vite: external hydration helper accepts same-origin relative dataUrl with allowed origin', () => {
+  const manifest = {
+    'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
+  };
+
+  const hydration = externalHydrationForEntry(
+    manifest,
+    'src/entry-client.tsx',
+    { ok: true },
+    {
+      allowedOrigin: 'https://app.example',
+      dataUrl: '/_facetheory/hydration\\page.json',
+    },
+  );
+
+  assert.equal(hydration.dataUrl, '/_facetheory/hydration\\page.json');
+});
+
 test('vite: external hydration helper rejects unsafe and cross-origin dataUrl', () => {
   const manifest = {
     'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
@@ -238,6 +256,50 @@ test('vite: external hydration helper rejects unsafe and cross-origin dataUrl', 
       }),
     /dataUrl must be same-origin or relative/,
   );
+});
+
+test('vite: external hydration helper rejects backslash-prefixed network-path dataUrl', () => {
+  const manifest = {
+    'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
+  };
+
+  for (const dataUrl of [
+    '/\\evil.example/page.json',
+    '/\\\\evil.example/page.json',
+    '\\\\evil.example/page.json',
+    '\\\\\\\\evil.example/page.json',
+    'https:\\\\evil.example/page.json',
+  ]) {
+    assert.throws(
+      () =>
+        externalHydrationForEntry(manifest, 'src/entry-client.tsx', {}, {
+          allowedOrigin: 'https://app.example',
+          dataUrl,
+        }),
+      /dataUrl resolved cross-origin: expected https:\/\/app\.example, received https:\/\/evil\.example/,
+    );
+  }
+});
+
+test('vite: external hydration helper rejects backslash-prefixed network-path dataUrl without allowed origin', () => {
+  const manifest = {
+    'src/entry-client.tsx': { file: 'assets/entry.aaa.js' },
+  };
+
+  for (const dataUrl of [
+    '/\\evil.example/page.json',
+    '/\\\\evil.example/page.json',
+    '\\\\evil.example/page.json',
+    '\\\\\\\\evil.example/page.json',
+  ]) {
+    assert.throws(
+      () =>
+        externalHydrationForEntry(manifest, 'src/entry-client.tsx', {}, {
+          dataUrl,
+        }),
+      /dataUrl must be same-origin or relative/,
+    );
+  }
 });
 
 test('vite: dynamic import policy is ignore', () => {


### PR DESCRIPTION
## Issue summary

THE-1473 reported that `externalHydrationForEntry()` validated `FaceExternalHydration.dataUrl` with WHATWG `new URL()` but only enforced `allowedOrigin` for strings classified as explicit absolute/protocol-relative URLs. Browser/WHATWG backslash-prefixed network-path forms such as `/\evil.example/page.json` and `\\evil.example/page.json` could resolve cross-origin while being treated as relative by the string-prefix classifier.

## Remediation summary

- Resolve external hydration `dataUrl` values against the real allowed origin when one is available, then enforce the parsed `origin` for every http(s) result.
- Keep the sentinel-origin path for cases without an allowed origin, but reject values that WHATWG resolution moves off the sentinel even if the string-prefix classifier missed them.
- Preserve ordinary same-origin relative paths, same-origin absolute URLs, existing unsafe-protocol rejection, and safe relative paths that contain backslash data but still resolve same-origin.

No shared strict-CSP URL surface was changed; this is scoped to the Vite external hydration helper path for THE-1473 and does not intentionally overlap THE-1474.

## Changed files

- `ts/src/vite.ts`
- `ts/test/unit/vite.test.ts`

## Validation

- `cd ts && npx tsx --test test/unit/vite.test.ts` — PASS, 11 tests passed, including new backslash-prefixed external hydration rejections and existing Vite URL safety coverage.
- `cd ts && npm test` — PASS, 481 tests total; 480 passed, 0 failed, 1 skipped (`portal reference` fixture absent).
- `cd ts && npm run typecheck` — PASS.
- `cd ts && npm run lint` — PASS.
- `scripts/verify-version-alignment.sh` — PASS (`version-alignment: PASS (3.2.1)`).
- `git diff --check` — PASS.

## Residual risks / backwards compatibility

- Relative hydration data URLs that resolve same-origin remain accepted, including normal paths like `/_facetheory/hydration/page.json` and safe same-origin paths containing a backslash.
- Backslash-prefixed values that WHATWG resolves as cross-origin now fail closed. This could reject previously accepted malformed hydration links, but that behavior was the security bug.
- No docs or release/version files changed.

## Blockers

None.