### PR TITLE
fix(ssr-hydration): reject control chars in sidecar prefixes (THE-1724)

### DIFF
--- a/ts/src/ssr-hydration.ts
+++ b/ts/src/ssr-hydration.ts
@@ -537,7 +537,13 @@ function normalizeNow(now: () => number): number {
 }
 
 function normalizeObjectPrefix(prefix: string): string {
-  const trimmed = String(prefix ?? '').trim();
+  const raw = String(prefix ?? '');
+  if (containsAsciiControlCharacter(raw)) {
+    throw new TypeError(
+      'SSR hydration sidecar keyPrefix must be an object prefix',
+    );
+  }
+  const trimmed = raw.trim();
   const withoutOuterSlashes = trimOuterSlashes(trimmed);
   if (!withoutOuterSlashes) return '';
   if (
@@ -560,7 +566,13 @@ function normalizeObjectPrefix(prefix: string): string {
 }
 
 function normalizeDataUrlPrefix(prefix: string): string {
-  const trimmed = String(prefix ?? '').trim();
+  const raw = String(prefix ?? '');
+  if (containsAsciiControlCharacter(raw)) {
+    throw new TypeError(
+      'SSR hydration sidecar dataUrlPrefix must be a same-origin path prefix',
+    );
+  }
+  const trimmed = raw.trim();
   if (!trimmed) return DEFAULT_DATA_URL_PREFIX;
   if (trimmed.startsWith('//')) {
     throw new TypeError(
@@ -579,6 +591,14 @@ function normalizeDataUrlPrefix(prefix: string): string {
   const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
   const withoutTrailingSlash = trimTrailingSlashes(withLeadingSlash);
   return withoutTrailingSlash || '/';
+}
+
+function containsAsciiControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const charCode = value.charCodeAt(index);
+    if (charCode <= 0x1f || charCode === 0x7f) return true;
+  }
+  return false;
 }
 
 function normalizeToken(token: string): string {

--- a/ts/test/unit/ssr-hydration.test.ts
+++ b/ts/test/unit/ssr-hydration.test.ts
@@ -429,3 +429,90 @@ test('SSR hydration sidecar helpers: reject network-path data URL prefixes', () 
     );
   }
 });
+
+test('SSR hydration sidecar helpers: reject control characters in data URL prefixes', () => {
+  for (const dataUrlPrefix of [
+    '/\t//evil.example/ssr-data',
+    '/\t/evil.example/ssr-data',
+    '/_facetheory/\nssr-data',
+    '/_facetheory/\rssr-data',
+    '/_facetheory/\u0000ssr-data',
+    '/_facetheory/\u001fssr-data',
+    '/_facetheory/\u007fssr-data',
+  ]) {
+    assert.throws(
+      () =>
+        buildSsrHydrationSidecarDataUrl('payload.signature', {
+          dataUrlPrefix,
+        }),
+      /same-origin path prefix/,
+    );
+    assert.throws(
+      () => normalizeSsrHydrationSidecarDataUrlPrefix(dataUrlPrefix),
+      /same-origin path prefix/,
+    );
+    assert.throws(
+      () =>
+        createFaceApp({
+          faces: [],
+          ssrHydrationSidecars: {
+            htmlStore: new RecordingHtmlStore(),
+            signingSecret: SIGNING_SECRET,
+            dataUrlPrefix,
+          },
+        }),
+      /same-origin path prefix/,
+    );
+  }
+});
+
+test('SSR hydration sidecar helpers: reject control characters in object prefixes', () => {
+  for (const keyPrefix of [
+    'tenant/\tdata',
+    'tenant/\ndata',
+    'tenant/\rdata',
+    'tenant/\u0000data',
+    'tenant/\u001fdata',
+    'tenant/\u007fdata',
+  ]) {
+    assert.throws(
+      () =>
+        createSsrHydrationSidecarStore({
+          htmlStore: new RecordingHtmlStore(),
+          signingSecret: SIGNING_SECRET,
+          keyPrefix,
+        }),
+      /object prefix/,
+    );
+  }
+});
+
+test('SSR hydration sidecar helpers: accept valid same-origin and object prefixes', async () => {
+  assert.equal(
+    normalizeSsrHydrationSidecarDataUrlPrefix('tenant/ssr-data/'),
+    '/tenant/ssr-data',
+  );
+  assert.equal(
+    buildSsrHydrationSidecarDataUrl('payload.signature', {
+      dataUrlPrefix: 'tenant/ssr-data/',
+    }),
+    '/tenant/ssr-data/payload.signature',
+  );
+
+  const htmlStore = new RecordingHtmlStore();
+  const store = createSsrHydrationSidecarStore({
+    htmlStore,
+    signingSecret: SIGNING_SECRET,
+    now: () => 1_000,
+    keyPrefix: 'tenant/sidecars',
+    dataUrlPrefix: 'tenant/ssr-data/',
+  });
+
+  const written = await store.write({
+    data: { route: '/valid-prefixes' },
+    variant: { path: '/valid-prefixes' },
+  });
+
+  assert.ok(written.key.startsWith('tenant/sidecars/'));
+  assert.ok(written.dataUrl.startsWith('/tenant/ssr-data/'));
+});


### PR DESCRIPTION
## Linear
Refs THE-1724 — [FaceTheory] Control chars bypass sidecar URL same-origin prefix check.

## Summary
- Reject ASCII control characters (`<= 0x1F` and `0x7F`) in SSR hydration sidecar `dataUrlPrefix` before trimming or URL construction.
- Apply the same control-character guard to sidecar object `keyPrefix` normalization.
- Add focused tests for the double-slash and single-slash control-character URL normalization bypasses, other ASCII controls, DEL, object-prefix rejection, and valid same-origin prefixes.

## Security invariant
FaceTheory SSR hydration sidecar URL helpers must reject embedded ASCII control characters in data/object prefixes so WHATWG URL normalization cannot turn an apparently path-relative prefix into an off-origin/network-path URL.

## Validation
```text
$ scripts/verify-version-alignment.sh
version-alignment: PASS (3.4.3)

$ git diff --check origin/staging...HEAD
git diff --check origin/staging...HEAD: PASS

$ cd ts && npx tsx --test test/unit/ssr-hydration.test.ts
ℹ tests 13
ℹ pass 13
ℹ fail 0
ℹ duration_ms 184.273206

$ cd ts && npm run lint
PASS (exit 0)

$ cd ts && npm run typecheck
PASS (exit 0)

$ cd ts && npm test
ℹ tests 541
ℹ pass 540
ℹ fail 0
ℹ skipped 1
ℹ duration_ms 10621.634983
```

## Notes
- `cd ts && npm run check` was attempted, but this package currently has no `check` script (`npm error Missing script: "check"`), so I ran the repo-local equivalents separately: `lint`, `typecheck`, and `test`.
- `npm install`/`npm ci` was not needed: `ts/node_modules` was already present and no dependency files changed.
- Additional non-gate observation: `cd ts && npm run format:check` still fails on the existing repo-wide formatting baseline (114 files); the changed files in this PR were not listed by Prettier.