### PR TITLE
fix(head): reject backslash strict CSP URLs

### DIFF
--- a/ts/src/head.ts
+++ b/ts/src/head.ts
@@ -61,6 +61,8 @@ function isAbsoluteOrProtocolRelativeUrl(value: string): boolean {
   return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value) || value.startsWith('//');
 }
 
+const STRICT_CSP_SAME_ORIGIN_SENTINEL = 'https://facetheory.invalid';
+
 function assertStrictSameOriginUrl(
   value: string,
   label: string,
@@ -73,7 +75,10 @@ function assertStrictSameOriginUrl(
 
   let parsed: URL;
   try {
-    parsed = new URL(trimmed, 'https://facetheory.invalid');
+    // Resolve against the real allowed origin when present so WHATWG/browser
+    // network-path forms such as `/\host` or control-stripped `//host` values
+    // cannot bypass strict CSP through the raw relative-url classifier.
+    parsed = new URL(trimmed, allowedOrigin ?? STRICT_CSP_SAME_ORIGIN_SENTINEL);
   } catch {
     throw new Error(`FaceTheory strict CSP ${label} URL is invalid: ${trimmed}`);
   }
@@ -84,9 +89,14 @@ function assertStrictSameOriginUrl(
     );
   }
 
-  if (!isAbsoluteOrProtocolRelativeUrl(trimmed)) return;
-
   if (!allowedOrigin) {
+    if (
+      !isAbsoluteOrProtocolRelativeUrl(trimmed) &&
+      parsed.origin === STRICT_CSP_SAME_ORIGIN_SENTINEL
+    ) {
+      return;
+    }
+
     throw new Error(
       `FaceTheory strict CSP ${label} URL must be same-origin or relative: ${trimmed}`,
     );

--- a/ts/test/unit/head.test.ts
+++ b/ts/test/unit/head.test.ts
@@ -242,6 +242,222 @@ test('head: strict CSP rejects cross-origin bootstrap and data URLs', () => {
   );
 });
 
+test('head: strict CSP allows same-origin relative and absolute script src/link href URLs', () => {
+  const csp = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } as const;
+
+  const relativeHead = renderFaceHead({
+    html: '<div>ok</div>',
+    csp,
+    headTags: [
+      { type: 'script', attrs: { type: 'module', src: '/assets/entry.js' } },
+      { type: 'link', attrs: { rel: 'stylesheet', href: 'assets/app.css' } },
+    ],
+  });
+
+  assert.ok(relativeHead.includes('src="/assets/entry.js"'));
+  assert.ok(relativeHead.includes('href="assets/app.css"'));
+
+  const absoluteHead = renderFaceHead(
+    {
+      html: '<div>ok</div>',
+      csp,
+      headTags: [
+        {
+          type: 'script',
+          attrs: { type: 'module', src: 'https://app.example/assets/entry.js' },
+        },
+        {
+          type: 'link',
+          attrs: { rel: 'stylesheet', href: 'https://app.example/assets/app.css' },
+        },
+      ],
+    },
+    { allowedOrigin: 'https://app.example' },
+  );
+
+  assert.ok(absoluteHead.includes('src="https://app.example/assets/entry.js"'));
+  assert.ok(absoluteHead.includes('href="https://app.example/assets/app.css"'));
+});
+
+test('head: strict CSP rejects unsafe and canonical cross-origin script src/link href URLs', () => {
+  const csp = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } as const;
+
+  assert.throws(
+    () =>
+      renderFaceHead(
+        {
+          html: '<div>ok</div>',
+          csp,
+          headTags: [
+            { type: 'script', attrs: { type: 'module', src: 'javascript:alert(1)' } },
+          ],
+        },
+        { allowedOrigin: 'https://app.example' },
+      ),
+    /script src URL must be http\(s\) or same-origin/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead(
+        {
+          html: '<div>ok</div>',
+          csp,
+          headTags: [
+            { type: 'link', attrs: { rel: 'stylesheet', href: '//evil.example/app.css' } },
+          ],
+        },
+        { allowedOrigin: 'https://app.example' },
+      ),
+    /link href URL resolved cross-origin/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        headTags: [
+          {
+            type: 'script',
+            attrs: { type: 'module', src: 'https://app.example/assets/entry.js' },
+          },
+        ],
+      }),
+    /script src URL must be same-origin or relative/,
+  );
+});
+
+test('head: strict CSP rejects backslash and control-normalized cross-origin head URLs', () => {
+  const csp = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } as const;
+
+  for (const src of [
+    '/\\evil.example/entry.js',
+    '/\\\\evil.example/entry.js',
+    '/\t/evil.example/entry.js',
+  ]) {
+    assert.throws(
+      () =>
+        renderFaceHead(
+          {
+            html: '<div>ok</div>',
+            csp,
+            headTags: [{ type: 'script', attrs: { type: 'module', src } }],
+          },
+          { allowedOrigin: 'https://app.example' },
+        ),
+      /script src URL resolved cross-origin/,
+    );
+  }
+
+  for (const href of [
+    '/\\evil.example/app.css',
+    '/\\\\evil.example/app.css',
+    '/\n/evil.example/app.css',
+  ]) {
+    assert.throws(
+      () =>
+        renderFaceHead(
+          {
+            html: '<div>ok</div>',
+            csp,
+            headTags: [{ type: 'link', attrs: { rel: 'stylesheet', href } }],
+          },
+          { allowedOrigin: 'https://app.example' },
+        ),
+      /link href URL resolved cross-origin/,
+    );
+  }
+});
+
+test('head: strict CSP fails closed for browser-cross-origin URLs without allowed origin', () => {
+  const csp = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } as const;
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        headTags: [
+          { type: 'script', attrs: { type: 'module', src: '/\\evil.example/entry.js' } },
+        ],
+      }),
+    /script src URL must be same-origin or relative/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead({
+        html: '<div>ok</div>',
+        csp,
+        headTags: [
+          { type: 'link', attrs: { rel: 'stylesheet', href: '/\t/evil.example/app.css' } },
+        ],
+      }),
+    /link href URL must be same-origin or relative/,
+  );
+});
+
+test('head: strict CSP rejects backslash-normalized external hydration URLs', () => {
+  const csp = {
+    inlineScripts: false,
+    inlineStyles: false,
+    rawHead: false,
+  } as const;
+
+  assert.throws(
+    () =>
+      renderFaceHead(
+        {
+          html: '<div>ok</div>',
+          csp,
+          hydration: {
+            type: 'external',
+            data: { page: 'strict' },
+            dataUrl: '/_facetheory/hydration/strict.json',
+            bootstrapModule: '/\\evil.example/entry.js',
+          },
+        },
+        { allowedOrigin: 'https://app.example' },
+      ),
+    /script src URL resolved cross-origin/,
+  );
+
+  assert.throws(
+    () =>
+      renderFaceHead(
+        {
+          html: '<div>ok</div>',
+          csp,
+          hydration: {
+            type: 'external',
+            data: { page: 'strict' },
+            dataUrl: '/\t/evil.example/data.json',
+            bootstrapModule: '/assets/entry.js',
+          },
+        },
+        { allowedOrigin: 'https://app.example' },
+      ),
+    /link href URL resolved cross-origin/,
+  );
+});
+
 test('head: escapes legacy head fields and blocks unsafe hydration module URLs', () => {
   const head = renderFaceHead({
     html: '<div>ok</div>',


### PR DESCRIPTION
## Issue

THE-1474 — Strict CSP URL check can be bypassed with backslash URLs.

`renderFaceHead()` strict-CSP validation was parsing script `src` and link `href` values with WHATWG `URL`, but only compared origins when the raw string looked absolute/protocol-relative. Browser-normalized values like `/\\evil.example/entry.js` or control-stripped `//evil.example/...` forms could therefore be treated as relative by the raw classifier while resolving cross-origin in the browser parser.

## Remediation

- Updated `assertStrictSameOriginUrl()` in `ts/src/head.ts` to resolve candidates against the real `allowedOrigin` when available and reject any parsed-origin mismatch.
- When no `allowedOrigin` is available, retained the existing fail-closed shape for absolute/protocol-relative inputs and now also rejects values that WHATWG resolution moves off the same-origin sentinel.
- Preserved ordinary same-origin relative URLs and same-origin absolute URLs under strict CSP.
- Preserved rejection for unsafe protocols and canonical cross-origin absolute/protocol-relative URLs.

## Changed files

- `ts/src/head.ts`
- `ts/test/unit/head.test.ts`

## Validation

Targeted head strict-CSP coverage added for:

- backslash-normalized cross-origin `script src` and `link href` values with `allowedOrigin`;
- control-character-normalized cross-origin `script src` and `link href` values with `allowedOrigin`;
- fail-closed behavior for browser-cross-origin-resolving values when `allowedOrigin` is absent;
- external hydration `bootstrapModule` and `dataUrl` sinks emitted by `renderFaceHead()`;
- ordinary same-origin relative and same-origin absolute URL acceptance;
- canonical unsafe protocol and cross-origin URL rejection.

Commands run:

- `cd ts && npm test` — PASS (`485` pass, `1` skipped, `486` total)
- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run lint` — PASS
- `scripts/verify-version-alignment.sh` — PASS (`3.2.1`)
- `git diff --check` — PASS

## Residual risks / backwards compatibility

- This intentionally tightens strict-CSP head URL validation only. Non-strict rendering behavior is unchanged.
- Strict-CSP consumers emitting backslash/control-normalized URLs that browsers resolve cross-origin will now fail closed instead of receiving head output.
- Ordinary relative same-origin paths, including normal relative asset paths, remain accepted; same-origin absolute URLs remain accepted when `allowedOrigin` is supplied.

## Blockers

None.