### PR TITLE
fix(ssg): preserve external hydration sidecars under strict csp

### DIFF
--- a/ts/src/ssg.ts
+++ b/ts/src/ssg.ts
@@ -6,6 +6,7 @@ import { renderHTMLDocument, safeJson } from './html.js';
 import type {
   FaceBody,
   FaceHydration,
+  FaceInlineHydration,
   FaceModule,
   FaceRenderResult,
   Headers,
@@ -308,12 +309,16 @@ function withSsgStrictHydrationSidecars(
 
 function requiresSsgStrictHydrationSidecar(
   out: FaceRenderResult,
-): out is FaceRenderResult & { hydration: FaceHydration } {
-  return out.csp?.inlineScripts === false && out.hydration !== undefined;
+): out is FaceRenderResult & { hydration: FaceInlineHydration } {
+  return (
+    out.csp?.inlineScripts === false &&
+    out.hydration !== undefined &&
+    out.hydration.type !== 'external'
+  );
 }
 
 function externalizeSsgHydration(
-  hydration: FaceHydration,
+  hydration: FaceInlineHydration,
   dataUrl: string,
 ): FaceHydration {
   return {

--- a/ts/test/unit/ssg.test.ts
+++ b/ts/test/unit/ssg.test.ts
@@ -306,6 +306,112 @@ test('ssg: strict CSP hydration emits canonical sidecar without inline data', as
   }
 });
 
+test('ssg: strict CSP preserves caller-managed external hydration sidecars', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-external-'));
+  const outDir = path.resolve(tempRoot, 'out');
+
+  const faces: FaceModule[] = [
+    {
+      route: '/',
+      mode: 'ssg',
+      render: () => ({
+        csp: {
+          inlineScripts: false,
+          inlineStyles: false,
+          rawHead: false,
+        },
+        html: '<main>external</main>',
+        hydration: {
+          type: 'external',
+          data: { message: 'caller-managed' },
+          dataUrl: '/caller/hydration/home.json',
+          bootstrapModule: '/assets/client-entry.js',
+        },
+      }),
+    },
+  ];
+
+  try {
+    const result = await buildSsgSite({ faces, outDir });
+
+    assert.equal(result.pages.length, 1);
+    assert.equal(result.pages[0]?.hydrationDataFile, undefined);
+
+    const html = await readFile(path.resolve(outDir, 'index.html'), 'utf8');
+    assert.ok(html.includes('id="__FACETHEORY_DATA_URL__"'));
+    assert.ok(html.includes('href="/caller/hydration/home.json"'));
+    assert.ok(html.includes('src="/assets/client-entry.js"'));
+    assert.equal(html.includes('/_facetheory/data/index.json'), false);
+    assert.equal(html.includes('id="__FACETHEORY_DATA__"'), false);
+
+    const manifestRaw = await readFile(
+      path.resolve(outDir, '.facetheory/ssg-manifest.json'),
+      'utf8',
+    );
+    const manifest = JSON.parse(manifestRaw) as {
+      pages: Array<{ path: string; hydrationDataFile?: string }>;
+    };
+    assert.equal(Object.hasOwn(manifest.pages[0] ?? {}, 'hydrationDataFile'), false);
+    assert.deepEqual(
+      manifest.pages.map((page) => `${page.path} -> ${page.hydrationDataFile}`),
+      ['/ -> undefined'],
+    );
+
+    const files = await listFilesRecursively(outDir);
+    assert.deepEqual(
+      files.filter((file) => file.startsWith('_facetheory/data/')),
+      [],
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('ssg: strict CSP external hydration with undefined data does not serialize a sidecar', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-external-undefined-'));
+  const outDir = path.resolve(tempRoot, 'out');
+
+  const faces: FaceModule[] = [
+    {
+      route: '/',
+      mode: 'ssg',
+      render: () => ({
+        csp: {
+          inlineScripts: false,
+          inlineStyles: false,
+          rawHead: false,
+        },
+        html: '<main>external undefined</main>',
+        hydration: {
+          type: 'external',
+          data: undefined,
+          dataUrl: '/caller/hydration/undefined.json',
+          bootstrapModule: '/assets/client-entry.js',
+        },
+      }),
+    },
+  ];
+
+  try {
+    const result = await buildSsgSite({ faces, outDir });
+
+    assert.equal(result.pages.length, 1);
+    assert.equal(result.pages[0]?.hydrationDataFile, undefined);
+
+    const html = await readFile(path.resolve(outDir, 'index.html'), 'utf8');
+    assert.ok(html.includes('href="/caller/hydration/undefined.json"'));
+    assert.equal(html.includes('/_facetheory/data/index.json'), false);
+
+    const files = await listFilesRecursively(outDir);
+    assert.deepEqual(
+      files.filter((file) => file.startsWith('_facetheory/data/')),
+      [],
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('ssg: non-strict hydration sidecars remain opt-in compatibility output', async () => {
   const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-compat-'));
   const outDir = path.resolve(tempRoot, 'out');


### PR DESCRIPTION
## Summary
- Restricts strict-CSP SSG sidecar rewriting to inline/legacy hydration only.
- Preserves caller-managed external hydration `type`, `dataUrl`, and bootstrap module metadata instead of replacing it with generated `/_facetheory/data/...` output.
- Adds SSG regressions for existing strict inline sidecar generation, strict external preservation, and strict external `data: undefined` robustness.

## Linear
- THE-1478 — Strict SSG rewrites external hydration sidecars
- https://linear.app/theorycloud/issue/THE-1478/strict-ssg-rewrites-external-hydration-sidecars

## Render modes and adapters affected
- SSG core hydration handling only.
- React/Vue/Svelte adapter surfaces remain unchanged; existing inline strict-CSP adapter behavior continues through the same core SSG sidecar path.

## Determinism impact
- Preserves deterministic generated sidecars for strict-CSP inline hydration.
- Avoids mutating already-external hydration metadata, so caller-provided sidecar URLs remain the single hydration source for that Face.

## Validation
- `cd ts && node --import tsx --test test/unit/ssg.test.ts` — PASS (8 tests). Covers: strict inline hydration still emits the canonical generated sidecar; strict external hydration preserves caller `dataUrl` and emits no generated sidecar metadata/file; strict external hydration with `data: undefined` does not crash or enter strict sidecar serialization.
- `cd ts && npm test` — PASS (490 pass, 1 skip / 491 total).
- `cd ts && npm run typecheck` — PASS.
- `cd ts && npm run lint` — PASS.
- `scripts/verify-version-alignment.sh` — PASS (`version-alignment: PASS (3.2.1)`).
- `git diff --check` — PASS.

## Cross-repo coordination
None.