### PR TITLE
fix(client): require JSON hydration script markers for THE-1705

### DIFF
--- a/ts/src/client/index.ts
+++ b/ts/src/client/index.ts
@@ -191,8 +191,18 @@ function readInlineHydrationScript(doc: Document):
   | { present: false }
   | { present: true; text: string } {
   const el = doc.getElementById(FACE_HYDRATION_DATA_SCRIPT_ID);
-  if (!el) return { present: false };
+  if (!isJsonHydrationScriptElement(el)) return { present: false };
   return { present: true, text: el.textContent ?? '' };
+}
+
+function isJsonHydrationScriptElement(el: Element | null): el is HTMLScriptElement {
+  if (el?.tagName.toLowerCase() !== 'script') return false;
+  return isJsonScriptType(el.getAttribute('type'));
+}
+
+function isJsonScriptType(type: string | null): boolean {
+  const mediaType = String(type ?? '').split(';', 1)[0]?.trim().toLowerCase();
+  return mediaType === 'application/json' || Boolean(mediaType?.endsWith('+json'));
 }
 
 function readExternalHydrationUrl(doc: Document): string | null {

--- a/ts/src/spa.ts
+++ b/ts/src/spa.ts
@@ -102,12 +102,22 @@ export interface FaceNavigationController {
 
 export function readFaceHydrationData<T = unknown>(doc: Document = document): T | null {
   const el = doc.getElementById(HYDRATION_DATA_SCRIPT_ID);
-  if (!el?.textContent) return null;
+  if (!isJsonHydrationScriptElement(el) || !el.textContent) return null;
   try {
     return JSON.parse(el.textContent) as T;
   } catch {
     return null;
   }
+}
+
+function isJsonHydrationScriptElement(el: Element | null): el is HTMLScriptElement {
+  if (el?.tagName.toLowerCase() !== 'script') return false;
+  return isJsonScriptType(el.getAttribute('type'));
+}
+
+function isJsonScriptType(type: string | null): boolean {
+  const mediaType = String(type ?? '').split(';', 1)[0]?.trim().toLowerCase();
+  return mediaType === 'application/json' || Boolean(mediaType?.endsWith('+json'));
 }
 
 export function readFaceHydrationDataUrl(doc: Document = document): string | null {

--- a/ts/test/unit/client-hydration.test.ts
+++ b/ts/test/unit/client-hydration.test.ts
@@ -56,6 +56,48 @@ test('client hydration loader: reads inline hydration before external links', as
   }
 });
 
+test('client hydration loader: treats spoofed inline markers as absent', async () => {
+  for (const marker of [
+    '<div id="__FACETHEORY_DATA__">{"subject":"spoofed-div"}</div>',
+    '<script id="__FACETHEORY_DATA__" type="text/plain">{"subject":"spoofed-type"}</script>',
+  ]) {
+    const dom = new JSDOM(
+      `<!doctype html>
+        <html>
+          <head>
+            ${marker}
+            <link id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration" href="/_facetheory/ssr-data/home.json" type="application/json">
+          </head>
+          <body></body>
+        </html>`,
+      { url: 'https://app.test/account' },
+    );
+
+    try {
+      const fetched: string[] = [];
+      const data = await loadFaceHydrationData<{ route: string }>({
+        document: dom.window.document,
+        fetcher: async (input) => {
+          fetched.push(String(input));
+          return responseWithUrl(
+            new Response(JSON.stringify({ route: 'external-home' }), {
+              headers: { 'content-type': 'application/json' },
+              status: 200,
+            }),
+            'https://app.test/_facetheory/ssr-data/home.json',
+          );
+        },
+      });
+
+      assert.equal(readFaceInlineHydrationData(dom.window.document), null);
+      assert.deepEqual(data, { route: 'external-home' });
+      assert.deepEqual(fetched, ['https://app.test/_facetheory/ssr-data/home.json']);
+    } finally {
+      dom.window.close();
+    }
+  }
+});
+
 test('client hydration loader: fetches same-origin external hydration data', async () => {
   const dom = new JSDOM(
     `<!doctype html>

--- a/ts/test/unit/spa.test.ts
+++ b/ts/test/unit/spa.test.ts
@@ -98,6 +98,66 @@ test('spa helpers: parse external hydration metadata without inline data', () =>
   }
 });
 
+test('spa helpers: treats spoofed inline hydration markers as absent', async () => {
+  for (const marker of [
+    '<div id="__FACETHEORY_DATA__">{"page":"spoofed-div"}</div>',
+    '<script id="__FACETHEORY_DATA__" type="text/plain">{"page":"spoofed-type"}</script>',
+  ]) {
+    const html = `<!doctype html>
+      <html lang="en">
+        <head>
+          <title>External</title>
+          ${marker}
+          <link id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration" href="/_facetheory/hydration/next.json" type="application/json">
+          <script src="/assets/entry-client.js" type="module"></script>
+        </head>
+        <body>
+          <main data-facetheory-view><h1>External Page</h1></main>
+        </body>
+      </html>`;
+    const dom = new JSDOM(html, { url: 'http://localhost/next' });
+
+    try {
+      assert.equal(readFaceHydrationData(dom.window.document), null);
+
+      const snapshot = parseFaceNavigationSnapshot(html, {
+        parser: new dom.window.DOMParser(),
+        url: 'http://localhost/next',
+        viewSelector: DEFAULT_FACE_VIEW_SELECTOR,
+      });
+
+      assert.deepEqual(snapshot.hydration, {
+        type: 'external',
+        data: undefined,
+        dataUrl: '/_facetheory/hydration/next.json',
+        bootstrapModule: '/assets/entry-client.js',
+      });
+
+      const fetched: string[] = [];
+      const loaded = await loadFaceNavigationHydrationData(snapshot, {
+        allowedOrigin: 'http://localhost',
+        fetcher: async (input) => {
+          fetched.push(String(input));
+          return new Response(JSON.stringify({ page: 'external-next' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        },
+      });
+
+      assert.deepEqual(fetched, ['http://localhost/_facetheory/hydration/next.json']);
+      assert.deepEqual(loaded.hydration, {
+        type: 'external',
+        data: { page: 'external-next' },
+        dataUrl: '/_facetheory/hydration/next.json',
+        bootstrapModule: '/assets/entry-client.js',
+      });
+    } finally {
+      dom.window.close();
+    }
+  }
+});
+
 test('spa helpers: load external hydration data before module hydration', async () => {
   const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>', {
     url: 'http://localhost/',


### PR DESCRIPTION
## Summary
- Require inline hydration data markers in `ts/src/client/index.ts` to be `<script>` elements with JSON script types before parsing.
- Apply the same script/type guard to `ts/src/spa.ts` SPA hydration data reads.
- Add regression coverage proving spoofed `<div>` / wrong-type markers are ignored and same-origin external sidecar hydration proceeds, while existing valid `application/json` script hydration remains accepted.

## Security invariant
FaceTheory hydration loaders now only trust FaceTheory-generated JSON script markers for inline hydration data. Spoofable non-script DOM elements or wrong-type scripts with `id="__FACETHEORY_DATA__"` are treated as absent so external same-origin sidecar loading can proceed.

## Validation
- Initial state recorded: repo `/home/aron/ai-workspace/codebases/theory.cloud/FaceTheory`, branch `theorymcp/theorycloud/facetheory/update-tabletheory-1-9-0`, HEAD `6a5a0ec3a969231a7b817f954bb4928edf2f1771`, clean status.
- Created task branch from `origin/staging` at `bb52ba7f53011a60e17c263bd6395b8ecb4222aa`; fetched `origin/main`, `origin/premain`, and `origin/staging` first.
- `scripts/verify-version-alignment.sh` — PASS (3.4.3)
- `git diff --check origin/staging...HEAD` — PASS
- `cd ts && npx tsx test/unit/client-hydration.test.ts` — PASS (10 tests)
- `cd ts && npx tsx test/unit/spa.test.ts` — PASS (14 tests)
- `cd ts && npm run lint` — PASS
- `cd ts && npm run typecheck` — PASS
- `cd ts && npm run test` — PASS (537 passed, 1 skipped)
- `cd ts && npm run build` — PASS

Note: `cd ts && npm run check` is unavailable in this checkout because `ts/package.json` does not define a `check` script, so the equivalent repo-local components (`lint`, `typecheck`, `test`, `build`) were run separately.

## Compatibility notes
- Valid inline `<script id="__FACETHEORY_DATA__" type="application/json">…</script>` hydration behavior is preserved.
- JSON script types are accepted for `application/json` and structured `+json` media types; missing, non-script, and non-JSON markers are absent for loader purposes.
- External hydration URL validation/fetch behavior is unchanged.

## Memory / lessons
- Scoped memory tools were not exposed by tool discovery in this session (`memory_recent` / `memory_append` unavailable), so no prior memory could be applied and no new memory was appended.

Closes THE-1705