### PR TITLE
chore(deps): update AppTheory pin to v1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Add the framework peers that match your adapter surface:
 
 Optional companion packages from pinned GitHub releases:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-cdk-1.7.1.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz`
 
 ## Quickstart

--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -7,8 +7,8 @@ This file records the currently pinned versions and the exact install strings we
 
 ## Pins
 
-- AppTheory (TypeScript): `v1.7.0`
-- AppTheory (CDK): `v1.7.0`
+- AppTheory (TypeScript): `v1.7.1`
+- AppTheory (CDK): `v1.7.1`
 - TableTheory (TypeScript): `v1.8.3`
 
 ## Known Audit Exceptions
@@ -35,7 +35,7 @@ the `infra/apptheory-*` workspaces only. Anything outside those gates is still t
 
 ### Recently cleared
 
-- **`fast-uri`** — AppTheory CDK `v1.7.0` requires `aws-cdk-lib@2.254.0`, and the infra example
+- **`fast-uri`** — AppTheory CDK `v1.7.1` requires `aws-cdk-lib@2.254.0`, and the infra example
   lockfiles now resolve the previous nested `fast-uri` audit finding to the patched AWS CDK
   dependency set. The `fast-uri` allowlist in `scripts/verify-npm-audit.sh` is kept as a
   belt-and-suspenders guard against future regressions; remove it when `aws-cdk-lib` no
@@ -52,7 +52,7 @@ locks so `npm ci` can validate the AWS CDK package tree under npm 11.
 ```bash
   # AppTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz
 
   # TableTheory (TS)
 npm install --save-exact \
