### PR TITLE
feat(spa): add navigation pending browser helper

### DIFF
--- a/ts/examples/navigation-pending/README.md
+++ b/ts/examples/navigation-pending/README.md
@@ -1,0 +1,21 @@
+# FaceTheory Navigation Pending Example
+
+This example shows the Tier A Responsive Control Plane helper as a neutral browser
+ESM module. A control plane can re-serve FaceTheory's built
+`dist/navigation-pending.js` same-origin (for example,
+`/control-plane/assets/facetheory/navigation-pending.js`) and load a small entry
+module that starts the helper.
+
+The helper observes accepted same-origin link clicks and form submissions only for
+pending presentation. It does not prevent native navigation, and it does not take
+over form submit authority from `startAwsOacFormTransport`.
+
+```html
+<link rel="stylesheet" href="/assets/navigation-pending.css">
+<script type="module" src="/assets/navigation-pending-entry.js"></script>
+```
+
+`navigation-pending-entry.ts` demonstrates a bundled/package-specifier import for
+apps that build their client entry. A server that re-serves the FaceTheory build
+artifact directly can use the same call after importing from the same-origin asset
+URL instead.

--- a/ts/examples/navigation-pending/navigation-pending-entry.ts
+++ b/ts/examples/navigation-pending/navigation-pending-entry.ts
@@ -1,0 +1,7 @@
+import { startNavigationPending } from '@theory-cloud/facetheory/navigation-pending';
+
+const navigationPending = startNavigationPending();
+
+window.addEventListener('beforeunload', () => {
+  navigationPending.stop();
+});

--- a/ts/examples/navigation-pending/navigation-pending.css
+++ b/ts/examples/navigation-pending/navigation-pending.css
@@ -1,0 +1,22 @@
+.facetheory-navigation-pending-pill {
+  align-items: center;
+  background: #10233f;
+  border: 1px solid #87a7d9;
+  border-radius: 999px;
+  color: #ffffff;
+  display: inline-flex;
+  font: 600 0.875rem/1.4 system-ui, sans-serif;
+  gap: 0.4rem;
+  inset: auto 1rem 1rem auto;
+  padding: 0.45rem 0.75rem;
+  position: fixed;
+  z-index: 1000;
+}
+
+.facetheory-navigation-pending-control {
+  cursor: progress;
+}
+
+.facetheory-navigation-pending--reduced-motion {
+  animation: none;
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -35,6 +35,18 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./spa": {
+      "types": "./dist/spa.d.ts",
+      "import": "./dist/spa.js"
+    },
+    "./oac-form": {
+      "types": "./dist/oac-form.d.ts",
+      "import": "./dist/oac-form.js"
+    },
+    "./navigation-pending": {
+      "types": "./dist/navigation-pending.d.ts",
+      "import": "./dist/navigation-pending.js"
+    },
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.js"

