### PR TITLE
fix(release): build existing-tag assets from tag source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
           mkdir -p "${trusted_dir}"
           cp \
             scripts/release-json-by-tag.sh \
+            scripts/resolve-release-source-ref.sh \
+            scripts/checkout-release-source.sh \
             scripts/verify-release-branch.sh \
             scripts/verify-release-draft-target.sh \
             "${trusted_dir}/"
@@ -102,6 +104,64 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
 
+      - name: Resolve existing tag source
+        id: source
+        env:
+          TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
+          RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${TAG_NAME}" ]]; then
+            echo "release-source: FAIL (missing tag name)"
+            exit 1
+          fi
+
+          source_output="$(mktemp)"
+          GH_BIN="${RUNNER_TEMP}/facetheory-gh-disabled" \
+          RELEASE_JSON="${RELEASE_JSON}" \
+            "${RUNNER_TEMP}/facetheory-release-scripts/resolve-release-source-ref.sh" "${TAG_NAME}" |
+            tee "${source_output}"
+
+          while IFS='=' read -r key value; do
+            case "${key}" in
+              source_ref|release_is_draft|release_target|release_target_commit|release_source_commit|release_tag_commit|release_id)
+                printf '%s=%s\n' "${key}" "${value}" >> "${GITHUB_OUTPUT}"
+                ;;
+            esac
+          done < "${source_output}"
+
+          source_ref="$(awk -F= '$1 == "source_ref" { print substr($0, index($0, "=") + 1) }' "${source_output}")"
+          source_commit="$(awk -F= '$1 == "release_source_commit" { print $2 }' "${source_output}")"
+          rm -f "${source_output}"
+
+          if [[ -z "${source_ref}" ]]; then
+            echo "release-source: FAIL (${TAG_NAME} did not resolve to a source ref)"
+            exit 1
+          fi
+          if [[ ! "${source_commit}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "release-source: FAIL (${TAG_NAME} did not resolve to an immutable source commit)"
+            exit 1
+          fi
+
+      - name: Checkout existing tag source
+        env:
+          SOURCE_REF: ${{ steps.source.outputs.source_ref }}
+          RELEASE_SOURCE_COMMIT: ${{ steps.source.outputs.release_source_commit }}
+        run: |
+          set -euo pipefail
+
+          source_ref="${SOURCE_REF}"
+          source_commit="${RELEASE_SOURCE_COMMIT}"
+          "${RUNNER_TEMP}/facetheory-release-scripts/checkout-release-source.sh" "${source_ref}" "${source_commit}"
+
+          actual_commit="$(git rev-parse HEAD)"
+          if [[ "${actual_commit}" != "${source_commit}" ]]; then
+            echo "release-source: FAIL (${source_ref} checked out ${actual_commit}, expected ${source_commit})"
+            exit 1
+          fi
+          echo "release-source: checked out immutable source ${actual_commit} for ${source_ref}"
+
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "24.13.1"
@@ -115,6 +175,8 @@ jobs:
         env:
           TAG_NAME: ${{ inputs.tag_name || github.ref_name }}
           RELEASE_JSON: ${{ steps.metadata.outputs.release_json }}
+          RELEASE_IS_DRAFT: ${{ steps.source.outputs.release_is_draft }}
+          RELEASE_SOURCE_COMMIT: ${{ steps.source.outputs.release_source_commit }}
         run: |
           set -euo pipefail
 
@@ -123,8 +185,11 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main --force
-          git fetch origin premain --force || true
+          if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+            git fetch origin --unshallow --force
+          fi
+          git fetch origin main:refs/remotes/origin/main --force
+          git fetch origin premain:refs/remotes/origin/premain --force || true
 
           # Existing draft tags may predate synchronized version manifests.
           # Normalize the workspace copy so verification/build scripts use the requested tag version.
@@ -155,29 +220,16 @@ jobs:
           update_manifest(".release-please-manifest.premain.json")
           PY
 
-          release_is_draft="false"
-          if [[ -n "${RELEASE_JSON}" ]]; then
-            release_is_draft="$(
-              python3 - <<'PY'
-          import json
-          import os
-
-          data = json.loads(os.environ["RELEASE_JSON"])
-          print("true" if data.get("isDraft", data.get("draft")) is True else "false")
-          PY
-            )"
-          fi
-
-          if [[ "${release_is_draft}" == "true" ]]; then
+          if [[ "${RELEASE_IS_DRAFT}" == "true" ]]; then
             RELEASE_JSON="${RELEASE_JSON}" \
               REPO_ROOT="${GITHUB_WORKSPACE}" \
-              "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${TAG_NAME}" "${{ github.sha }}"
+              "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-draft-target.sh" "${TAG_NAME}" "${RELEASE_SOURCE_COMMIT}"
           fi
 
           REPO_ROOT="${GITHUB_WORKSPACE}" \
             "${RUNNER_TEMP}/facetheory-release-scripts/verify-release-branch.sh" "${TAG_NAME}"
 
-          export SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
+          export SOURCE_DATE_EPOCH="$(git show -s --format=%ct "${RELEASE_SOURCE_COMMIT}")"
           cd ts && npm ci
           cd ..
           make rubric

--- a/scripts/checkout-release-source.sh
+++ b/scripts/checkout-release-source.sh
@@ -2,15 +2,19 @@
 set -euo pipefail
 
 source_ref="${1:-}"
+expected_commit="${2:-}"
 remote="${GIT_REMOTE:-origin}"
 
 if [[ -z "${source_ref}" ]]; then
   echo "release-source-checkout: FAIL (missing source ref)" >&2
   exit 1
 fi
+if [[ -n "${expected_commit}" && ! "${expected_commit}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "release-source-checkout: FAIL (expected commit must be a full 40-character SHA)" >&2
+  exit 1
+fi
 
 fetch_ref=""
-expected_commit=""
 case "${source_ref}" in
   refs/heads/*)
     echo "release-source-checkout: FAIL (mutable branch ref ${source_ref} is not allowed)" >&2
@@ -32,7 +36,9 @@ case "${source_ref}" in
   *)
     if [[ "${source_ref}" =~ ^[0-9a-f]{40}$ ]]; then
       fetch_ref="${source_ref}"
-      expected_commit="${source_ref}"
+      if [[ -z "${expected_commit}" ]]; then
+        expected_commit="${source_ref}"
+      fi
     else
       if ! git check-ref-format "refs/tags/${source_ref}" >/dev/null 2>&1; then
         echo "release-source-checkout: FAIL (source ref must be an immutable commit or release tag)" >&2

--- a/scripts/resolve-release-source-ref.sh
+++ b/scripts/resolve-release-source-ref.sh
@@ -6,7 +6,7 @@ gh_bin="${GH_BIN:-gh}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 git_remote="${GIT_REMOTE:-origin}"
 
-resolve_draft_target() {
+resolve_release_target() {
   local target="$1"
   local branch=""
   local resolved=""
@@ -21,7 +21,7 @@ resolve_draft_target() {
       branch="${target#refs/heads/}"
       ;;
     refs/*)
-      echo "release-source-ref: FAIL (draft target ${target} is not a branch or immutable commit)" >&2
+      echo "release-source-ref: FAIL (release target ${target} is not a branch or immutable commit)" >&2
       return 1
       ;;
     *)
@@ -30,11 +30,11 @@ resolve_draft_target() {
   esac
 
   if [[ -z "${branch}" ]]; then
-    echo "release-source-ref: FAIL (draft target branch is empty)" >&2
+    echo "release-source-ref: FAIL (release target branch is empty)" >&2
     return 1
   fi
   if ! git check-ref-format "refs/heads/${branch}" >/dev/null 2>&1; then
-    echo "release-source-ref: FAIL (draft target ${target} is not a valid branch ref)" >&2
+    echo "release-source-ref: FAIL (release target ${target} is not a valid branch ref)" >&2
     return 1
   fi
 
@@ -43,16 +43,60 @@ resolve_draft_target() {
       awk 'NR == 1 { print $1 }'
   )"
   if [[ -z "${resolved}" ]]; then
-    echo "release-source-ref: FAIL (draft target ${target} did not resolve on ${git_remote})" >&2
+    echo "release-source-ref: FAIL (release target ${target} did not resolve on ${git_remote})" >&2
     return 1
   fi
   if [[ ! "${resolved}" =~ ^[0-9a-f]{40}$ ]]; then
-    echo "release-source-ref: FAIL (draft target ${target} resolved to non-commit ${resolved})" >&2
+    echo "release-source-ref: FAIL (release target ${target} resolved to non-commit ${resolved})" >&2
     return 1
   fi
 
-  echo "release-source-ref: draft target ${target} resolved to immutable commit ${resolved}" >&2
+  echo "release-source-ref: release target ${target} resolved to immutable commit ${resolved}" >&2
   printf '%s\n' "${resolved}"
+}
+
+resolve_tag_commit() {
+  local tag_name="$1"
+  local refs=""
+  local direct=""
+  local peeled=""
+  local sha=""
+  local ref=""
+
+  if [[ -z "${tag_name}" ]]; then
+    return 1
+  fi
+  if ! git check-ref-format "refs/tags/${tag_name}" >/dev/null 2>&1; then
+    return 1
+  fi
+
+  refs="$(
+    git ls-remote --exit-code "${git_remote}" \
+      "refs/tags/${tag_name}" \
+      "refs/tags/${tag_name}^{}" 2>/dev/null || true
+  )"
+  if [[ -z "${refs}" ]]; then
+    return 1
+  fi
+
+  while read -r sha ref; do
+    case "${ref}" in
+      "refs/tags/${tag_name}^{}")
+        peeled="${sha}"
+        ;;
+      "refs/tags/${tag_name}")
+        direct="${sha}"
+        ;;
+    esac
+  done <<<"${refs}"
+
+  sha="${peeled:-${direct}}"
+  if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "release-source-ref: FAIL (tag ${tag_name} resolved to non-commit ${sha:-<empty>})" >&2
+    return 1
+  fi
+
+  printf '%s\n' "${sha}"
 }
 
 if [[ -z "${tag}" ]]; then
@@ -66,9 +110,18 @@ if [[ -z "${release_json}" ]] && command -v "${gh_bin}" >/dev/null 2>&1; then
   release_json="$(GH_BIN="${gh_bin}" "${script_dir}/release-json-by-tag.sh" "${tag}" || true)"
 fi
 
+tag_commit="$(resolve_tag_commit "${tag}" || true)"
+
 if [[ -z "${release_json}" ]]; then
-  echo "source_ref=${tag}"
-  echo "release_is_draft=false"
+  if [[ -n "${tag_commit}" ]]; then
+    echo "source_ref=refs/tags/${tag}"
+    echo "release_is_draft=false"
+    echo "release_source_commit=${tag_commit}"
+    echo "release_tag_commit=${tag_commit}"
+  else
+    echo "source_ref=${tag}"
+    echo "release_is_draft=false"
+  fi
   exit 0
 fi
 
@@ -102,6 +155,11 @@ if [[ -z "${target_commitish}" ]]; then
   echo "release-source-ref: FAIL (${tag} missing targetCommitish)" >&2
   exit 1
 fi
+
+release_target_commit="$(resolve_release_target "${target_commitish}")"
+source_ref="${release_target_commit}"
+source_commit="${release_target_commit}"
+
 if [[ "${is_draft}" == "true" ]]; then
   if [[ "${tag}" =~ -rc(\.|$) && "${is_prerelease}" != "true" ]]; then
     echo "release-source-ref: FAIL (${tag} draft must be marked prerelease)" >&2
@@ -111,14 +169,28 @@ if [[ "${is_draft}" == "true" ]]; then
     echo "release-source-ref: FAIL (${tag} stable draft must not be marked prerelease)" >&2
     exit 1
   fi
-  source_ref="$(resolve_draft_target "${target_commitish}")"
-  echo "release-source-ref: draft ${tag} targets ${target_commitish} as ${source_ref} (${release_url})" >&2
-else
-  source_ref="${target_commitish}"
+fi
+
+if [[ -n "${tag_commit}" ]]; then
+  source_ref="refs/tags/${tag}"
+  source_commit="${tag_commit}"
+  if [[ "${release_target_commit}" != "${tag_commit}" ]]; then
+    echo "release-source-ref: FAIL (${tag} tag resolves to ${tag_commit}, release target resolves to ${release_target_commit})" >&2
+    [[ -n "${release_url}" ]] && echo "release-source-ref: release ${release_url}" >&2
+    exit 1
+  fi
+  echo "release-source-ref: existing tag ${tag} resolves to immutable commit ${tag_commit}" >&2
+  echo "release-source-ref: release target ${target_commitish} matches tag commit ${tag_commit}${release_url:+ (${release_url})}" >&2
+elif [[ "${is_draft}" == "true" ]]; then
+  echo "release-source-ref: draft ${tag} targets ${target_commitish} as ${release_target_commit}${release_url:+ (${release_url})}" >&2
 fi
 
 echo "source_ref=${source_ref}"
 echo "release_is_draft=${is_draft}"
 echo "release_target=${target_commitish}"
-echo "release_source_commit=${source_ref}"
+echo "release_target_commit=${release_target_commit}"
+echo "release_source_commit=${source_commit}"
+if [[ -n "${tag_commit}" ]]; then
+  echo "release_tag_commit=${tag_commit}"
+fi
 echo "release_id=${release_id}"

--- a/scripts/test-release-workflow-changelog-preservation.sh
+++ b/scripts/test-release-workflow-changelog-preservation.sh
@@ -40,16 +40,24 @@ fi
 grep -Fq 'facetheory-release-scripts' .github/workflows/release.yml ||
   fail "release.yml must stage trusted release provenance scripts before asset provenance checks"
 
-if grep -R -Fq 'resolve-release-source-ref.sh' .github/workflows/release.yml .github/workflows/prerelease.yml; then
-  fail "release/prerelease asset workflows must not resolve draft release branches to mutable remote HEADs"
-fi
+grep -Fq 'scripts/resolve-release-source-ref.sh' .github/workflows/release.yml ||
+  fail "release.yml existing-tag path must resolve requested tags through trusted provenance scripts"
 
-if grep -R -Fq 'checkout-release-source.sh' .github/workflows/release.yml .github/workflows/prerelease.yml; then
-  fail "release/prerelease asset workflows must not replace github.sha with a resolved draft source ref"
-fi
+grep -Fq 'scripts/checkout-release-source.sh' .github/workflows/release.yml ||
+  fail "release.yml existing-tag path must checkout the requested tag source through trusted provenance scripts"
 
-grep -Fq 'verify-release-draft-target.sh" "${TAG_NAME}" "${{ github.sha }}"' .github/workflows/release.yml ||
-  fail "release.yml existing-tag path must compare draft target identity to github.sha"
+grep -Fq 'GH_BIN="${RUNNER_TEMP}/facetheory-gh-disabled"' .github/workflows/release.yml ||
+  fail "release.yml existing-tag source resolver must not perform repo-script GitHub API lookups"
+
+grep -Fq 'checkout-release-source.sh" "${source_ref}" "${source_commit}"' .github/workflows/release.yml ||
+  fail "release.yml existing-tag path must checkout the resolved immutable tag source"
+
+grep -Fq 'verify-release-draft-target.sh" "${TAG_NAME}" "${RELEASE_SOURCE_COMMIT}"' .github/workflows/release.yml ||
+  fail "release.yml existing-tag path must compare draft target identity to the checked-out source commit"
+
+if grep -Fq 'verify-release-draft-target.sh" "${TAG_NAME}" "${{ github.sha }}"' .github/workflows/release.yml; then
+  fail "release.yml existing-tag path must not compare draft target identity to workflow github.sha"
+fi
 
 if grep -Fq 'verify-release-draft-target.sh" "${TAG_NAME}" HEAD' .github/workflows/release.yml; then
   fail "release.yml existing-tag path must not verify draft targets against mutable workspace HEAD"

--- a/scripts/test-resolve-release-source-ref.sh
+++ b/scripts/test-resolve-release-source-ref.sh
@@ -12,56 +12,39 @@ fail() {
 write_fake_gh() {
   local bin_dir="$1"
   mkdir -p "${bin_dir}"
-  cat > "${bin_dir}/gh" <<'SH'
+  cat > "${bin_dir}/gh" <<'GH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "${FAKE_GH_LOG}"
-if [[ "$1" == "api" ]]; then
-  endpoint="$2"
+json_release() {
+  local id="$1"
+  local tag="$2"
+  local target="$3"
+  local draft="$4"
+  local prerelease="$5"
+  local url_suffix="$6"
+  printf '[{"id":%s,"tag_name":"%s","target_commitish":"%s","draft":%s,"prerelease":%s,"html_url":"https://github.test/releases/%s"}]\n' \
+    "${id}" "${tag}" "${target}" "${draft}" "${prerelease}" "${url_suffix}"
+}
+if [[ "${1:-}" == "api" ]]; then
+  endpoint="${2:-}"
   case "${endpoint}" in
     repos/theory-cloud/FaceTheory/releases\?per_page=100\&page=1)
       case "${FAKE_RELEASE_MODE}" in
-        draft)
-          cat <<'JSON'
-[
-  {
-    "id": 99,
-    "tag_name": "v1.2.3-rc",
-    "target_commitish": "1111111111111111111111111111111111111111",
-    "draft": true,
-    "prerelease": true,
-    "html_url": "https://github.test/releases/untagged"
-  }
-]
-JSON
+        untagged-draft)
+          json_release 99 "v0.1.0-rc" "1111111111111111111111111111111111111111" true true untagged
           ;;
-        draft-branch)
-          cat <<'JSON'
-[
-  {
-    "id": 100,
-    "tag_name": "v1.2.4-rc",
-    "target_commitish": "release-candidate",
-    "draft": true,
-    "prerelease": true,
-    "html_url": "https://github.test/releases/branch"
-  }
-]
-JSON
+        existing-immutable)
+          json_release 100 "v1.2.3-rc" "${FAKE_TARGET}" true true existing-immutable
+          ;;
+        existing-branch)
+          json_release 101 "v1.2.3-rc" "release-candidate" true true existing-branch
+          ;;
+        existing-main)
+          json_release 102 "v1.2.3-rc" "main" true true existing-main
           ;;
         malicious)
-          cat <<'JSON'
-[
-  {
-    "id": 101,
-    "tag_name": "v1.2.5-rc",
-    "target_commitish": "refs/pull/1/head",
-    "draft": true,
-    "prerelease": true,
-    "html_url": "https://github.test/releases/malicious"
-  }
-]
-JSON
+          json_release 103 "v1.2.5-rc" "refs/pull/1/head" true true malicious
           ;;
         none|fallback)
           printf '[]\n'
@@ -79,10 +62,10 @@ JSON
   esac
   exit 0
 fi
-if [[ "$1 $2" == "release view" ]]; then
+if [[ "${1:-} ${2:-}" == "release view" ]]; then
   if [[ "${FAKE_RELEASE_MODE}" == "fallback" ]]; then
     cat <<'JSON'
-{"tagName":"v1.2.3","targetCommitish":"2222222222222222222222222222222222222222","isDraft":false,"isPrerelease":false,"url":"https://github.test/releases/v1.2.3","databaseId":100}
+{"tagName":"v1.2.3","targetCommitish":"2222222222222222222222222222222222222222","isDraft":false,"isPrerelease":false,"url":"https://github.test/releases/v1.2.3","databaseId":104}
 JSON
     exit 0
   fi
@@ -90,7 +73,7 @@ JSON
 fi
 echo "unexpected gh invocation: $*" >&2
 exit 1
-SH
+GH
   chmod +x "${bin_dir}/gh"
 }
 
@@ -109,59 +92,78 @@ git -C "${source_dir}" config user.email "facetheory-test@example.com"
 printf '%s\n' seed > "${source_dir}/README.md"
 git -C "${source_dir}" add README.md
 git -C "${source_dir}" -c commit.gpgSign=false commit -m "test: seed" >/dev/null 2>&1
-git -C "${source_dir}" branch release-candidate
+tag_sha="$(git -C "${source_dir}" rev-parse HEAD)"
+git -C "${source_dir}" -c tag.gpgSign=false tag -a v1.2.3-rc -m "test tag v1.2.3-rc" "${tag_sha}"
+git -C "${source_dir}" -c tag.gpgSign=false tag -a v9.9.9 -m "test tag v9.9.9" "${tag_sha}"
+git -C "${source_dir}" branch release-candidate "${tag_sha}"
 git -C "${source_dir}" remote add origin "${remote_dir}"
-git -C "${source_dir}" push origin release-candidate >/dev/null 2>&1
-branch_sha="$(git -C "${source_dir}" rev-parse release-candidate)"
+git -C "${source_dir}" push origin refs/heads/release-candidate HEAD:refs/heads/main refs/tags/v1.2.3-rc refs/tags/v9.9.9 >/dev/null 2>&1
+printf '%s\n' advanced >> "${source_dir}/README.md"
+git -C "${source_dir}" add README.md
+git -C "${source_dir}" -c commit.gpgSign=false commit -m "test: advance main" >/dev/null 2>&1
+main_sha="$(git -C "${source_dir}" rev-parse HEAD)"
+git -C "${source_dir}" push origin HEAD:refs/heads/main >/dev/null 2>&1
 
-draft_out="$(
+untagged_out="$(
   FAKE_GH_LOG="${log_file}" \
-  FAKE_RELEASE_MODE=draft \
-  GH_BIN="${bin_dir}/gh" \
-  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
-  bash "${script_path}" v1.2.3-rc \
-    2>"${tmpdir}/draft.err"
-)"
-
-grep -Fxq 'source_ref=1111111111111111111111111111111111111111' <<<"${draft_out}" || fail "draft source_ref did not use target_commitish"
-grep -Fxq 'release_is_draft=true' <<<"${draft_out}" || fail "draft output missing release_is_draft=true"
-grep -Fxq 'release_target=1111111111111111111111111111111111111111' <<<"${draft_out}" || fail "draft output missing release_target"
-grep -Fxq 'release_id=99' <<<"${draft_out}" || fail "draft output missing release_id"
-grep -Fq 'release-source-ref: draft v1.2.3-rc targets 1111111111111111111111111111111111111111' "${tmpdir}/draft.err" || fail "draft stderr did not describe resolved target"
-if grep -Fq 'release view v1.2.3-rc' "${log_file}"; then
-  fail "draft lookup fell through to release view despite list API match"
-fi
-
-env_out="$(
-  RELEASE_JSON='{"id":102,"tag_name":"v1.2.3-rc","target_commitish":"3333333333333333333333333333333333333333","draft":true,"prerelease":true,"html_url":"https://github.test/releases/env"}' \
-  GH_BIN="${tmpdir}/missing-gh" \
-  bash "${script_path}" v1.2.3-rc \
-    2>"${tmpdir}/env.err"
-)"
-grep -Fxq 'source_ref=3333333333333333333333333333333333333333' <<<"${env_out}" ||
-  fail "environment-provided release metadata did not resolve source_ref"
-grep -Fxq 'release_is_draft=true' <<<"${env_out}" ||
-  fail "environment-provided release metadata did not preserve draft state"
-grep -Fxq 'release_id=102' <<<"${env_out}" ||
-  fail "environment-provided release metadata did not preserve release_id"
-
-branch_out="$(
-  FAKE_GH_LOG="${log_file}" \
-  FAKE_RELEASE_MODE=draft-branch \
+  FAKE_RELEASE_MODE=untagged-draft \
   GH_BIN="${bin_dir}/gh" \
   GIT_REMOTE="${remote_dir}" \
   GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
-  bash "${script_path}" v1.2.4-rc \
-    2>"${tmpdir}/branch.err"
+  bash "${script_path}" v0.1.0-rc \
+    2>"${tmpdir}/untagged.err"
 )"
-grep -Fxq "source_ref=${branch_sha}" <<<"${branch_out}" || fail "draft branch target did not resolve to immutable commit"
-grep -Fxq 'release_target=release-candidate' <<<"${branch_out}" || fail "draft branch output missing original target"
-grep -Fxq "release_source_commit=${branch_sha}" <<<"${branch_out}" || fail "draft branch output missing release_source_commit"
-if grep -Fxq 'source_ref=release-candidate' <<<"${branch_out}"; then
-  fail "draft branch target leaked mutable source_ref"
+grep -Fxq 'source_ref=1111111111111111111111111111111111111111' <<<"${untagged_out}" || fail "untagged draft source_ref did not use immutable target commit"
+grep -Fxq 'release_source_commit=1111111111111111111111111111111111111111' <<<"${untagged_out}" || fail "untagged draft output missing release_source_commit"
+grep -Fxq 'release_is_draft=true' <<<"${untagged_out}" || fail "untagged draft output missing release_is_draft=true"
+grep -Fxq 'release_target=1111111111111111111111111111111111111111' <<<"${untagged_out}" || fail "untagged draft output missing release_target"
+grep -Fxq 'release_target_commit=1111111111111111111111111111111111111111' <<<"${untagged_out}" || fail "untagged draft output missing release_target_commit"
+grep -Fxq 'release_id=99' <<<"${untagged_out}" || fail "untagged draft output missing release_id"
+if grep -Fq 'release view v0.1.0-rc' "${log_file}"; then
+  fail "draft lookup fell through to release view despite list API match"
 fi
-grep -Fq "draft target release-candidate resolved to immutable commit ${branch_sha}" "${tmpdir}/branch.err" ||
-  fail "draft branch stderr did not describe immutable resolution"
+
+existing_immutable_out="$(
+  FAKE_GH_LOG="${log_file}" \
+  FAKE_RELEASE_MODE=existing-immutable \
+  FAKE_TARGET="${tag_sha}" \
+  GH_BIN="${bin_dir}/gh" \
+  GIT_REMOTE="${remote_dir}" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}" v1.2.3-rc \
+    2>"${tmpdir}/existing-immutable.err"
+)"
+grep -Fxq 'source_ref=refs/tags/v1.2.3-rc' <<<"${existing_immutable_out}" || fail "existing tag source_ref did not use requested tag ref"
+grep -Fxq "release_source_commit=${tag_sha}" <<<"${existing_immutable_out}" || fail "existing tag output missing release_source_commit"
+grep -Fxq "release_tag_commit=${tag_sha}" <<<"${existing_immutable_out}" || fail "existing tag output missing release_tag_commit"
+grep -Fxq "release_target_commit=${tag_sha}" <<<"${existing_immutable_out}" || fail "existing immutable target did not resolve to tag commit"
+grep -Fq "existing tag v1.2.3-rc resolves to immutable commit ${tag_sha}" "${tmpdir}/existing-immutable.err" || fail "existing tag stderr did not describe tag commit"
+
+existing_branch_out="$(
+  FAKE_GH_LOG="${log_file}" \
+  FAKE_RELEASE_MODE=existing-branch \
+  GH_BIN="${bin_dir}/gh" \
+  GIT_REMOTE="${remote_dir}" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}" v1.2.3-rc \
+    2>"${tmpdir}/existing-branch.err"
+)"
+grep -Fxq 'source_ref=refs/tags/v1.2.3-rc' <<<"${existing_branch_out}" || fail "existing tag with matching branch did not keep tag source_ref"
+grep -Fxq "release_target_commit=${tag_sha}" <<<"${existing_branch_out}" || fail "matching branch target did not resolve to tag commit"
+if grep -Fxq "source_ref=${tag_sha}" <<<"${existing_branch_out}"; then
+  fail "existing tag source drifted to target commit instead of requested tag"
+fi
+
+if FAKE_GH_LOG="${log_file}" \
+  FAKE_RELEASE_MODE=existing-main \
+  GH_BIN="${bin_dir}/gh" \
+  GIT_REMOTE="${remote_dir}" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}" v1.2.3-rc >"${tmpdir}/existing-main.out" 2>"${tmpdir}/existing-main.err"; then
+  fail "existing tag with moved main target unexpectedly resolved"
+fi
+grep -Fq "tag resolves to ${tag_sha}, release target resolves to ${main_sha}" "${tmpdir}/existing-main.err" ||
+  fail "moved main failure did not report tag/target commit mismatch"
 
 if FAKE_GH_LOG="${log_file}" \
   FAKE_RELEASE_MODE=malicious \
@@ -176,24 +178,65 @@ none_out="$(
   FAKE_GH_LOG="${log_file}" \
   FAKE_RELEASE_MODE=none \
   GH_BIN="${bin_dir}/gh" \
+  GIT_REMOTE="${remote_dir}" \
   GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
   bash "${script_path}" v9.9.9
 )"
-grep -Fxq 'source_ref=v9.9.9' <<<"${none_out}" || fail "missing release should fall back to tag ref"
+grep -Fxq 'source_ref=refs/tags/v9.9.9' <<<"${none_out}" || fail "missing release should fall back to existing tag ref"
+grep -Fxq "release_source_commit=${tag_sha}" <<<"${none_out}" || fail "missing release should preserve existing tag commit"
 grep -Fxq 'release_is_draft=false' <<<"${none_out}" || fail "missing release should not be draft"
+
+missing_tag_out="$(
+  FAKE_GH_LOG="${log_file}" \
+  FAKE_RELEASE_MODE=none \
+  GH_BIN="${bin_dir}/gh" \
+  GIT_REMOTE="${remote_dir}" \
+  GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
+  bash "${script_path}" v8.8.8
+)"
+grep -Fxq 'source_ref=v8.8.8' <<<"${missing_tag_out}" || fail "missing release and missing tag should leave checkout to fail closed on tag ref"
+grep -Fxq 'release_is_draft=false' <<<"${missing_tag_out}" || fail "missing release and missing tag should not be draft"
 
 fallback_out="$(
   FAKE_GH_LOG="${log_file}" \
   FAKE_RELEASE_MODE=fallback \
   GH_BIN="${bin_dir}/gh" \
+  GIT_REMOTE="${remote_dir}" \
   GITHUB_REPOSITORY="theory-cloud/FaceTheory" \
   bash "${script_path}" v1.2.3
 )"
 grep -Fxq 'source_ref=2222222222222222222222222222222222222222' <<<"${fallback_out}" || fail "release view fallback did not resolve source_ref"
+grep -Fxq 'release_source_commit=2222222222222222222222222222222222222222' <<<"${fallback_out}" || fail "release view fallback did not resolve release_source_commit"
 grep -Fxq 'release_is_draft=false' <<<"${fallback_out}" || fail "published release fallback should not be draft"
 
 empty_out="$(GITHUB_REF='refs/heads/premain' bash "${script_path}")"
 grep -Fxq 'source_ref=refs/heads/premain' <<<"${empty_out}" || fail "empty tag should use GITHUB_REF"
 grep -Fxq 'release_is_draft=false' <<<"${empty_out}" || fail "empty tag should not be draft"
+
+checkout_work="${tmpdir}/checkout-work"
+git init "${checkout_work}" >/dev/null 2>&1
+git -C "${checkout_work}" remote add origin "${remote_dir}"
+(
+  cd "${checkout_work}"
+  GIT_REMOTE="${remote_dir}" \
+    bash "${repo_root}/scripts/checkout-release-source.sh" refs/tags/v1.2.3-rc "${tag_sha}" >/dev/null
+) ||
+  fail "checkout helper did not check out requested tag commit"
+checkout_head="$(git -C "${checkout_work}" rev-parse HEAD)"
+[[ "${checkout_head}" == "${tag_sha}" ]] || fail "checkout helper produced ${checkout_head}, expected tag ${tag_sha}"
+if (
+  cd "${checkout_work}"
+  GIT_REMOTE="${remote_dir}" \
+    bash "${repo_root}/scripts/checkout-release-source.sh" refs/tags/v1.2.3-rc "${main_sha}" >/dev/null 2>&1
+); then
+  fail "checkout helper accepted tag checkout that did not match expected commit"
+fi
+if (
+  cd "${checkout_work}"
+  GIT_REMOTE="${remote_dir}" \
+    bash "${repo_root}/scripts/checkout-release-source.sh" refs/pull/1/head >/dev/null 2>&1
+); then
+  fail "checkout helper accepted unsupported pull-request ref"
+fi
 
 echo "test-resolve-release-source-ref: PASS"

--- a/scripts/test-verify-release-draft-target.sh
+++ b/scripts/test-verify-release-draft-target.sh
@@ -74,6 +74,31 @@ REPO_ROOT="${work_env}" GH_BIN="${tmpdir}/missing-gh" RELEASE_JSON="${release_js
   bash "${script_path}" "v3.1.2-rc" "HEAD" >/dev/null ||
   fail "environment-provided draft metadata did not pass without gh"
 
+# Existing-tag asset builds must prove the draft target still resolves to the
+# checked-out tag commit. A mutable target such as main must not pass after main
+# advances beyond the requested tag.
+work_tag="$(setup_repo existing-tag "${tmpdir}")"
+tag_head="$(git -C "${work_tag}" rev-parse HEAD)"
+remote_tag="${tmpdir}/existing-tag-remote.git"
+git init --bare "${remote_tag}" >/dev/null 2>&1
+git -C "${work_tag}" remote add origin "${remote_tag}"
+git -C "${work_tag}" -c tag.gpgSign=false tag -a v3.1.2-rc -m "test tag v3.1.2-rc" "${tag_head}"
+git -C "${work_tag}" push origin HEAD:refs/heads/main refs/tags/v3.1.2-rc >/dev/null 2>&1
+printf '%s\n' "main moved after tag" >> "${work_tag}/README.md"
+git -C "${work_tag}" add README.md
+git -C "${work_tag}" commit -m "test: move main after tag" >/dev/null 2>&1
+git -C "${work_tag}" push origin HEAD:refs/heads/main >/dev/null 2>&1
+git -C "${work_tag}" checkout --detach "${tag_head}" >/dev/null 2>&1
+release_json_tag_commit="{\"tagName\":\"v3.1.2-rc\",\"targetCommitish\":\"${tag_head}\",\"isDraft\":true,\"isPrerelease\":true,\"url\":\"https://github.test/releases/existing-tag\"}"
+REPO_ROOT="${work_tag}" GH_BIN="${tmpdir}/missing-gh" RELEASE_JSON="${release_json_tag_commit}" \
+  bash "${script_path}" "v3.1.2-rc" "HEAD" >/dev/null ||
+  fail "existing tag draft with immutable tag target did not pass"
+release_json_moved_main='{"tagName":"v3.1.2-rc","targetCommitish":"main","isDraft":true,"isPrerelease":true,"url":"https://github.test/releases/existing-tag-main"}'
+if REPO_ROOT="${work_tag}" GIT_REMOTE="${remote_tag}" GH_BIN="${tmpdir}/missing-gh" RELEASE_JSON="${release_json_moved_main}" \
+  bash "${script_path}" "v3.1.2-rc" "HEAD" >/dev/null 2>&1; then
+  fail "existing tag draft with moved main target unexpectedly passed"
+fi
+
 # A draft release pointing somewhere other than the checked-out commit must fail
 # closed; otherwise assets can be built from different code than the release.
 work_b="$(setup_repo wrong-target "${tmpdir}")"


### PR DESCRIPTION
## Summary
- Fixes THE-1475 by resolving the requested existing tag to its immutable commit before any asset build.
- Checks out the requested tag source with trusted workflow-staged scripts, verifies the checkout commit, and compares draft release metadata against that checked-out immutable source commit instead of `github.sha`.
- Fails closed when draft `targetCommitish` resolves to a different commit (for example, tag A with `main` advanced to B), while preserving safe tag-build fallback when release metadata is absent.
- Keeps privileged release metadata/publish steps separated from repo-controlled build scripts; the resolver is invoked without a GitHub API-capable `GH_BIN` in the workflow.

## Validation
```text
$ scripts/test-resolve-release-source-ref.sh && scripts/test-verify-release-draft-target.sh && scripts/test-release-workflow-changelog-preservation.sh && git diff --check && scripts/verify-version-alignment.sh
test-resolve-release-source-ref: PASS
test-verify-release-draft-target: PASS
test-release-workflow-changelog-preservation: PASS
version-alignment: PASS (3.2.1)
```

```text
$ cd ts && npm test && npm run typecheck && npm run lint
> @theory-cloud/facetheory@3.2.1 test
> npm run test:unit

> @theory-cloud/facetheory@3.2.1 test:unit
> tsx test/run-unit.ts

ℹ tests 486
ℹ suites 0
ℹ pass 485
ℹ fail 0
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
ℹ duration_ms 9016.730456

> @theory-cloud/facetheory@3.2.1 typecheck
> tsc -p tsconfig.json --noEmit

> @theory-cloud/facetheory@3.2.1 lint
> eslint . --max-warnings=0
```

## Notes
No runtime FaceTheory code, adapter code, version files, GitHub releases, tags, assets, or cloud state were changed.