### PR TITLE
fix(security): require parser-valid script end tags

### DIFF
--- a/ts/src/security.ts
+++ b/ts/src/security.ts
@@ -40,10 +40,11 @@ const STRICT_CSP_DIRECTIVES: Array<[name: string, values: string[]]> = [
   ['form-action', ["'self'"]],
 ];
 
-const SCRIPT_PAIR_RE = /<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi;
+const SCRIPT_TAG_NAME = 'script';
 
 interface HtmlStartTag {
   attrs: string;
+  end: number;
   tagName: string;
 }
 
@@ -113,19 +114,22 @@ function normalizeCspNonce(nonce: string | null): string | null {
 }
 
 function validateNoInlineScriptElements(html: string): void {
+  const scriptStartTags: HtmlStartTag[] = [];
+
   for (const startTag of scanHtmlStartTags(html)) {
     const tagName = startTag.tagName.toLowerCase();
-    if (tagName !== 'script') continue;
+    if (tagName !== SCRIPT_TAG_NAME) continue;
+
+    scriptStartTags.push(startTag);
 
     if (!hasHtmlAttribute(startTag.attrs, 'src')) {
       throw new Error('FaceTheory strict CSP rejects inline script tags in document');
     }
   }
 
-  SCRIPT_PAIR_RE.lastIndex = 0;
-  let pairMatch: RegExpExecArray | null;
-  while ((pairMatch = SCRIPT_PAIR_RE.exec(html)) !== null) {
-    const body = String(pairMatch[2] ?? '');
+  for (const startTag of scriptStartTags) {
+    const bodyEnd = findScriptEndTagStart(html, startTag.end);
+    const body = html.slice(startTag.end, bodyEnd);
     if (body.trim().length > 0) {
       throw new Error('FaceTheory strict CSP rejects inline script tags in document');
     }
@@ -186,10 +190,81 @@ function* scanHtmlStartTags(html: string): Generator<HtmlStartTag> {
 
     yield {
       attrs: html.slice(nameEnd, tagEnd),
+      end: tagEnd + 1,
       tagName: html.slice(nameStart, nameEnd),
     };
     cursor = tagEnd + 1;
   }
+}
+
+function findScriptEndTagStart(html: string, bodyStart: number): number {
+  let cursor = bodyStart;
+  while (cursor < html.length) {
+    const closeStart = html.indexOf('</', cursor);
+    if (closeStart === -1) return html.length;
+
+    const nameStart = closeStart + 2;
+    const nameEnd = nameStart + SCRIPT_TAG_NAME.length;
+    if (
+      htmlStartsWithAsciiCaseInsensitive(html, nameStart, SCRIPT_TAG_NAME) &&
+      isScriptEndTagBoundary(html, nameEnd) &&
+      findHtmlTagEnd(html, nameEnd) !== -1
+    ) {
+      return closeStart;
+    }
+
+    cursor = closeStart + 2;
+  }
+  return html.length;
+}
+
+function htmlStartsWithAsciiCaseInsensitive(
+  html: string,
+  start: number,
+  expected: string,
+): boolean {
+  if (start + expected.length > html.length) return false;
+
+  for (let offset = 0; offset < expected.length; offset += 1) {
+    const actualCode = html.charCodeAt(start + offset);
+    const expectedCode = expected.charCodeAt(offset);
+    if (toAsciiLowercaseCode(actualCode) !== expectedCode) return false;
+  }
+  return true;
+}
+
+function isScriptEndTagBoundary(html: string, index: number): boolean {
+  if (index >= html.length) return false;
+
+  const code = html.charCodeAt(index);
+  // Script data only recognizes `</script` as an end tag when the name is
+  // followed by whitespace, `/`, or `>`; `=`/`-` remain script text.
+  return code === 47 || code === 62 || isHtmlWhitespace(code);
+}
+
+function findHtmlTagEnd(html: string, start: number): number {
+  let cursor = start;
+  let quote: '"' | "'" | null = null;
+
+  while (cursor < html.length) {
+    const char = html[cursor];
+    if (quote) {
+      if (char === quote) quote = null;
+      cursor += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      cursor += 1;
+      continue;
+    }
+
+    if (char === '>') return cursor;
+    cursor += 1;
+  }
+
+  return -1;
 }
 
 function hasHtmlAttribute(attrs: string, name: string): boolean {
@@ -259,6 +334,11 @@ function skipHtmlWhitespace(value: string, start: number): number {
     cursor += 1;
   }
   return cursor;
+}
+
+function toAsciiLowercaseCode(code: number): number {
+  if (code >= 65 && code <= 90) return code + 32;
+  return code;
 }
 
 function isAsciiAlpha(code: number): boolean {

--- a/ts/test/unit/html.test.ts
+++ b/ts/test/unit/html.test.ts
@@ -103,6 +103,58 @@ test('security: strict CSP document validator rejects inline document scripts an
   );
 });
 
+test('security: strict CSP document validator rejects malformed script end tag bodies', () => {
+  const policy = { inlineScripts: false, rawHead: false } as const;
+
+  assert.throws(
+    () =>
+      validateStrictCspDocument(
+        '<!doctype html><html><body><script src="/app.js"></script=not-end>alert(1)</script></body></html>',
+        { policy },
+      ),
+    /inline script tags in document/,
+  );
+  assert.throws(
+    () =>
+      validateStrictCspDocument(
+        '<!doctype html><html><body><script src="/app.js"></script-foo>alert(1)</script></body></html>',
+        { policy },
+      ),
+    /inline script tags in document/,
+  );
+});
+
+test('security: strict CSP document validator accepts only empty external script bodies', () => {
+  const policy = { inlineScripts: false, rawHead: false } as const;
+
+  assert.doesNotThrow(() =>
+    validateStrictCspDocument(
+      '<!doctype html><html><body><script src="/app.js"></script></body></html>',
+      { policy },
+    ),
+  );
+  assert.doesNotThrow(() =>
+    validateStrictCspDocument(
+      '<!doctype html><html><body><script src="/app.js"></script data-ignored="yes" ></body></html>',
+      { policy },
+    ),
+  );
+  assert.doesNotThrow(() =>
+    validateStrictCspDocument(
+      '<!doctype html><html><body><script src="/app.js"></SCRIPT \t data-ignored=yes></body></html>',
+      { policy },
+    ),
+  );
+  assert.throws(
+    () =>
+      validateStrictCspDocument(
+        '<!doctype html><html><body><script src="/app.js">alert(1)</script data-ignored="yes"></body></html>',
+        { policy },
+      ),
+    /inline script tags in document/,
+  );
+});
+
 test('security: strict CSP document validator rejects inline body attributes', () => {
   const policy = { inlineScripts: false, inlineStyles: false, rawHead: false } as const;
 


### PR DESCRIPTION
## Summary
- Replaced strict-CSP's over-broad script-pair regex with a deterministic script end-tag scanner.
- The scanner only terminates script data on browser-recognized `</script` boundaries: whitespace, `/`, or `>`.
- Added regressions so `</script=not-end>` and `</script-foo>` stay in the external script body and are rejected when non-empty.

## Linear
THE-1476

## Product plane
FaceTheory strict-CSP document validation.

## Determinism / compatibility
- Preserves the strict-CSP invariant that external scripts must have empty bodies.
- Preserves ordinary empty external scripts and attributed/whitespace end tags that browser parsers treat as script end tags.
- No adapter, render-mode, release, version, or documentation files changed.

## Validation
- `cd ts && node --import tsx --test test/unit/html.test.ts` — PASS
  ```text
  ℹ tests 11
  ℹ suites 0
  ℹ pass 11
  ℹ fail 0
  ℹ cancelled 0
  ℹ skipped 0
  ℹ todo 0
  ```
- `cd ts && npm test` — PASS
  ```text
  ℹ tests 488
  ℹ suites 0
  ℹ pass 487
  ℹ fail 0
  ℹ cancelled 0
  ℹ skipped 1
  ℹ todo 0
  ```
- `cd ts && npm run typecheck` — PASS
  ```text
  > @theory-cloud/facetheory@3.2.1 typecheck
  > tsc -p tsconfig.json --noEmit
  ```
- `cd ts && npm run lint` — PASS
  ```text
  > @theory-cloud/facetheory@3.2.1 lint
  > eslint . --max-warnings=0
  ```
- `scripts/verify-version-alignment.sh` — PASS
  ```text
  version-alignment: PASS (3.2.1)
  ```
- `git diff --check` — PASS (no output)

## Risks / blockers
- Risk is limited to the strict-CSP document validator's script body scan.
- No blockers known.