--- a/ts/src/navigation-pending.ts
+++ b/ts/src/navigation-pending.ts
@@ -1,0 +1,326 @@
+import {
+  classifyFaceNavigationAnchorClick,
+  FACE_NAVIGATION_CLASSIFIER_SOURCE,
+} from './spa.js';
+import type { ClassifyFaceNavigationAnchorClickOptions } from './spa.js';
+
+export const NAVIGATION_PENDING_CLASSIFIER_SOURCE = FACE_NAVIGATION_CLASSIFIER_SOURCE;
+export const NAVIGATION_PENDING_ATTRIBUTE = 'data-facetheory-navigation-pending';
+export const NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE =
+  'data-facetheory-reduced-motion';
+export const DEFAULT_NAVIGATION_PENDING_INDICATOR_ID =
+  'facetheory-navigation-pending';
+export const DEFAULT_NAVIGATION_PENDING_TEXT = 'Loading…';
+
+export interface NavigationPendingClassNames {
+  form?: string;
+  indicator?: string;
+  link?: string;
+  pendingControl?: string;
+  reducedMotion?: string;
+  submitter?: string;
+}
+
+export interface StartNavigationPendingOptions {
+  classNames?: NavigationPendingClassNames;
+  document?: Document;
+  indicatorId?: string;
+  indicatorText?: string;
+  shouldHandleUrl?: (url: URL, anchor: HTMLAnchorElement | null) => boolean;
+  window?: Window;
+}
+
+export interface NavigationPendingController {
+  clear: () => void;
+  isPending: () => boolean;
+  stop: () => void;
+}
+
+interface ResolvedNavigationPendingClassNames {
+  form: string;
+  indicator: string;
+  link: string;
+  pendingControl: string;
+  reducedMotion: string;
+  submitter: string;
+}
+
+interface ElementSnapshot {
+  attributes: Map<string, string | null>;
+  element: Element;
+  textContent?: string | null;
+}
+
+interface IndicatorSnapshot extends ElementSnapshot {
+  created: boolean;
+}
+
+export function startNavigationPending(
+  options: StartNavigationPendingOptions = {},
+): NavigationPendingController {
+  const doc = options.document ?? document;
+  const win = options.window ?? doc.defaultView ?? window;
+  const classNames = resolveClassNames(options.classNames);
+  const indicatorId = options.indicatorId ?? DEFAULT_NAVIGATION_PENDING_INDICATOR_ID;
+  const indicatorText = options.indicatorText ?? DEFAULT_NAVIGATION_PENDING_TEXT;
+
+  let indicator: IndicatorSnapshot | null = null;
+  let pendingElements: ElementSnapshot[] = [];
+  let pending = false;
+  let stopped = false;
+
+  const classifyOptions = (): ClassifyFaceNavigationAnchorClickOptions => {
+    const nextOptions: ClassifyFaceNavigationAnchorClickOptions = {
+      window: win,
+    };
+    if (options.shouldHandleUrl !== undefined) {
+      nextOptions.shouldHandleUrl = options.shouldHandleUrl;
+    }
+    return nextOptions;
+  };
+
+  const clearPending = (): void => {
+    for (let index = pendingElements.length - 1; index >= 0; index -= 1) {
+      const snapshot = pendingElements[index];
+      if (snapshot) restoreElementSnapshot(snapshot);
+    }
+    pendingElements = [];
+
+    if (indicator) {
+      if (indicator.created) {
+        indicator.element.remove();
+      } else {
+        restoreElementSnapshot(indicator);
+      }
+      indicator = null;
+    }
+
+    pending = false;
+  };
+
+  const showPending = (
+    source: 'link' | 'form',
+    targets: ReadonlyArray<{ element: Element; role: 'link' | 'form' | 'submitter' }>,
+  ): void => {
+    if (stopped) return;
+    clearPending();
+
+    for (const target of targets) {
+      markPendingElement(target.element, target.role, classNames, pendingElements);
+    }
+
+    indicator = showIndicator({
+      classNames,
+      doc,
+      id: indicatorId,
+      reducedMotion: prefersReducedMotion(win),
+      source,
+      text: indicatorText,
+    });
+
+    pending = true;
+  };
+
+  const handleClick = (event: MouseEvent): void => {
+    const navigation = classifyFaceNavigationAnchorClick(event, classifyOptions());
+    if (!navigation) return;
+
+    showPending('link', [{ element: navigation.anchor, role: 'link' }]);
+  };
+
+  const handleSubmit = (event: Event): void => {
+    const submitEvent = event as SubmitEvent;
+    const form = readSubmitForm(submitEvent);
+    if (!form) return;
+
+    const targets: Array<{ element: Element; role: 'form' | 'submitter' }> = [
+      { element: form, role: 'form' },
+    ];
+    const submitter = readSubmitter(submitEvent);
+    if (submitter) {
+      targets.push({ element: submitter, role: 'submitter' });
+    }
+
+    showPending('form', targets);
+  };
+
+  const handleLifecycleCleanup = (): void => {
+    clearPending();
+  };
+
+  doc.addEventListener('click', handleClick);
+  doc.addEventListener('submit', handleSubmit, true);
+  win.addEventListener('pageshow', handleLifecycleCleanup);
+  win.addEventListener('pagehide', handleLifecycleCleanup);
+  doc.addEventListener('visibilitychange', handleLifecycleCleanup);
+
+  return {
+    clear: clearPending,
+    isPending: () => pending,
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      doc.removeEventListener('click', handleClick);
+      doc.removeEventListener('submit', handleSubmit, true);
+      win.removeEventListener('pageshow', handleLifecycleCleanup);
+      win.removeEventListener('pagehide', handleLifecycleCleanup);
+      doc.removeEventListener('visibilitychange', handleLifecycleCleanup);
+      clearPending();
+    },
+  };
+}
+
+function resolveClassNames(
+  classNames: NavigationPendingClassNames | undefined,
+): ResolvedNavigationPendingClassNames {
+  return {
+    form: classNames?.form ?? 'facetheory-navigation-pending-form',
+    indicator: classNames?.indicator ?? 'facetheory-navigation-pending-pill',
+    link: classNames?.link ?? 'facetheory-navigation-pending-link',
+    pendingControl:
+      classNames?.pendingControl ?? 'facetheory-navigation-pending-control',
+    reducedMotion:
+      classNames?.reducedMotion ??
+      'facetheory-navigation-pending--reduced-motion',
+    submitter:
+      classNames?.submitter ?? 'facetheory-navigation-pending-submitter',
+  };
+}
+
+function showIndicator(options: {
+  classNames: ResolvedNavigationPendingClassNames;
+  doc: Document;
+  id: string;
+  reducedMotion: boolean;
+  source: 'link' | 'form';
+  text: string;
+}): IndicatorSnapshot {
+  const existing = options.doc.getElementById(options.id);
+  const element = existing ?? options.doc.createElement('div');
+  const snapshot = snapshotElement(element, [
+    'role',
+    'aria-live',
+    'aria-atomic',
+    'class',
+    NAVIGATION_PENDING_ATTRIBUTE,
+    NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE,
+  ]);
+
+  if (!existing) {
+    element.id = options.id;
+  }
+  element.textContent = options.text;
+  element.setAttribute('role', 'status');
+  element.setAttribute('aria-live', 'polite');
+  element.setAttribute('aria-atomic', 'true');
+  element.setAttribute(NAVIGATION_PENDING_ATTRIBUTE, options.source);
+  element.classList.add(options.classNames.indicator);
+
+  if (options.reducedMotion) {
+    element.setAttribute(NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE, 'true');
+    element.classList.add(options.classNames.reducedMotion);
+  } else {
+    element.removeAttribute(NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE);
+    element.classList.remove(options.classNames.reducedMotion);
+  }
+
+  if (!existing) {
+    (options.doc.body ?? options.doc.documentElement).appendChild(element);
+  }
+
+  return {
+    ...snapshot,
+    created: !existing,
+  };
+}
+
+function markPendingElement(
+  element: Element,
+  role: 'link' | 'form' | 'submitter',
+  classNames: ResolvedNavigationPendingClassNames,
+  snapshots: ElementSnapshot[],
+): void {
+  snapshots.push(
+    snapshotElement(element, [
+      'aria-busy',
+      'class',
+      NAVIGATION_PENDING_ATTRIBUTE,
+    ]),
+  );
+
+  element.setAttribute(NAVIGATION_PENDING_ATTRIBUTE, role);
+  element.setAttribute('aria-busy', 'true');
+  element.classList.add(classNames.pendingControl);
+
+  if (role === 'link') {
+    element.classList.add(classNames.link);
+  } else if (role === 'form') {
+    element.classList.add(classNames.form);
+  } else {
+    element.classList.add(classNames.submitter);
+  }
+}
+
+function snapshotElement(
+  element: Element,
+  attributeNames: readonly string[],
+): ElementSnapshot {
+  const attributes = new Map<string, string | null>();
+  for (const name of attributeNames) {
+    attributes.set(name, element.getAttribute(name));
+  }
+  return {
+    attributes,
+    element,
+    textContent: element.textContent,
+  };
+}
+
+function restoreElementSnapshot(snapshot: ElementSnapshot): void {
+  for (const [name, value] of snapshot.attributes) {
+    if (value === null) {
+      snapshot.element.removeAttribute(name);
+    } else {
+      snapshot.element.setAttribute(name, value);
+    }
+  }
+
+  if (snapshot.textContent !== undefined) {
+    snapshot.element.textContent = snapshot.textContent;
+  }
+}
+
+function prefersReducedMotion(win: Window): boolean {
+  try {
+    return (
+      typeof win.matchMedia === 'function' &&
+      win.matchMedia('(prefers-reduced-motion: reduce)').matches
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readSubmitForm(event: SubmitEvent): HTMLFormElement | null {
+  return isElementWithTag(event.target, 'form')
+    ? (event.target as HTMLFormElement)
+    : null;
+}
+
+function readSubmitter(event: SubmitEvent): HTMLElement | null {
+  return isElement(event.submitter) ? (event.submitter as HTMLElement) : null;
+}
+
+function isElement(value: EventTarget | null): value is Element {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { tagName?: unknown }).tagName === 'string' &&
+    typeof (value as { setAttribute?: unknown }).setAttribute === 'function' &&
+    typeof (value as { classList?: unknown }).classList === 'object'
+  );
+}
+
+function isElementWithTag(value: EventTarget | null, tagName: string): value is Element {
+  return isElement(value) && value.tagName.toLowerCase() === tagName;
+}

--- a/ts/src/spa.ts
+++ b/ts/src/spa.ts
@@ -7,6 +7,8 @@ const HYDRATION_DATA_LINK_ID = '__FACETHEORY_DATA_URL__';
 const HYDRATION_DATA_LINK_REL = 'facetheory-hydration';
 const NAVIGATION_CACHE_BUST_PARAM = 'facetheory-nav';
 
+export const FACE_NAVIGATION_CLASSIFIER_SOURCE = 'facetheory_spa_navigation';
+
 export interface FaceNavigationSnapshot {
   url: string;
   title: string | null;
@@ -90,6 +92,17 @@ export interface StartFaceNavigationOptions
   shouldHandleUrl?: (url: URL, anchor: HTMLAnchorElement | null) => boolean;
   viewSelector?: string;
   window?: Window;
+}
+
+export interface ClassifyFaceNavigationAnchorClickOptions {
+  shouldHandleUrl?: (url: URL, anchor: HTMLAnchorElement | null) => boolean;
+  window?: Window;
+}
+
+export interface FaceNavigationAnchorClick {
+  anchor: HTMLAnchorElement;
+  classifierSource: typeof FACE_NAVIGATION_CLASSIFIER_SOURCE;
+  url: URL;
 }
 
 export interface FaceNavigationController {
@@ -464,18 +477,19 @@ export function startFaceNavigation(
   };
 
   const handleClick = (event: MouseEvent): void => {
-    const anchor = findAnchor(event.target);
-    if (!anchor) return;
-
-    const url = new URL(anchor.href, win.location.href);
-    if (!shouldHandleAnchorClick(event, anchor, url, win, options.shouldHandleUrl)) return;
+    const classifyOptions: ClassifyFaceNavigationAnchorClickOptions = { window: win };
+    if (options.shouldHandleUrl !== undefined) {
+      classifyOptions.shouldHandleUrl = options.shouldHandleUrl;
+    }
+    const navigation = classifyFaceNavigationAnchorClick(event, classifyOptions);
+    if (!navigation) return;
 
     event.preventDefault();
-    void navigateInternal(url, {
+    void navigateInternal(navigation.url, {
       source: 'link',
       updateHistory: true,
     }).catch((error) => {
-      reportError(error, 'link', url);
+      reportError(error, 'link', navigation.url);
     });
   };
 
@@ -704,7 +718,27 @@ function withNavigationCacheBust(specifier: string): string {
   return `${specifier}${delimiter}${NAVIGATION_CACHE_BUST_PARAM}=${Date.now()}`;
 }
 
-function shouldHandleAnchorClick(
+export function classifyFaceNavigationAnchorClick(
+  event: MouseEvent,
+  options: ClassifyFaceNavigationAnchorClickOptions = {},
+): FaceNavigationAnchorClick | null {
+  const win = options.window ?? (event.view as Window | null) ?? window;
+  const anchor = findFaceNavigationAnchor(event.target);
+  if (!anchor) return null;
+
+  const url = new URL(anchor.href, win.location.href);
+  if (!shouldHandleAnchorClick(event, anchor, url, win, options.shouldHandleUrl)) {
+    return null;
+  }
+
+  return {
+    anchor,
+    classifierSource: FACE_NAVIGATION_CLASSIFIER_SOURCE,
+    url,
+  };
+}
+
+export function shouldHandleAnchorClick(
   event: MouseEvent,
   anchor: HTMLAnchorElement,
   url: URL,
@@ -726,7 +760,9 @@ function shouldHandleAnchorClick(
   return true;
 }
 
-function findAnchor(target: EventTarget | null): HTMLAnchorElement | null {
+export function findFaceNavigationAnchor(
+  target: EventTarget | null,
+): HTMLAnchorElement | null {
   let current = target as (Node & Partial<Element> & { href?: string }) | null;
   while (current) {
     if (

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -8,6 +8,7 @@ await import('./unit/client-hydration.test.js');
 await import('./unit/ssr-hydration.test.js');
 await import('./unit/ops.test.js');
 await import('./unit/oac-form.test.js');
+await import('./unit/navigation-pending.test.js');
 await import('./unit/strict-csp-harness.test.js');
 await import('./unit/lambda-url.test.js');
 await import('./unit/aws-s3.test.js');

--- a/ts/test/unit/navigation-pending.test.ts
+++ b/ts/test/unit/navigation-pending.test.ts
@@ -1,0 +1,367 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { JSDOM } from 'jsdom';
+
+import {
+  DEFAULT_NAVIGATION_PENDING_INDICATOR_ID,
+  NAVIGATION_PENDING_ATTRIBUTE,
+  NAVIGATION_PENDING_CLASSIFIER_SOURCE,
+  NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE,
+  startNavigationPending,
+} from '../../src/navigation-pending.js';
+import {
+  classifyFaceNavigationAnchorClick,
+  FACE_NAVIGATION_CLASSIFIER_SOURCE,
+  shouldHandleAnchorClick,
+} from '../../src/spa.js';
+
+type DomWindow = Window & typeof globalThis;
+
+function click(
+  win: DomWindow,
+  init: MouseEventInit = {},
+): MouseEvent {
+  return new win.MouseEvent('click', {
+    bubbles: true,
+    button: 0,
+    cancelable: true,
+    view: win,
+    ...init,
+  });
+}
+
+function pageTransitionEvent(win: DomWindow, type: 'pagehide' | 'pageshow'): Event {
+  const PageTransitionEventCtor = (
+    win as Window & { PageTransitionEvent?: typeof PageTransitionEvent }
+  ).PageTransitionEvent;
+  if (typeof PageTransitionEventCtor === 'function') {
+    return new PageTransitionEventCtor(type, { persisted: true });
+  }
+  return new win.Event(type);
+}
+
+test('navigation pending: reuses the FaceTheory SPA navigation classifier source', () => {
+  const dom = new JSDOM(
+    '<!doctype html><a id="next" href="/next"><span>Next</span></a>',
+    { url: 'https://control.lab.theorymcp.ai/current' },
+  );
+
+  try {
+    const win = dom.window as unknown as DomWindow;
+    const doc = dom.window.document;
+    const anchor = doc.querySelector('a');
+    const target = doc.querySelector('span');
+    assert.ok(anchor instanceof dom.window.HTMLAnchorElement);
+    assert.ok(target instanceof dom.window.HTMLElement);
+
+    let directClassifierResult: boolean | null = null;
+    let composedClassifierSource: string | null = null;
+    let composedUrl: string | null = null;
+
+    doc.addEventListener('click', (event) => {
+      const url = new URL(anchor.href, dom.window.location.href);
+      directClassifierResult = shouldHandleAnchorClick(
+        event,
+        anchor,
+        url,
+        win,
+        undefined,
+      );
+      const classification = classifyFaceNavigationAnchorClick(event, { window: win });
+      composedClassifierSource = classification?.classifierSource ?? null;
+      composedUrl = classification?.url.toString() ?? null;
+    });
+
+    target.dispatchEvent(click(win));
+
+    assert.equal(
+      NAVIGATION_PENDING_CLASSIFIER_SOURCE,
+      FACE_NAVIGATION_CLASSIFIER_SOURCE,
+    );
+    assert.equal(NAVIGATION_PENDING_CLASSIFIER_SOURCE, 'facetheory_spa_navigation');
+    assert.equal(directClassifierResult, true);
+    assert.equal(composedClassifierSource, FACE_NAVIGATION_CLASSIFIER_SOURCE);
+    assert.equal(composedUrl, 'https://control.lab.theorymcp.ai/next');
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('navigation pending: shows an immediate status pill for accepted same-origin links', () => {
+  const dom = new JSDOM(
+    '<!doctype html><body><a id="next" href="/next">Next</a></body>',
+    { url: 'https://control.lab.theorymcp.ai/current' },
+  );
+
+  try {
+    const win = dom.window as unknown as DomWindow;
+    const doc = dom.window.document;
+    const anchor = doc.querySelector('a');
+    assert.ok(anchor instanceof dom.window.HTMLAnchorElement);
+
+    const controller = startNavigationPending({ document: doc, window: win });
+    const event = click(win);
+    const dispatched = anchor.dispatchEvent(event);
+
+    assert.equal(dispatched, true);
+    assert.equal(event.defaultPrevented, false);
+    assert.equal(controller.isPending(), true);
+    assert.equal(anchor.getAttribute(NAVIGATION_PENDING_ATTRIBUTE), 'link');
+    assert.equal(anchor.getAttribute('aria-busy'), 'true');
+    assert.equal(
+      anchor.classList.contains('facetheory-navigation-pending-control'),
+      true,
+    );
+    assert.equal(anchor.classList.contains('facetheory-navigation-pending-link'), true);
+
+    const indicator = doc.getElementById(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID);
+    assert.ok(indicator instanceof dom.window.HTMLElement);
+    assert.equal(indicator.textContent, 'Loading…');
+    assert.equal(indicator.getAttribute('role'), 'status');
+    assert.equal(indicator.getAttribute('aria-live'), 'polite');
+    assert.equal(indicator.getAttribute('aria-atomic'), 'true');
+    assert.equal(indicator.getAttribute(NAVIGATION_PENDING_ATTRIBUTE), 'link');
+    assert.equal(
+      indicator.classList.contains('facetheory-navigation-pending-pill'),
+      true,
+    );
+
+    controller.stop();
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('navigation pending: preserves native behavior for skipped link classifications', () => {
+  const cases: Array<{
+    event?: MouseEventInit;
+    html: string;
+    name: string;
+    url?: string;
+  }> = [
+    {
+      event: { button: 1 },
+      html: '<a href="/next">Next</a>',
+      name: 'middle click',
+    },
+    {
+      event: { button: 2 },
+      html: '<a href="/next">Next</a>',
+      name: 'right click',
+    },
+    {
+      event: { metaKey: true },
+      html: '<a href="/next">Next</a>',
+      name: 'modifier click',
+    },
+    {
+      html: '<a href="/next" target="_blank">Next</a>',
+      name: 'target blank',
+    },
+    {
+      html: '<a href="/download" download>Download</a>',
+      name: 'download',
+    },
+    {
+      html: '<a href="/next" rel="external">Next</a>',
+      name: 'rel external',
+    },
+    {
+      html: '<a href="https://external.example/next">External</a>',
+      name: 'external origin',
+    },
+    {
+      html: '<a href="mailto:ops@example.test">Mail</a>',
+      name: 'non-http scheme',
+    },
+    {
+      html: '<a href="#section">Section</a>',
+      name: 'hash-only same-document navigation',
+      url: 'https://control.lab.theorymcp.ai/current?tab=agents',
+    },
+    {
+      html: '<a href="/next" data-facetheory-reload>Next</a>',
+      name: 'FaceTheory reload opt-out',
+    },
+  ];
+
+  for (const skippedCase of cases) {
+    const dom = new JSDOM(`<!doctype html><body>${skippedCase.html}</body>`, {
+      url: skippedCase.url ?? 'https://control.lab.theorymcp.ai/current',
+    });
+
+    try {
+      const win = dom.window as unknown as DomWindow;
+      const doc = dom.window.document;
+      const anchor = doc.querySelector('a');
+      assert.ok(anchor instanceof dom.window.HTMLAnchorElement, skippedCase.name);
+
+      const controller = startNavigationPending({ document: doc, window: win });
+      const event = click(win, skippedCase.event);
+      const dispatched = anchor.dispatchEvent(event);
+
+      assert.equal(dispatched, true, skippedCase.name);
+      assert.equal(event.defaultPrevented, false, skippedCase.name);
+      assert.equal(controller.isPending(), false, skippedCase.name);
+      assert.equal(
+        doc.getElementById(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID),
+        null,
+        skippedCase.name,
+      );
+      assert.equal(
+        anchor.hasAttribute(NAVIGATION_PENDING_ATTRIBUTE),
+        false,
+        skippedCase.name,
+      );
+
+      controller.stop();
+    } finally {
+      dom.window.close();
+    }
+  }
+});
+
+test('navigation pending: observes form submits without taking submit authority', () => {
+  const dom = new JSDOM(
+    `<!doctype html>
+      <form action="/agents/new" method="post" data-facetheory-oac-form>
+        <input name="agent" value="demo">
+        <button name="intent" value="create">Create</button>
+      </form>`,
+    { url: 'https://control.lab.theorymcp.ai/agents/new' },
+  );
+
+  try {
+    const win = dom.window as unknown as DomWindow;
+    const doc = dom.window.document;
+    const form = doc.querySelector('form');
+    const submitter = doc.querySelector('button');
+    assert.ok(form instanceof dom.window.HTMLFormElement);
+    assert.ok(submitter instanceof dom.window.HTMLButtonElement);
+
+    const actionBefore = form.getAttribute('action');
+    const methodBefore = form.getAttribute('method');
+    let preventDefaultCalls = 0;
+    const controller = startNavigationPending({ document: doc, window: win });
+    const event = new dom.window.SubmitEvent('submit', {
+      bubbles: true,
+      cancelable: true,
+      submitter,
+    });
+    const originalPreventDefault = event.preventDefault.bind(event);
+    Object.defineProperty(event, 'preventDefault', {
+      value: () => {
+        preventDefaultCalls += 1;
+        originalPreventDefault();
+      },
+    });
+
+    const dispatched = form.dispatchEvent(event);
+
+    assert.equal(dispatched, true);
+    assert.equal(preventDefaultCalls, 0);
+    assert.equal(event.defaultPrevented, false);
+    assert.equal(form.getAttribute('action'), actionBefore);
+    assert.equal(form.getAttribute('method'), methodBefore);
+    assert.equal(controller.isPending(), true);
+    assert.equal(form.getAttribute(NAVIGATION_PENDING_ATTRIBUTE), 'form');
+    assert.equal(form.getAttribute('aria-busy'), 'true');
+    assert.equal(submitter.getAttribute(NAVIGATION_PENDING_ATTRIBUTE), 'submitter');
+    assert.equal(submitter.getAttribute('aria-busy'), 'true');
+
+    controller.stop();
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('navigation pending: clears pending UI on lifecycle cleanup events', () => {
+  for (const lifecycleEventName of ['pageshow', 'pagehide', 'visibilitychange'] as const) {
+    const dom = new JSDOM(
+      '<!doctype html><body><a id="next" href="/next">Next</a></body>',
+      { url: 'https://control.lab.theorymcp.ai/current' },
+    );
+
+    try {
+      const win = dom.window as unknown as DomWindow;
+      const doc = dom.window.document;
+      const anchor = doc.querySelector('a');
+      assert.ok(anchor instanceof dom.window.HTMLAnchorElement);
+
+      const controller = startNavigationPending({ document: doc, window: win });
+      anchor.dispatchEvent(click(win));
+
+      assert.equal(controller.isPending(), true, lifecycleEventName);
+      assert.ok(doc.getElementById(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID));
+
+      if (lifecycleEventName === 'visibilitychange') {
+        doc.dispatchEvent(new dom.window.Event('visibilitychange'));
+      } else {
+        dom.window.dispatchEvent(pageTransitionEvent(win, lifecycleEventName));
+      }
+
+      assert.equal(controller.isPending(), false, lifecycleEventName);
+      assert.equal(
+        doc.getElementById(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID),
+        null,
+        lifecycleEventName,
+      );
+      assert.equal(
+        anchor.hasAttribute(NAVIGATION_PENDING_ATTRIBUTE),
+        false,
+        lifecycleEventName,
+      );
+      assert.equal(anchor.hasAttribute('aria-busy'), false, lifecycleEventName);
+
+      controller.stop();
+    } finally {
+      dom.window.close();
+    }
+  }
+});
+
+test('navigation pending: marks reduced-motion status without adding motion itself', () => {
+  const dom = new JSDOM(
+    '<!doctype html><body><a id="next" href="/next">Next</a></body>',
+    { url: 'https://control.lab.theorymcp.ai/current' },
+  );
+
+  try {
+    const win = dom.window as unknown as DomWindow & {
+      matchMedia: Window['matchMedia'];
+    };
+    win.matchMedia = (query: string) =>
+      ({
+        addEventListener: () => undefined,
+        addListener: () => undefined,
+        dispatchEvent: () => false,
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        removeEventListener: () => undefined,
+        removeListener: () => undefined,
+      }) as MediaQueryList;
+    const doc = dom.window.document;
+    const anchor = doc.querySelector('a');
+    assert.ok(anchor instanceof dom.window.HTMLAnchorElement);
+
+    const controller = startNavigationPending({ document: doc, window: win });
+    anchor.dispatchEvent(click(win));
+
+    const indicator = doc.getElementById(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID);
+    assert.ok(indicator instanceof dom.window.HTMLElement);
+    assert.equal(
+      indicator.getAttribute(NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE),
+      'true',
+    );
+    assert.equal(
+      indicator.classList.contains('facetheory-navigation-pending--reduced-motion'),
+      true,
+    );
+
+    controller.stop();
+  } finally {
+    dom.window.close();
+  }
+});


### PR DESCRIPTION
## Milestone
Responsive Control Plane — RCP-M1 (Tier A navigation-pending helper)

## Linear
THE-1782 — https://linear.app/theorycloud/issue/THE-1782

## Render modes and adapters affected
- Neutral browser ESM helper for navigation/form pending presentation.
- Reuses the existing SPA same-origin anchor classifier; no render mode semantics changed.
- No React/Vue/Svelte adapter code changed.

## Determinism impact
Preserves FaceTheory determinism. This does not touch server rendering, head emission, style extraction, CSP nonce generation, ISR, or OAC submit authority. The helper emits DOM classes/ARIA attributes at browser interaction time only and uses no inline scripts/styles.

## Backward compatibility
Additive. Adds public browser subpath exports for `./spa`, `./oac-form`, and `./navigation-pending`.

## Tasks
- [x] Refactor SPA navigation classification for shared reuse without changing `startFaceNavigation` behavior.
- [x] Add neutral `navigation-pending` ESM browser helper.
- [x] Declare browser entrypoints in `ts/package.json#exports`.
- [x] Add unit coverage for classifier reuse, accept/skip cases, observe-only form handling, lifecycle cleanup, and reduced motion.
- [x] Add a small neutral browser helper example.

## Tier A invariants
1. **Classifier reuse:** `navigation-pending` imports the classifier source from `spa.ts` via `classifyFaceNavigationAnchorClick`; exported source marker remains `facetheory_spa_navigation`. No forked anchor classifier was added.
2. **Immediate link pending:** accepted same-origin left-clicks synchronously add a loading status pill plus `aria-busy`/`data-facetheory-navigation-pending` state to the clicked link before native navigation proceeds. The helper does not call `preventDefault` for links.
3. **Form observe-only:** submit handling marks the form and submitter busy but never calls `preventDefault`, never fetches, and never changes action/body/headers. `startAwsOacFormTransport` remains the sole OAC submit authority.
4. **Accessibility/motion:** the indicator is a `role="status"` polite live region with `aria-atomic="true"`; `prefers-reduced-motion: reduce` adds a reduced-motion marker/class and the helper itself adds no motion.
5. **Lifecycle cleanup:** pending state is cleared on `pageshow`, `pagehide`, and `visibilitychange`, plus manual `clear()`/`stop()`.
6. **Native behavior preserved:** unit tests cover skipped pending UI for modifier/middle/right clicks, `_blank`, `download`, `rel=external`, external origin, non-HTTP scheme, hash-only same-document navigation, and `data-facetheory-reload`.
7. **Distribution:** source is TypeScript and builds to ESM (`dist/navigation-pending.js`) with no IIFE/UMD/CDN/npm-publish path.
8. **Exports:** `./spa`, `./oac-form`, and `./navigation-pending` now map to built ESM files plus types.

## Validation
```text
$ cd ts && npm ci && npm run typecheck && npm test && npm run lint
added 430 packages, and audited 431 packages in 2s
found 0 vulnerabilities
> @theory-cloud/facetheory@3.4.3 typecheck
> tsc -p tsconfig.json --noEmit
> @theory-cloud/facetheory@3.4.3 test
> npm run test:unit
> @theory-cloud/facetheory@3.4.3 test:unit
> tsx test/run-unit.ts
✔ navigation pending: reuses the FaceTheory SPA navigation classifier source
✔ navigation pending: shows an immediate status pill for accepted same-origin links
✔ navigation pending: preserves native behavior for skipped link classifications
✔ navigation pending: observes form submits without taking submit authority
✔ navigation pending: clears pending UI on lifecycle cleanup events
✔ navigation pending: marks reduced-motion status without adding motion itself
ℹ tests 551
ℹ pass 550
ℹ fail 0
ℹ skipped 1
> @theory-cloud/facetheory@3.4.3 lint
> eslint . --max-warnings=0
```

```text
$ bash scripts/verify-version-alignment.sh
version-alignment: PASS (3.4.3)
```

```text
$ cd ts && npm run build
> @theory-cloud/facetheory@3.4.3 build
> tsc -p tsconfig.build.json && node scripts/copy-svelte-sources.mjs
```

```text
$ cd ts && node --input-type=module -e "const [spa, oac, pending] = await Promise.all([import('@theory-cloud/facetheory/spa'), import('@theory-cloud/facetheory/oac-form'), import('@theory-cloud/facetheory/navigation-pending')]); console.log(JSON.stringify({spa: typeof spa.startFaceNavigation, oac: typeof oac.startAwsOacFormTransport, navigationPending: typeof pending.startNavigationPending, classifierSource: pending.NAVIGATION_PENDING_CLASSIFIER_SOURCE}));"
{"spa":"function","oac":"function","navigationPending":"function","classifierSource":"facetheory_spa_navigation"}
```

```text
$ cd ts && npm run example:ssg:build && npm run example:vite:ssr:build
SSG build wrote 5 page(s) to /home/aron/ai-workspace/codebases/theory.cloud/FaceTheory/ts/examples/ssg-basic/dist-static
vite v8.0.14 building client environment for production...
✓ built in 63ms
vite v8.0.14 building ssr environment for production...
✓ built in 19ms
```

## Cross-repo coordination
Factory/theory-mcp-server can consume this after a FaceTheory release tarball is cut by the normal Release Please flow and pinned downstream. No sibling repos or cloud state were modified.

## Tooling notes
`facetheory_lab` and FaceTheory memory tools were not exposed in this Codex session, so this used local git plus the generic GitHub connector for PR creation.