@@ -60,7 +60,7 @@ npm install --save-exact \
 
   # AppTheory CDK (only for infra projects)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-cdk-1.7.1.tgz
 ```
 
 ## package.json Snippet (Pinned)
@@ -71,7 +71,7 @@ registry installs:
 ```json
 {
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz"
   },
   "overrides": {

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -92,7 +92,7 @@ patterns:
     solution: "Use exact release asset URLs documented in the compatibility pins."
     correct_example: |
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz
       npm install --save-exact \
         https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz
     anti_patterns:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ These are only required if your application uses the corresponding integration s
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz
 
 npm install --save-exact \
   https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz

--- a/gov-infra/planning/docs-init-examples/_decisions.yaml
+++ b/gov-infra/planning/docs-init-examples/_decisions.yaml
@@ -54,7 +54,7 @@ decisions:
           reason: "The repo states GitHub releases are source-of-truth and npm registry drift is unsupported."
           example: |
             npm install --save-exact \
-              https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
+              https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz
         if_no:
           choice: "Do not publish docs claiming compatibility; add TODO and pin versions first."
           reason: "Unpinned installs can break runtime and infra examples."

--- a/gov-infra/planning/docs-init-examples/_patterns.yaml
+++ b/gov-infra/planning/docs-init-examples/_patterns.yaml
@@ -37,7 +37,7 @@ patterns:
     correct_example: |
       # CORRECT: install pinned release assets
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz
       npm install --save-exact \
         https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz
     anti_patterns:

--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -9,8 +9,8 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1005.0",
         "@aws-sdk/client-s3": "^3.1005.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-cdk-1.7.1.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.254.0",
@@ -2477,9 +2477,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "1.7.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
-      "integrity": "sha512-MYDvBpV+L0rU3IfYbcTXy4Lowp0Z0fSMND91SLhTG8XkoSf/oaLx25Fir86WhJyPMhedR+FE6d5iiaK2mXgd0w==",
+      "version": "1.7.1",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz",
+      "integrity": "sha512-/fm2RJN/SJk86JEosdPUOQ8UU3beZKjf31uDl0JwSGPf79AB4Pyaq1Jq3pC4AxekzCAGAigBX/fH48P7O+ERSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2491,9 +2491,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "1.7.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
-      "integrity": "sha512-dfF6FVMOo5rRuf6qN4/LWPlfycYuR9A0/jPY63rodt3oCP6Mcamunp8MitWnoQT6YUXuKdgwU6Rne6WMIMyOww==",
+      "version": "1.7.1",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-cdk-1.7.1.tgz",
+      "integrity": "sha512-kJeN4BZO1wP7IlTtiy2sAEDi1O/bKAo/lj9BN0ODeTIMPWsd8nq6YjnSi5jVm32EEsQ3smL8jsBkoCsnekx5KA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssg-isr-site/package.json
+++ b/infra/apptheory-ssg-isr-site/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1005.0",
     "@aws-sdk/client-s3": "^3.1005.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-cdk-1.7.1.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.254.0",

--- a/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
+++ b/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
@@ -509,7 +509,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "84f9b64897b38a874e5f77a62f428428a1146da9e61b6bf256a033db0a55c4e9.zip"
+          "S3Key": "4f59e27d9b81ad80234408da0258c3e98192d2387c2c8dd1342ef3ffc67b72bc.zip"
         },
         "Environment": {
           "Variables": {

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-cdk-1.7.1.tgz",
         "@types/node": "^24.12.0",
         "aws-cdk-lib": "2.254.0",
         "constructs": "10.6.0",
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "1.7.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
-      "integrity": "sha512-dfF6FVMOo5rRuf6qN4/LWPlfycYuR9A0/jPY63rodt3oCP6Mcamunp8MitWnoQT6YUXuKdgwU6Rne6WMIMyOww==",
+      "version": "1.7.1",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-cdk-1.7.1.tgz",
+      "integrity": "sha512-kJeN4BZO1wP7IlTtiy2sAEDi1O/bKAo/lj9BN0ODeTIMPWsd8nq6YjnSi5jVm32EEsQ3smL8jsBkoCsnekx5KA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,7 +12,7 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-cdk-1.7.1.tgz",
     "@types/node": "^24.12.0",
     "aws-cdk-lib": "2.254.0",
     "constructs": "10.6.0",

--- a/ts/README.md
+++ b/ts/README.md
@@ -19,8 +19,8 @@ Install the peers that match your adapter surface:
 
 Optional companion packages:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-cdk-1.7.0.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-cdk-1.7.1.tgz`
 - TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz`
 
 ## Minimal App

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -15,7 +15,7 @@
         "@emotion/server": "^11.11.0",
         "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz",
         "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz",
         "@types/jsdom": "^28.0.0",
         "@types/node": "^24.12.0",
@@ -4423,9 +4423,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "1.7.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
-      "integrity": "sha512-MYDvBpV+L0rU3IfYbcTXy4Lowp0Z0fSMND91SLhTG8XkoSf/oaLx25Fir86WhJyPMhedR+FE6d5iiaK2mXgd0w==",
+      "version": "1.7.1",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz",
+      "integrity": "sha512-/fm2RJN/SJk86JEosdPUOQ8UU3beZKjf31uDl0JwSGPf79AB4Pyaq1Jq3pC4AxekzCAGAigBX/fH48P7O+ERSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -194,7 +194,7 @@
     "@emotion/server": "^11.11.0",
     "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.0/theory-cloud-apptheory-1.7.0.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.7.1/theory-cloud-apptheory-1.7.1.tgz",
     "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.8.3/theory-cloud-tabletheory-ts-1.8.3.tgz",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^24.12.0",


### PR DESCRIPTION
## Summary
- update FaceTheory's pinned AppTheory TypeScript runtime tarball to v1.7.1
- update AppTheory CDK pins in docs and reference infra examples to v1.7.1
- refresh the SSG/ISR AppTheory infra snapshot for the new runtime bundle hash

## Validation
- `scripts/verify-version-alignment.sh`
- `scripts/verify-npm-audit.sh`
- `git diff --check`
- `cd ts && npm ci`
- `cd ts && npm run lint`
- `cd ts && npm run typecheck`
- `cd ts && npm test`
- `cd infra/apptheory-ssr-site && npm ci && npm test`
- `cd infra/apptheory-ssg-isr-site && npm ci && npm test`

## Upstream release
- Verified AppTheory `v1.7.1` GitHub Release is stable/latest with runtime and CDK tarball assets.
