### PR TITLE
feat(responsive-primitives): add control plane primitive parity

### DIFF
--- a/ts/examples/responsive-primitives-react/render.ts
+++ b/ts/examples/responsive-primitives-react/render.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+
+import * as React from 'react';
+
+import { createFaceApp } from '../../src/app.js';
+import { createReactFace } from '../../src/adapters/react.js';
+import {
+  AsyncStateBoundary,
+  Button,
+  Link,
+  LoadingState,
+  Skeleton,
+  Spinner,
+} from '../../src/react/responsive-primitives/index.js';
+import { RESPONSIVE_PRIMITIVES_CSS } from '../../src/responsive-primitives/index.js';
+
+const app = createFaceApp({
+  faces: [
+    createReactFace({
+      route: '/',
+      mode: 'ssr',
+      render: () =>
+        React.createElement('main', { className: 'responsive-example' }, [
+          React.createElement(Spinner, {
+            key: 'spinner',
+            label: 'Loading control plane data',
+            size: 'sm',
+          }),
+          React.createElement(Skeleton, {
+            key: 'skeleton',
+            width: 'two-thirds',
+            height: 'lg',
+          }),
+          React.createElement(LoadingState, {
+            key: 'loading',
+            message: 'Loading tenants',
+          }),
+          React.createElement(AsyncStateBoundary, {
+            key: 'boundary',
+            state: 'empty',
+            empty: React.createElement('p', null, 'No tenants yet'),
+          }),
+          React.createElement(
+            Button,
+            {
+              key: 'button',
+              loading: true,
+              loadingPlacement: 'replace-prefix',
+            },
+            'Create tenant',
+          ),
+          React.createElement(
+            Link,
+            {
+              key: 'link',
+              href: '/tenants',
+            },
+            'View tenants',
+          ),
+        ]),
+      renderOptions: {
+        styleTags: [{ cssText: RESPONSIVE_PRIMITIVES_CSS }],
+      },
+    }),
+  ],
+});
+
+const response = await app.handle({ method: 'GET', path: '/' });
+const html = new TextDecoder().decode(response.body as Uint8Array);
+
+assert.equal(response.status, 200);
+assert.match(html, /facetheory-rcp-spinner/);
+assert.match(html, /facetheory-rcp-skeleton--width-two-thirds/);
+assert.match(html, /aria-busy="true"/);
+assert.match(html, /href="\/tenants"/);
+assert.doesNotMatch(html, /style="/);
+
+console.log('responsive primitives React example rendered');
+console.log(`bytes=${html.length}`);

--- a/ts/examples/responsive-primitives-svelte/render.ts
+++ b/ts/examples/responsive-primitives-svelte/render.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { compile } from 'svelte/compiler';
+
+import { createFaceApp } from '../../src/app.js';
+import { createSvelteFace } from '../../src/svelte/index.js';
+import { RESPONSIVE_PRIMITIVES_CSS } from '../../src/responsive-primitives/index.js';
+
+async function compileComponent(name: string): Promise<unknown> {
+  const componentPath = path.resolve(
+    'src/svelte/responsive-primitives',
+    `${name}.svelte`,
+  );
+  const source = await readFile(componentPath, 'utf8');
+  const compiled = compile(source, {
+    generate: 'server',
+    filename: path.basename(componentPath),
+  } as never);
+
+  const dir = path.resolve('examples/responsive-primitives-svelte/.tmp');
+  await mkdir(dir, { recursive: true });
+  const coreUrl = pathToFileURL(
+    path.resolve('src/responsive-primitives/index.ts'),
+  ).href;
+  const rewrittenCode = compiled.js.code.replace(
+    /from\s+(['"])\.\.\/\.\.\/responsive-primitives\/index\.js\1/g,
+    `from "${coreUrl}"`,
+  );
+  const file = path.join(dir, `${name}-${process.pid}-${Date.now()}.mjs`);
+  await writeFile(file, rewrittenCode, 'utf8');
+  const mod = await import(pathToFileURL(file).href);
+  return mod.default as unknown;
+}
+
+const [Spinner, Skeleton, LoadingState, AsyncStateBoundary, Button, Link] =
+  await Promise.all([
+    compileComponent('Spinner'),
+    compileComponent('Skeleton'),
+    compileComponent('LoadingState'),
+    compileComponent('AsyncStateBoundary'),
+    compileComponent('Button'),
+    compileComponent('Link'),
+  ]);
+
+try {
+  const app = createFaceApp({
+    faces: [
+      createSvelteFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => ({
+          component: {
+            render: () => ({
+              html: '',
+            }),
+          },
+        }),
+        renderOptions: {
+          styleTags: [{ cssText: RESPONSIVE_PRIMITIVES_CSS }],
+        },
+      }),
+    ],
+  });
+
+  const rendered = await Promise.all([
+    createFaceApp({
+      faces: [
+        createSvelteFace({
+          route: '/',
+          mode: 'ssr',
+          render: () => ({
+            component: Spinner,
+            props: { label: 'Loading control plane data', size: 'sm' },
+          }),
+        }),
+      ],
+    }).handle({ method: 'GET', path: '/' }),
+    createFaceApp({
+      faces: [
+        createSvelteFace({
+          route: '/',
+          mode: 'ssr',
+          render: () => ({
+            component: Skeleton,
+            props: { width: 'two-thirds', height: 'lg' },
+          }),
+        }),
+      ],
+    }).handle({ method: 'GET', path: '/' }),
+    createFaceApp({
+      faces: [
+        createSvelteFace({
+          route: '/',
+          mode: 'ssr',
+          render: () => ({
+            component: LoadingState,
+            props: { message: 'Loading tenants' },
+          }),
+        }),
+      ],
+    }).handle({ method: 'GET', path: '/' }),
+    createFaceApp({
+      faces: [
+        createSvelteFace({
+          route: '/',
+          mode: 'ssr',
+          render: () => ({
+            component: AsyncStateBoundary,
+            props: { state: 'loading', loadingMessage: 'Loading tenants' },
+          }),
+        }),
+      ],
+    }).handle({ method: 'GET', path: '/' }),
+    createFaceApp({
+      faces: [
+        createSvelteFace({
+          route: '/',
+          mode: 'ssr',
+          render: () => ({
+            component: Button,
+            props: { loading: true, loadingPlacement: 'replace-prefix' },
+          }),
+        }),
+      ],
+    }).handle({ method: 'GET', path: '/' }),
+    createFaceApp({
+      faces: [
+        createSvelteFace({
+          route: '/',
+          mode: 'ssr',
+          render: () => ({ component: Link, props: { href: '/tenants' } }),
+        }),
+      ],
+    }).handle({ method: 'GET', path: '/' }),
+    app.handle({ method: 'GET', path: '/' }),
+  ]);
+
+  const html = rendered
+    .map((response) => new TextDecoder().decode(response.body as Uint8Array))
+    .join('\n');
+
+  assert.match(html, /facetheory-rcp-spinner/);
+  assert.match(html, /facetheory-rcp-skeleton--width-two-thirds/);
+  assert.match(html, /aria-busy="true"/);
+  assert.match(html, /href="\/tenants"/);
+  assert.match(html, /prefers-reduced-motion/);
+  assert.doesNotMatch(html, /style="/);
+
+  console.log('responsive primitives Svelte example rendered');
+  console.log(`bytes=${html.length}`);
+} finally {
+  await rm(path.resolve('examples/responsive-primitives-svelte/.tmp'), {
+    recursive: true,
+    force: true,
+  });
+}

--- a/ts/examples/responsive-primitives-vue/render.ts
+++ b/ts/examples/responsive-primitives-vue/render.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+
+import { createFaceApp } from '../../src/app.js';
+import { createVueFace, h } from '../../src/vue/index.js';
+import {
+  AsyncStateBoundary,
+  Button,
+  Link,
+  LoadingState,
+  Skeleton,
+  Spinner,
+} from '../../src/vue/responsive-primitives/index.js';
+import { RESPONSIVE_PRIMITIVES_CSS } from '../../src/responsive-primitives/index.js';
+
+const app = createFaceApp({
+  faces: [
+    createVueFace({
+      route: '/',
+      mode: 'ssr',
+      render: () =>
+        h('main', { class: 'responsive-example' }, [
+          h(Spinner, { label: 'Loading control plane data', size: 'sm' }),
+          h(Skeleton, { width: 'two-thirds', height: 'lg' }),
+          h(LoadingState, { message: 'Loading tenants' }),
+          h(
+            AsyncStateBoundary,
+            { state: 'empty' },
+            { empty: () => h('p', null, 'No tenants yet') },
+          ),
+          h(
+            Button,
+            { loading: true, loadingPlacement: 'replace-prefix' },
+            { default: () => 'Create tenant' },
+          ),
+          h(Link, { href: '/tenants' }, { default: () => 'View tenants' }),
+        ]),
+      renderOptions: {
+        styleTags: [{ cssText: RESPONSIVE_PRIMITIVES_CSS }],
+      },
+    }),
+  ],
+});
+
+const response = await app.handle({ method: 'GET', path: '/' });
+const html = new TextDecoder().decode(response.body as Uint8Array);
+
+assert.equal(response.status, 200);
+assert.match(html, /facetheory-rcp-spinner/);
+assert.match(html, /facetheory-rcp-skeleton--width-two-thirds/);
+assert.match(html, /aria-busy="true"/);
+assert.match(html, /href="\/tenants"/);
+assert.doesNotMatch(html, /style="/);
+
+console.log('responsive primitives Vue example rendered');
+console.log(`bytes=${html.length}`);

--- a/ts/package.json
+++ b/ts/package.json
@@ -47,6 +47,10 @@
       "types": "./dist/navigation-pending.d.ts",
       "import": "./dist/navigation-pending.js"
     },
+    "./responsive-primitives": {
+      "types": "./dist/responsive-primitives/index.d.ts",
+      "import": "./dist/responsive-primitives/index.js"
+    },
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.js"
@@ -103,9 +107,17 @@
       "types": "./dist/react/stitch-admin/index.d.ts",
       "import": "./dist/react/stitch-admin/index.js"
     },
+    "./react/responsive-primitives": {
+      "types": "./dist/react/responsive-primitives/index.d.ts",
+      "import": "./dist/react/responsive-primitives/index.js"
+    },
     "./vue": {
       "types": "./dist/vue/index.d.ts",
       "import": "./dist/vue/index.js"
+    },
+    "./vue/responsive-primitives": {
+      "types": "./dist/vue/responsive-primitives/index.d.ts",
+      "import": "./dist/vue/responsive-primitives/index.js"
     },
     "./vue/stitch-shell": {
       "types": "./dist/vue/stitch-shell/index.d.ts",
@@ -122,6 +134,11 @@
     "./svelte": {
       "types": "./dist/svelte/index.d.ts",
       "import": "./dist/svelte/index.js"
+    },
+    "./svelte/responsive-primitives": {
+      "types": "./dist/svelte/responsive-primitives/index.d.ts",
+      "svelte": "./dist/svelte/responsive-primitives/index.js",
+      "import": "./dist/svelte/responsive-primitives/index.js"
     },
     "./svelte/stitch-shell": {
       "types": "./dist/svelte/stitch-shell/index.d.ts",
@@ -200,6 +217,9 @@
     "example:vite:svelte:library:serve": "tsx examples/vite-ssr-svelte-library/node-server.ts",
     "example:operator-visibility:build": "tsx examples/operator-visibility-react/build.ts",
     "example:operator-visibility:serve": "tsx examples/operator-visibility-react/node-server.ts",
+    "example:responsive:react": "tsx examples/responsive-primitives-react/render.ts",
+    "example:responsive:vue": "tsx examples/responsive-primitives-vue/render.ts",
+    "example:responsive:svelte": "tsx examples/responsive-primitives-svelte/render.ts",
     "example:vite:svelte:strict-csp:build": "vite build --config examples/vite-strict-csp-svelte/vite.config.ts && vite build --ssr src/entry-server.ts --config examples/vite-strict-csp-svelte/vite.config.ts",
     "example:vite:svelte:strict-csp:serve": "tsx examples/vite-strict-csp-svelte/node-server.ts"
   },

--- a/ts/src/react/responsive-primitives/index.ts
+++ b/ts/src/react/responsive-primitives/index.ts
@@ -1,0 +1,454 @@
+import * as React from 'react';
+
+import {
+  buttonClassName,
+  classifyResponsiveLinkClick,
+  forcedSafeLinkRel,
+  handleResponsiveLinkClick,
+  loadingStateClassName,
+  normalizeAsyncViewState,
+  skeletonClassName,
+  spinnerClassName,
+  spinnerSvgSize,
+  suppressButtonActivation,
+  type AsyncViewStateStatus,
+  type ButtonSize,
+  type ButtonVariant,
+  type LoadingPlacement,
+  type LoadingStateSize,
+  type ResponsiveLinkNavigateHandler,
+  type SkeletonAnimation,
+  type SkeletonHeightPreset,
+  type SkeletonVariant,
+  type SkeletonWidthPreset,
+  type SpinnerSize,
+  type SpinnerTone,
+} from '../../responsive-primitives/index.js';
+
+const h = React.createElement;
+
+export interface SpinnerProps extends Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  'role'
+> {
+  label?: string;
+  size?: SpinnerSize;
+  tone?: SpinnerTone;
+}
+
+export interface SkeletonProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'children'
+> {
+  animation?: SkeletonAnimation;
+  decorative?: boolean;
+  height?: SkeletonHeightPreset;
+  loading?: boolean;
+  variant?: SkeletonVariant;
+  width?: SkeletonWidthPreset;
+  children?: React.ReactNode;
+}
+
+export interface LoadingStateProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'role'
+> {
+  fullscreen?: boolean;
+  label?: string;
+  message?: React.ReactNode;
+  size?: LoadingStateSize;
+  spinner?: React.ReactNode;
+}
+
+export interface AsyncStateBoundaryProps extends Omit<
+  React.HTMLAttributes<HTMLElement>,
+  'children'
+> {
+  empty?: React.ReactNode;
+  error?: React.ReactNode | ((error: unknown) => React.ReactNode);
+  errorValue?: unknown;
+  idle?: React.ReactNode;
+  loading?: React.ReactNode;
+  loadingMessage?: string;
+  state: AsyncViewStateStatus;
+  children?: React.ReactNode | (() => React.ReactNode);
+}
+
+export interface ButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'disabled' | 'prefix'
+> {
+  disabled?: boolean;
+  loading?: boolean;
+  loadingAnnouncement?: React.ReactNode;
+  loadingPlacement?: LoadingPlacement;
+  prefix?: React.ReactNode;
+  size?: ButtonSize;
+  spinner?: React.ReactNode;
+  suffix?: React.ReactNode;
+  variant?: ButtonVariant;
+}
+
+export interface LinkProps extends Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  'onNavigate'
+> {
+  onNavigate?: ResponsiveLinkNavigateHandler;
+  sameOriginBaseHref?: string | URL;
+  shouldHandleUrl?: (url: URL, anchor: HTMLAnchorElement | null) => boolean;
+  window?: Window;
+}
+
+export function Spinner(props: SpinnerProps): React.ReactElement {
+  const {
+    className,
+    label = 'Loading',
+    size = 'md',
+    tone = 'primary',
+    ...rest
+  } = props;
+  const pixelSize = spinnerSvgSize(size);
+
+  return h(
+    'span',
+    {
+      ...rest,
+      className: spinnerClassName({ className, size, tone }),
+      role: 'status',
+      'aria-label': label,
+      'data-size': size,
+      'data-tone': tone,
+    },
+    h(
+      'svg',
+      {
+        className: 'facetheory-rcp-spinner__glyph',
+        width: pixelSize,
+        height: pixelSize,
+        viewBox: '0 0 24 24',
+        fill: 'none',
+        stroke: 'currentColor',
+        strokeWidth: 2,
+        strokeLinecap: 'round',
+        strokeLinejoin: 'round',
+        'aria-hidden': true,
+        focusable: false,
+      },
+      h('path', { d: 'M21 12a9 9 0 1 1-6.219-8.56' }),
+    ),
+    h('span', { className: 'facetheory-rcp-visually-hidden' }, label),
+  );
+}
+
+export function Skeleton(props: SkeletonProps): React.ReactElement | null {
+  const {
+    animation = 'pulse',
+    children,
+    className,
+    decorative = true,
+    height,
+    loading = true,
+    variant = 'text',
+    width,
+    ...rest
+  } = props;
+
+  if (!loading) {
+    return h(React.Fragment, null, children);
+  }
+
+  const a11yProps = decorative
+    ? { 'aria-hidden': true }
+    : {
+        role: rest.role ?? 'status',
+        'aria-label': rest['aria-label'] ?? 'Loading',
+      };
+
+  return h('div', {
+    ...rest,
+    ...a11yProps,
+    className: skeletonClassName({
+      animation,
+      className,
+      decorative,
+      height,
+      loading,
+      variant,
+      width,
+    }),
+    'data-animation': animation,
+    'data-loading': 'true',
+  });
+}
+
+export function LoadingState(props: LoadingStateProps): React.ReactElement {
+  const {
+    children,
+    className,
+    fullscreen = false,
+    label = 'Loading',
+    message,
+    size = 'md',
+    spinner,
+    ...rest
+  } = props;
+
+  return h(
+    'div',
+    {
+      ...rest,
+      className: loadingStateClassName({ className, fullscreen, label, size }),
+      role: 'status',
+      'aria-live': 'polite',
+      'aria-busy': true,
+      'data-fullscreen': fullscreen ? 'true' : undefined,
+    },
+    h(
+      'div',
+      { className: 'facetheory-rcp-loading-state__content' },
+      children ?? spinner ?? h(Spinner, { label, size }),
+      message !== undefined
+        ? h(
+            'p',
+            { className: 'facetheory-rcp-loading-state__message' },
+            message,
+          )
+        : null,
+    ),
+  );
+}
+
+export function AsyncStateBoundary(
+  props: AsyncStateBoundaryProps,
+): React.ReactElement {
+  const {
+    children,
+    className,
+    empty,
+    error,
+    errorValue,
+    idle,
+    loading,
+    loadingMessage,
+    state,
+    ...rest
+  } = props;
+  const descriptor = normalizeAsyncViewState({
+    error: errorValue,
+    loadingMessage,
+    status: state,
+  });
+
+  let content: React.ReactNode;
+  if (descriptor.status === 'loading') {
+    content =
+      loading ??
+      h(LoadingState, { message: descriptor.loadingMessage ?? 'Loading…' });
+  } else if (descriptor.status === 'idle') {
+    content = idle ?? null;
+  } else if (descriptor.status === 'empty') {
+    content = empty ?? null;
+  } else if (descriptor.status === 'error') {
+    content =
+      typeof error === 'function'
+        ? error(descriptor.error)
+        : (error ?? 'Something went wrong.');
+  } else {
+    content = typeof children === 'function' ? children() : children;
+  }
+
+  return h(
+    'section',
+    {
+      ...rest,
+      className: ['facetheory-rcp-async-boundary', className]
+        .filter(Boolean)
+        .join(' '),
+      'data-state': descriptor.status,
+      'aria-busy': descriptor.ariaBusy,
+      'aria-live': descriptor.status === 'loading' ? 'polite' : undefined,
+      role: descriptor.status === 'error' ? 'alert' : rest.role,
+    },
+    content,
+  );
+}
+
+export function Button(props: ButtonProps): React.ReactElement {
+  const {
+    children,
+    className,
+    disabled = false,
+    loading = false,
+    loadingAnnouncement = 'Loading',
+    loadingPlacement = 'replace-prefix',
+    onClick,
+    prefix,
+    size = 'md',
+    spinner,
+    suffix,
+    type = 'button',
+    variant = 'primary',
+    ...rest
+  } = props;
+  const blocked = disabled || loading;
+  const spinnerNode =
+    spinner ??
+    h(Spinner, {
+      label: 'Loading',
+      size: size === 'lg' ? 'sm' : 'xs',
+      tone: 'current',
+    });
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    if (blocked) {
+      suppressButtonActivation(event);
+      return;
+    }
+    onClick?.(event);
+  };
+
+  return h(
+    'button',
+    {
+      ...rest,
+      type,
+      className: buttonClassName({
+        className,
+        disabled,
+        loading,
+        loadingPlacement,
+        size,
+        variant,
+      }),
+      disabled: blocked,
+      'aria-disabled': blocked,
+      'aria-busy': loading ? true : undefined,
+      'data-loading': loading ? 'true' : undefined,
+      onClick: handleClick,
+    },
+    loading && loadingPlacement === 'prepend'
+      ? h(
+          'span',
+          {
+            className:
+              'facetheory-rcp-button__spinner facetheory-rcp-button__spinner--prepend',
+            'aria-hidden': true,
+          },
+          spinnerNode,
+        )
+      : null,
+    loading && loadingPlacement === 'replace-prefix'
+      ? h(
+          'span',
+          {
+            className:
+              'facetheory-rcp-button__spinner facetheory-rcp-button__spinner--prefix',
+            'aria-hidden': true,
+          },
+          spinnerNode,
+        )
+      : prefix !== undefined
+        ? h('span', { className: 'facetheory-rcp-button__prefix' }, prefix)
+        : null,
+    h('span', { className: 'facetheory-rcp-button__content' }, children),
+    loading && loadingPlacement === 'append'
+      ? h(
+          'span',
+          {
+            className:
+              'facetheory-rcp-button__spinner facetheory-rcp-button__spinner--append',
+            'aria-hidden': true,
+          },
+          spinnerNode,
+        )
+      : suffix !== undefined
+        ? h('span', { className: 'facetheory-rcp-button__suffix' }, suffix)
+        : null,
+    loading
+      ? h(
+          'span',
+          {
+            className: 'facetheory-rcp-visually-hidden',
+            role: 'status',
+            'aria-live': 'polite',
+          },
+          loadingAnnouncement,
+        )
+      : null,
+  );
+}
+
+export function Link(props: LinkProps): React.ReactElement {
+  const {
+    children,
+    className,
+    href,
+    onClick,
+    onNavigate,
+    rel,
+    sameOriginBaseHref,
+    shouldHandleUrl,
+    target,
+    window,
+    ...rest
+  } = props;
+  const resolvedHref = href ?? '';
+  const safeRel = forcedSafeLinkRel({
+    href: resolvedHref,
+    rel,
+    sameOriginBaseHref,
+    target,
+  });
+
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    if (onNavigate === undefined) return;
+
+    const nativeEvent = event.nativeEvent;
+    const classifierOptions = responsiveLinkClassifierOptions(
+      shouldHandleUrl,
+      window,
+    );
+    const intent = classifyResponsiveLinkClick(nativeEvent, classifierOptions);
+    if (!intent) return;
+
+    handleResponsiveLinkClick(nativeEvent, {
+      ...classifierOptions,
+      onNavigate,
+    });
+  };
+
+  return h(
+    'a',
+    {
+      ...rest,
+      className: ['facetheory-rcp-link', className].filter(Boolean).join(' '),
+      href: resolvedHref,
+      onClick: handleClick,
+      rel: safeRel,
+      target,
+    },
+    children,
+  );
+}
+
+export type { AsyncViewStateStatus, LoadingPlacement };
+
+function responsiveLinkClassifierOptions(
+  shouldHandleUrl:
+    | ((url: URL, anchor: HTMLAnchorElement | null) => boolean)
+    | undefined,
+  windowValue: Window | undefined,
+): {
+  shouldHandleUrl?: (url: URL, anchor: HTMLAnchorElement | null) => boolean;
+  window?: Window;
+} {
+  const options: {
+    shouldHandleUrl?: (url: URL, anchor: HTMLAnchorElement | null) => boolean;
+    window?: Window;
+  } = {};
+  if (shouldHandleUrl !== undefined) options.shouldHandleUrl = shouldHandleUrl;
+  if (windowValue !== undefined) options.window = windowValue;
+  return options;
+}

--- a/ts/src/responsive-primitives/index.ts
+++ b/ts/src/responsive-primitives/index.ts
@@ -1,0 +1,584 @@
+import {
+  classifyFaceNavigationAnchorClick,
+  FACE_NAVIGATION_CLASSIFIER_SOURCE,
+} from '../spa.js';
+import type { ClassifyFaceNavigationAnchorClickOptions } from '../spa.js';
+
+export const RESPONSIVE_PRIMITIVES_SURFACE_ID =
+  'theorycloud_responsive_control_plane.primitives';
+export const RESPONSIVE_PRIMITIVES_CONTRACT =
+  'theorycloud_responsive_control_plane.v0.1';
+export const RESPONSIVE_PRIMITIVES_CLASS_PREFIX = 'facetheory-rcp';
+export const RESPONSIVE_LINK_CLASSIFIER_SOURCE =
+  FACE_NAVIGATION_CLASSIFIER_SOURCE;
+
+export type ResponsivePrimitiveFramework =
+  | 'neutral'
+  | 'react'
+  | 'vue'
+  | 'svelte';
+
+export type ResponsivePrimitiveName =
+  | 'Spinner'
+  | 'Skeleton'
+  | 'LoadingState'
+  | 'AsyncStateBoundary'
+  | 'Button'
+  | 'Link';
+
+export interface ResponsivePrimitiveA11yContract {
+  readonly role?: string;
+  readonly liveRegion?: 'off' | 'polite' | 'assertive';
+  readonly ariaBusy?: boolean;
+  readonly reducedMotion: boolean;
+  readonly decorativeDefault?: boolean;
+  readonly notes: readonly string[];
+}
+
+export interface ResponsivePrimitiveContract {
+  readonly primitive: ResponsivePrimitiveName;
+  readonly frameworks: Readonly<Record<ResponsivePrimitiveFramework, true>>;
+  readonly a11y: ResponsivePrimitiveA11yContract;
+}
+
+const ALL_FRAMEWORKS: Readonly<Record<ResponsivePrimitiveFramework, true>> = {
+  neutral: true,
+  react: true,
+  vue: true,
+  svelte: true,
+};
+
+export const RESPONSIVE_PRIMITIVE_CONTRACTS: readonly ResponsivePrimitiveContract[] =
+  [
+    {
+      primitive: 'Spinner',
+      frameworks: ALL_FRAMEWORKS,
+      a11y: {
+        role: 'status',
+        reducedMotion: true,
+        notes: [
+          'The visible glyph is aria-hidden; the host element exposes the status label.',
+          'CSS disables spin animation under prefers-reduced-motion: reduce.',
+        ],
+      },
+    },
+    {
+      primitive: 'Skeleton',
+      frameworks: ALL_FRAMEWORKS,
+      a11y: {
+        reducedMotion: true,
+        decorativeDefault: true,
+        notes: [
+          'The loading placeholder is aria-hidden by default because it is decorative.',
+          'Preset width and height classes are used instead of inline styles.',
+          'Children are only rendered when loading is false.',
+        ],
+      },
+    },
+    {
+      primitive: 'LoadingState',
+      frameworks: ALL_FRAMEWORKS,
+      a11y: {
+        role: 'status',
+        liveRegion: 'polite',
+        ariaBusy: true,
+        reducedMotion: true,
+        notes: [
+          'The wrapper announces a polite busy status and can render a fullscreen overlay.',
+          'The embedded spinner inherits the Spinner reduced-motion contract.',
+        ],
+      },
+    },
+    {
+      primitive: 'AsyncStateBoundary',
+      frameworks: ALL_FRAMEWORKS,
+      a11y: {
+        liveRegion: 'polite',
+        ariaBusy: true,
+        reducedMotion: true,
+        notes: [
+          'The loading branch composes LoadingState; empty, error, idle, and success branches remain caller-supplied.',
+        ],
+      },
+    },
+    {
+      primitive: 'Button',
+      frameworks: ALL_FRAMEWORKS,
+      a11y: {
+        liveRegion: 'polite',
+        ariaBusy: true,
+        reducedMotion: true,
+        notes: [
+          'Loading buttons set aria-busy and disabled/aria-disabled.',
+          'Activation is suppressed in the click handler while disabled or loading.',
+          'A visually-hidden role=status announcement is emitted while loading.',
+        ],
+      },
+    },
+    {
+      primitive: 'Link',
+      frameworks: ALL_FRAMEWORKS,
+      a11y: {
+        reducedMotion: false,
+        notes: [
+          'The component always renders a real anchor with href.',
+          'Only accepted same-origin plain left clicks are intercepted through the shared spa.ts classifier.',
+          'External and target=_blank links force noopener noreferrer rel tokens.',
+        ],
+      },
+    },
+  ] as const;
+
+export type SpinnerSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type SpinnerTone = 'primary' | 'current' | 'inverse' | 'neutral';
+
+export interface SpinnerPrimitiveOptions {
+  className?: string | undefined;
+  label?: string | undefined;
+  size?: SpinnerSize | undefined;
+  tone?: SpinnerTone | undefined;
+}
+
+export type SkeletonVariant = 'text' | 'circle' | 'rectangle' | 'rounded';
+export type SkeletonAnimation = 'pulse' | 'wave' | 'none';
+export type SkeletonWidthPreset =
+  | 'auto'
+  | 'content'
+  | 'full'
+  | 'three-quarters'
+  | 'two-thirds'
+  | 'half'
+  | 'third'
+  | 'quarter';
+export type SkeletonHeightPreset = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+export interface SkeletonPrimitiveOptions {
+  animation?: SkeletonAnimation | undefined;
+  className?: string | undefined;
+  decorative?: boolean | undefined;
+  height?: SkeletonHeightPreset | undefined;
+  loading?: boolean | undefined;
+  variant?: SkeletonVariant | undefined;
+  width?: SkeletonWidthPreset | undefined;
+}
+
+export type LoadingStateSize = SpinnerSize;
+
+export interface LoadingStatePrimitiveOptions {
+  className?: string | undefined;
+  fullscreen?: boolean | undefined;
+  label?: string | undefined;
+  message?: string | undefined;
+  size?: LoadingStateSize | undefined;
+}
+
+export type AsyncViewStateStatus =
+  | 'idle'
+  | 'loading'
+  | 'empty'
+  | 'error'
+  | 'success';
+
+export interface AsyncViewStateInput {
+  status: AsyncViewStateStatus;
+  error?: unknown;
+  loadingMessage?: string | undefined;
+}
+
+export interface AsyncViewStateDescriptor {
+  ariaBusy: boolean;
+  error?: unknown;
+  loadingMessage?: string;
+  status: AsyncViewStateStatus;
+}
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+export type LoadingPlacement = 'replace-prefix' | 'prepend' | 'append';
+
+export interface ButtonPrimitiveOptions {
+  className?: string | undefined;
+  disabled?: boolean | undefined;
+  loading?: boolean | undefined;
+  loadingPlacement?: LoadingPlacement | undefined;
+  size?: ButtonSize | undefined;
+  variant?: ButtonVariant | undefined;
+}
+
+export interface LinkRelOptions {
+  href: string;
+  rel?: string | undefined;
+  sameOriginBaseHref?: string | URL | undefined;
+  target?: string | undefined;
+}
+
+export interface ResponsiveLinkNavigationIntent {
+  anchor: HTMLAnchorElement;
+  classifierSource: typeof FACE_NAVIGATION_CLASSIFIER_SOURCE;
+  event: MouseEvent;
+  url: URL;
+}
+
+export type ResponsiveLinkNavigateResult = boolean | void;
+export type ResponsiveLinkNavigateHandler = (
+  intent: ResponsiveLinkNavigationIntent,
+) => ResponsiveLinkNavigateResult;
+
+export interface ResponsiveLinkClickOptions extends ClassifyFaceNavigationAnchorClickOptions {
+  onNavigate?: ResponsiveLinkNavigateHandler | undefined;
+}
+
+export const RESPONSIVE_PRIMITIVES_CSS = `
+.facetheory-rcp-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.facetheory-rcp-spinner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--facetheory-rcp-spinner-color, currentColor);
+}
+
+.facetheory-rcp-spinner__glyph {
+  display: block;
+  animation: facetheory-rcp-spin 700ms linear infinite;
+}
+
+.facetheory-rcp-spinner--xs { inline-size: 0.75rem; block-size: 0.75rem; }
+.facetheory-rcp-spinner--sm { inline-size: 1rem; block-size: 1rem; }
+.facetheory-rcp-spinner--md { inline-size: 1.5rem; block-size: 1.5rem; }
+.facetheory-rcp-spinner--lg { inline-size: 2rem; block-size: 2rem; }
+.facetheory-rcp-spinner--xl { inline-size: 3rem; block-size: 3rem; }
+.facetheory-rcp-spinner--primary { --facetheory-rcp-spinner-color: var(--stitch-color-primary, #2f55d4); }
+.facetheory-rcp-spinner--current { --facetheory-rcp-spinner-color: currentColor; }
+.facetheory-rcp-spinner--inverse { --facetheory-rcp-spinner-color: var(--stitch-color-on-primary, #ffffff); }
+.facetheory-rcp-spinner--neutral { --facetheory-rcp-spinner-color: var(--stitch-color-on-surface-variant, #464553); }
+
+@keyframes facetheory-rcp-spin {
+  to { transform: rotate(360deg); }
+}
+
+.facetheory-rcp-skeleton {
+  display: block;
+  overflow: hidden;
+  position: relative;
+  background: var(--facetheory-rcp-skeleton-surface, var(--stitch-color-surface-container-high, #e2e7ff));
+  color: transparent;
+}
+
+.facetheory-rcp-skeleton--text { border-radius: 999px; block-size: 1em; }
+.facetheory-rcp-skeleton--circle { border-radius: 999px; aspect-ratio: 1 / 1; }
+.facetheory-rcp-skeleton--rectangle { border-radius: var(--stitch-radius-sm, 6px); }
+.facetheory-rcp-skeleton--rounded { border-radius: var(--stitch-radius-lg, 12px); }
+.facetheory-rcp-skeleton--width-auto { inline-size: auto; }
+.facetheory-rcp-skeleton--width-content { inline-size: 12ch; }
+.facetheory-rcp-skeleton--width-full { inline-size: 100%; }
+.facetheory-rcp-skeleton--width-three-quarters { inline-size: 75%; }
+.facetheory-rcp-skeleton--width-two-thirds { inline-size: 66.666%; }
+.facetheory-rcp-skeleton--width-half { inline-size: 50%; }
+.facetheory-rcp-skeleton--width-third { inline-size: 33.333%; }
+.facetheory-rcp-skeleton--width-quarter { inline-size: 25%; }
+.facetheory-rcp-skeleton--height-xs { block-size: 0.5rem; }
+.facetheory-rcp-skeleton--height-sm { block-size: 0.75rem; }
+.facetheory-rcp-skeleton--height-md { block-size: 1rem; }
+.facetheory-rcp-skeleton--height-lg { block-size: 1.5rem; }
+.facetheory-rcp-skeleton--height-xl { block-size: 2rem; }
+.facetheory-rcp-skeleton--height-2xl { block-size: 3rem; }
+.facetheory-rcp-skeleton--pulse { animation: facetheory-rcp-skeleton-pulse 1.2s ease-in-out infinite; }
+.facetheory-rcp-skeleton--wave::after {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  inset-inline: -150% 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.42), transparent);
+  animation: facetheory-rcp-skeleton-wave 1.4s linear infinite;
+}
+
+@keyframes facetheory-rcp-skeleton-pulse {
+  50% { opacity: 0.56; }
+}
+
+@keyframes facetheory-rcp-skeleton-wave {
+  to { transform: translateX(150%); }
+}
+
+.facetheory-rcp-loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--stitch-space-md, 1rem);
+}
+
+.facetheory-rcp-loading-state--fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: var(--facetheory-rcp-overlay-z-index, 1000);
+  background: var(--facetheory-rcp-overlay-background, rgba(0, 0, 0, 0.45));
+  backdrop-filter: blur(2px);
+}
+
+.facetheory-rcp-loading-state__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--stitch-space-sm, 0.75rem);
+}
+
+.facetheory-rcp-loading-state--fullscreen .facetheory-rcp-loading-state__content {
+  padding: var(--stitch-space-lg, 1.5rem);
+  border-radius: var(--stitch-radius-lg, 12px);
+  background: var(--stitch-color-surface, #ffffff);
+  color: var(--stitch-color-on-surface, #131b2e);
+}
+
+.facetheory-rcp-loading-state__message {
+  margin: 0;
+  color: var(--stitch-color-on-surface-variant, #464553);
+  font: inherit;
+  text-align: center;
+}
+
+.facetheory-rcp-async-boundary[data-state='idle'],
+.facetheory-rcp-async-boundary[data-state='empty'],
+.facetheory-rcp-async-boundary[data-state='error'] {
+  display: block;
+}
+
+.facetheory-rcp-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border: 0;
+  border-radius: var(--stitch-radius-md, 10px);
+  font: inherit;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.facetheory-rcp-button--sm { min-block-size: 2rem; padding: 0 0.75rem; }
+.facetheory-rcp-button--md { min-block-size: 2.5rem; padding: 0 1rem; }
+.facetheory-rcp-button--lg { min-block-size: 3rem; padding: 0 1.25rem; }
+.facetheory-rcp-button--primary { background: var(--stitch-color-primary, #2f55d4); color: var(--stitch-color-on-primary, #ffffff); }
+.facetheory-rcp-button--secondary { background: var(--stitch-color-secondary-container, #ffecc0); color: var(--stitch-color-on-secondary-container, #3f2e00); }
+.facetheory-rcp-button--ghost { background: transparent; color: var(--stitch-color-primary, #2f55d4); }
+.facetheory-rcp-button--danger { background: var(--stitch-color-error, #ba1a1a); color: var(--stitch-color-on-error, #ffffff); }
+.facetheory-rcp-button[disabled],
+.facetheory-rcp-button[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.facetheory-rcp-button__content,
+.facetheory-rcp-button__prefix,
+.facetheory-rcp-button__suffix,
+.facetheory-rcp-button__spinner {
+  display: inline-flex;
+  align-items: center;
+}
+
+.facetheory-rcp-link {
+  color: var(--stitch-color-primary, #2f55d4);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .facetheory-rcp-spinner__glyph,
+  .facetheory-rcp-skeleton--pulse,
+  .facetheory-rcp-skeleton--wave::after {
+    animation: none;
+  }
+
+  .facetheory-rcp-loading-state--fullscreen {
+    backdrop-filter: none;
+  }
+}
+`;
+
+export function joinResponsivePrimitiveClassNames(
+  ...values: Array<string | false | null | undefined>
+): string {
+  return values.filter((value): value is string => Boolean(value)).join(' ');
+}
+
+export function spinnerClassName(
+  options: SpinnerPrimitiveOptions = {},
+): string {
+  const size = options.size ?? 'md';
+  const tone = options.tone ?? 'primary';
+  return joinResponsivePrimitiveClassNames(
+    'facetheory-rcp-spinner',
+    `facetheory-rcp-spinner--${size}`,
+    `facetheory-rcp-spinner--${tone}`,
+    options.className,
+  );
+}
+
+export function spinnerSvgSize(size: SpinnerSize | undefined): number {
+  switch (size ?? 'md') {
+    case 'xs':
+      return 12;
+    case 'sm':
+      return 16;
+    case 'lg':
+      return 32;
+    case 'xl':
+      return 48;
+    case 'md':
+      return 24;
+  }
+}
+
+export function skeletonClassName(
+  options: SkeletonPrimitiveOptions = {},
+): string {
+  const variant = options.variant ?? 'text';
+  const animation = options.animation ?? 'pulse';
+  return joinResponsivePrimitiveClassNames(
+    'facetheory-rcp-skeleton',
+    `facetheory-rcp-skeleton--${variant}`,
+    animation !== 'none' && `facetheory-rcp-skeleton--${animation}`,
+    options.width !== undefined &&
+      `facetheory-rcp-skeleton--width-${options.width}`,
+    options.height !== undefined &&
+      `facetheory-rcp-skeleton--height-${options.height}`,
+    options.className,
+  );
+}
+
+export function loadingStateClassName(
+  options: LoadingStatePrimitiveOptions = {},
+): string {
+  return joinResponsivePrimitiveClassNames(
+    'facetheory-rcp-loading-state',
+    options.fullscreen === true && 'facetheory-rcp-loading-state--fullscreen',
+    options.className,
+  );
+}
+
+export function normalizeAsyncViewState(
+  input: AsyncViewStateInput,
+): AsyncViewStateDescriptor {
+  const descriptor: AsyncViewStateDescriptor = {
+    ariaBusy: input.status === 'loading',
+    status: input.status,
+  };
+  if (input.error !== undefined) descriptor.error = input.error;
+  if (input.loadingMessage !== undefined) {
+    descriptor.loadingMessage = input.loadingMessage;
+  }
+  return descriptor;
+}
+
+export function buttonClassName(options: ButtonPrimitiveOptions = {}): string {
+  const size = options.size ?? 'md';
+  const variant = options.variant ?? 'primary';
+  const loadingPlacement = options.loadingPlacement ?? 'replace-prefix';
+  return joinResponsivePrimitiveClassNames(
+    'facetheory-rcp-button',
+    `facetheory-rcp-button--${variant}`,
+    `facetheory-rcp-button--${size}`,
+    options.loading === true && 'facetheory-rcp-button--loading',
+    options.loading === true &&
+      `facetheory-rcp-button--loading-${loadingPlacement}`,
+    options.disabled === true && 'facetheory-rcp-button--disabled',
+    options.className,
+  );
+}
+
+export function suppressButtonActivation(
+  event: Pick<Event, 'preventDefault' | 'stopPropagation'>,
+): void {
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+export function forcedSafeLinkRel(options: LinkRelOptions): string | undefined {
+  const tokens = new Set(
+    (options.rel ?? '')
+      .split(/\s+/)
+      .map((token) => token.trim())
+      .filter(Boolean),
+  );
+
+  if (linkRequiresNoopener(options)) {
+    tokens.add('noopener');
+    tokens.add('noreferrer');
+  }
+
+  if (tokens.size === 0) return undefined;
+  return Array.from(tokens).join(' ');
+}
+
+export function linkRequiresNoopener(options: LinkRelOptions): boolean {
+  if (options.target === '_blank') return true;
+  return isExternalLinkHref(options.href, options.sameOriginBaseHref);
+}
+
+export function isExternalLinkHref(
+  href: string,
+  sameOriginBaseHref?: string | URL,
+): boolean {
+  if (!isHttpUrlLike(href)) return false;
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return false;
+  }
+
+  if (sameOriginBaseHref === undefined) return true;
+
+  try {
+    const base = new URL(String(sameOriginBaseHref));
+    return url.origin !== base.origin;
+  } catch {
+    return true;
+  }
+}
+
+export function classifyResponsiveLinkClick(
+  event: MouseEvent,
+  options: ClassifyFaceNavigationAnchorClickOptions = {},
+): ResponsiveLinkNavigationIntent | null {
+  const navigation = classifyFaceNavigationAnchorClick(event, options);
+  if (!navigation) return null;
+  return {
+    anchor: navigation.anchor,
+    classifierSource: navigation.classifierSource,
+    event,
+    url: navigation.url,
+  };
+}
+
+export function handleResponsiveLinkClick(
+  event: MouseEvent,
+  options: ResponsiveLinkClickOptions = {},
+): ResponsiveLinkNavigationIntent | null {
+  const intent = classifyResponsiveLinkClick(event, options);
+  if (!intent) return null;
+
+  if (options.onNavigate === undefined) return intent;
+
+  const result = options.onNavigate(intent);
+  event.preventDefault();
+  if (result === false) {
+    event.stopPropagation();
+  }
+  return intent;
+}
+
+function isHttpUrlLike(href: string): boolean {
+  return /^https?:\/\//i.test(href.trim());
+}

--- a/ts/src/svelte/responsive-primitives/AsyncStateBoundary.svelte
+++ b/ts/src/svelte/responsive-primitives/AsyncStateBoundary.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import {
+    normalizeAsyncViewState,
+    spinnerClassName,
+    spinnerSvgSize,
+    type AsyncViewStateStatus,
+  } from '../../responsive-primitives/index.js';
+
+  export let errorValue: unknown = undefined;
+  export let loadingMessage: string | undefined = undefined;
+  export let state: AsyncViewStateStatus;
+  let className = '';
+  export { className as class };
+
+  $: descriptor = normalizeAsyncViewState({ error: errorValue, loadingMessage, status: state });
+  $: embeddedSpinnerClass = spinnerClassName({ size: 'md', tone: 'primary' });
+  $: pixelSize = spinnerSvgSize('md');
+</script>
+
+<section
+  {...$$restProps}
+  class={['facetheory-rcp-async-boundary', className].filter(Boolean).join(' ')}
+  data-state={descriptor.status}
+  aria-busy={descriptor.ariaBusy}
+  aria-live={descriptor.status === 'loading' ? 'polite' : undefined}
+  role={descriptor.status === 'error' ? 'alert' : undefined}
+>
+  {#if descriptor.status === 'loading'}
+    {#if $$slots.loading}
+      <slot name="loading" />
+    {:else}
+      <div class="facetheory-rcp-loading-state" role="status" aria-live="polite" aria-busy="true">
+        <div class="facetheory-rcp-loading-state__content">
+          <span class={embeddedSpinnerClass} role="status" aria-label="Loading" data-size="md" data-tone="primary">
+            <svg
+              class="facetheory-rcp-spinner__glyph"
+              width={pixelSize}
+              height={pixelSize}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+            <span class="facetheory-rcp-visually-hidden">Loading</span>
+          </span>
+          <p class="facetheory-rcp-loading-state__message">{descriptor.loadingMessage ?? 'Loading…'}</p>
+        </div>
+      </div>
+    {/if}
+  {:else if descriptor.status === 'idle'}
+    <slot name="idle" />
+  {:else if descriptor.status === 'empty'}
+    <slot name="empty" />
+  {:else if descriptor.status === 'error'}
+    <slot name="error">Something went wrong.</slot>
+  {:else}
+    <slot />
+  {/if}
+</section>

--- a/ts/src/svelte/responsive-primitives/Button.svelte
+++ b/ts/src/svelte/responsive-primitives/Button.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import {
+    buttonClassName,
+    spinnerClassName,
+    spinnerSvgSize,
+    suppressButtonActivation,
+    type ButtonSize,
+    type ButtonVariant,
+    type LoadingPlacement,
+  } from '../../responsive-primitives/index.js';
+
+  export let disabled = false;
+  export let loading = false;
+  export let loadingAnnouncement: unknown = 'Loading';
+  export let loadingPlacement: LoadingPlacement = 'replace-prefix';
+  export let onclick: ((event: MouseEvent) => void) | undefined = undefined;
+  export let size: ButtonSize = 'md';
+  export let type: 'button' | 'submit' | 'reset' = 'button';
+  export let variant: ButtonVariant = 'primary';
+  let className = '';
+  export { className as class };
+
+  $: blocked = disabled || loading;
+  $: resolvedClass = buttonClassName({
+    className,
+    disabled,
+    loading,
+    loadingPlacement,
+    size,
+    variant,
+  });
+  $: spinnerSize = size === 'lg' ? 'sm' : 'xs';
+  $: embeddedSpinnerClass = spinnerClassName({ size: spinnerSize, tone: 'current' });
+  $: pixelSize = spinnerSvgSize(spinnerSize);
+
+  function handleClick(event: MouseEvent): void {
+    if (blocked) {
+      suppressButtonActivation(event);
+      return;
+    }
+    onclick?.(event);
+  }
+</script>
+
+
+<button
+  {...$$restProps}
+  class={resolvedClass}
+  {type}
+  disabled={blocked}
+  aria-disabled={blocked}
+  aria-busy={loading ? 'true' : undefined}
+  data-loading={loading ? 'true' : undefined}
+  onclick={handleClick}
+>
+  {#if loading && loadingPlacement === 'prepend'}
+    <span class="facetheory-rcp-button__spinner facetheory-rcp-button__spinner--prepend" aria-hidden="true">
+      {#if $$slots.spinner}
+        <slot name="spinner" />
+      {:else}
+        <span class={embeddedSpinnerClass} role="status" aria-label="Loading" data-size={spinnerSize} data-tone="current">
+          <svg
+            class="facetheory-rcp-spinner__glyph"
+            width={pixelSize}
+            height={pixelSize}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+          <span class="facetheory-rcp-visually-hidden">Loading</span>
+        </span>
+      {/if}
+    </span>
+  {/if}
+
+  {#if loading && loadingPlacement === 'replace-prefix'}
+    <span class="facetheory-rcp-button__spinner facetheory-rcp-button__spinner--prefix" aria-hidden="true">
+      {#if $$slots.spinner}
+        <slot name="spinner" />
+      {:else}
+        <span class={embeddedSpinnerClass} role="status" aria-label="Loading" data-size={spinnerSize} data-tone="current">
+          <svg
+            class="facetheory-rcp-spinner__glyph"
+            width={pixelSize}
+            height={pixelSize}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+          <span class="facetheory-rcp-visually-hidden">Loading</span>
+        </span>
+      {/if}
+    </span>
+  {:else if $$slots.prefix}
+    <span class="facetheory-rcp-button__prefix"><slot name="prefix" /></span>
+  {/if}
+
+  <span class="facetheory-rcp-button__content"><slot /></span>
+
+  {#if loading && loadingPlacement === 'append'}
+    <span class="facetheory-rcp-button__spinner facetheory-rcp-button__spinner--append" aria-hidden="true">
+      {#if $$slots.spinner}
+        <slot name="spinner" />
+      {:else}
+        <span class={embeddedSpinnerClass} role="status" aria-label="Loading" data-size={spinnerSize} data-tone="current">
+          <svg
+            class="facetheory-rcp-spinner__glyph"
+            width={pixelSize}
+            height={pixelSize}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+          <span class="facetheory-rcp-visually-hidden">Loading</span>
+        </span>
+      {/if}
+    </span>
+  {:else if $$slots.suffix}
+    <span class="facetheory-rcp-button__suffix"><slot name="suffix" /></span>
+  {/if}
+
+  {#if loading}
+    <span class="facetheory-rcp-visually-hidden" role="status" aria-live="polite">{loadingAnnouncement}</span>
+  {/if}
+</button>

--- a/ts/src/svelte/responsive-primitives/Link.svelte
+++ b/ts/src/svelte/responsive-primitives/Link.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import {
+    classifyResponsiveLinkClick,
+    forcedSafeLinkRel,
+    handleResponsiveLinkClick,
+    type ResponsiveLinkNavigateHandler,
+  } from '../../responsive-primitives/index.js';
+
+  export let href: string;
+  export let onclick: ((event: MouseEvent) => void) | undefined = undefined;
+  export let onnavigate: ResponsiveLinkNavigateHandler | undefined = undefined;
+  export let rel: string | undefined = undefined;
+  export let sameOriginBaseHref: string | URL | undefined = undefined;
+  export let shouldHandleUrl:
+    | ((url: URL, anchor: HTMLAnchorElement | null) => boolean)
+    | undefined = undefined;
+  export let target: string | undefined = undefined;
+  export let window: Window | undefined = undefined;
+  let className = '';
+  export { className as class };
+
+  $: safeRel = forcedSafeLinkRel({ href, rel, sameOriginBaseHref, target });
+  $: resolvedClass = ['facetheory-rcp-link', className].filter(Boolean).join(' ');
+
+  function handleClick(event: MouseEvent): void {
+    onclick?.(event);
+    if (event.defaultPrevented) return;
+    if (onnavigate === undefined) return;
+
+    const intent = classifyResponsiveLinkClick(event, { shouldHandleUrl, window });
+    if (!intent) return;
+
+    handleResponsiveLinkClick(event, { onNavigate: onnavigate, shouldHandleUrl, window });
+  }
+</script>
+
+<a
+  {...$$restProps}
+  class={resolvedClass}
+  {href}
+  rel={safeRel}
+  {target}
+  onclick={handleClick}
+><slot /></a>

--- a/ts/src/svelte/responsive-primitives/LoadingState.svelte
+++ b/ts/src/svelte/responsive-primitives/LoadingState.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import {
+    loadingStateClassName,
+    spinnerClassName,
+    spinnerSvgSize,
+    type LoadingStateSize,
+  } from '../../responsive-primitives/index.js';
+
+  export let fullscreen = false;
+  export let label = 'Loading';
+  export let message: unknown = undefined;
+  export let size: LoadingStateSize = 'md';
+  let className = '';
+  export { className as class };
+
+  $: resolvedClass = loadingStateClassName({ className, fullscreen, label, message: String(message ?? ''), size });
+  $: pixelSize = spinnerSvgSize(size);
+  $: embeddedSpinnerClass = spinnerClassName({ size, tone: 'primary' });
+</script>
+
+<div
+  {...$$restProps}
+  class={resolvedClass}
+  role="status"
+  aria-live="polite"
+  aria-busy="true"
+  data-fullscreen={fullscreen ? 'true' : undefined}
+>
+  <div class="facetheory-rcp-loading-state__content">
+    {#if $$slots.default}
+      <slot />
+    {:else if $$slots.spinner}
+      <slot name="spinner" />
+    {:else}
+      <span class={embeddedSpinnerClass} role="status" aria-label={label} data-size={size} data-tone="primary">
+        <svg
+          class="facetheory-rcp-spinner__glyph"
+          width={pixelSize}
+          height={pixelSize}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+        </svg>
+        <span class="facetheory-rcp-visually-hidden">{label}</span>
+      </span>
+    {/if}
+
+    {#if $$slots.message || message !== undefined}
+      <p class="facetheory-rcp-loading-state__message"><slot name="message">{message}</slot></p>
+    {/if}
+  </div>
+</div>

--- a/ts/src/svelte/responsive-primitives/Skeleton.svelte
+++ b/ts/src/svelte/responsive-primitives/Skeleton.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import {
+    skeletonClassName,
+    type SkeletonAnimation,
+    type SkeletonHeightPreset,
+    type SkeletonVariant,
+    type SkeletonWidthPreset,
+  } from '../../responsive-primitives/index.js';
+
+  export let animation: SkeletonAnimation = 'pulse';
+  export let decorative = true;
+  export let height: SkeletonHeightPreset | undefined = undefined;
+  export let loading = true;
+  export let variant: SkeletonVariant = 'text';
+  export let width: SkeletonWidthPreset | undefined = undefined;
+  let className = '';
+  export { className as class };
+
+  $: resolvedClass = skeletonClassName({
+    animation,
+    className,
+    decorative,
+    height,
+    loading,
+    variant,
+    width,
+  });
+</script>
+
+{#if loading}
+  <div
+    {...$$restProps}
+    class={resolvedClass}
+    aria-hidden={decorative ? 'true' : undefined}
+    role={decorative ? undefined : 'status'}
+    aria-label={decorative ? undefined : 'Loading'}
+    data-animation={animation}
+    data-loading="true"
+  ></div>
+{:else}
+  <slot />
+{/if}

--- a/ts/src/svelte/responsive-primitives/Spinner.svelte
+++ b/ts/src/svelte/responsive-primitives/Spinner.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import {
+    spinnerClassName,
+    spinnerSvgSize,
+    type SpinnerSize,
+    type SpinnerTone,
+  } from '../../responsive-primitives/index.js';
+
+  export let label = 'Loading';
+  export let size: SpinnerSize = 'md';
+  export let tone: SpinnerTone = 'primary';
+  let className = '';
+  export { className as class };
+
+  $: pixelSize = spinnerSvgSize(size);
+  $: resolvedClass = spinnerClassName({ className, size, tone });
+</script>
+
+<span
+  {...$$restProps}
+  class={resolvedClass}
+  role="status"
+  aria-label={label}
+  data-size={size}
+  data-tone={tone}
+>
+  <svg
+    class="facetheory-rcp-spinner__glyph"
+    width={pixelSize}
+    height={pixelSize}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+  </svg>
+  <span class="facetheory-rcp-visually-hidden">{label}</span>
+</span>

--- a/ts/src/svelte/responsive-primitives/index.d.ts
+++ b/ts/src/svelte/responsive-primitives/index.d.ts
@@ -1,0 +1,94 @@
+import type { Component } from 'svelte';
+import type {
+  AsyncViewStateStatus,
+  ButtonSize,
+  ButtonVariant,
+  LoadingPlacement,
+  LoadingStateSize,
+  ResponsiveLinkNavigateHandler,
+  SkeletonAnimation,
+  SkeletonHeightPreset,
+  SkeletonVariant,
+  SkeletonWidthPreset,
+  SpinnerSize,
+  SpinnerTone,
+} from '../../responsive-primitives/index.js';
+
+export interface SpinnerProps {
+  label?: string;
+  size?: SpinnerSize;
+  tone?: SpinnerTone;
+  class?: string;
+}
+
+export interface SkeletonProps {
+  animation?: SkeletonAnimation;
+  decorative?: boolean;
+  height?: SkeletonHeightPreset;
+  loading?: boolean;
+  variant?: SkeletonVariant;
+  width?: SkeletonWidthPreset;
+  class?: string;
+}
+
+export interface LoadingStateProps {
+  fullscreen?: boolean;
+  label?: string;
+  message?: unknown;
+  size?: LoadingStateSize;
+  class?: string;
+}
+
+export interface AsyncStateBoundaryProps {
+  errorValue?: unknown;
+  loadingMessage?: string;
+  state: AsyncViewStateStatus;
+  class?: string;
+}
+
+export interface ButtonProps {
+  disabled?: boolean;
+  loading?: boolean;
+  loadingAnnouncement?: unknown;
+  loadingPlacement?: LoadingPlacement;
+  onclick?: (event: MouseEvent) => void;
+  size?: ButtonSize;
+  type?: 'button' | 'submit' | 'reset';
+  variant?: ButtonVariant;
+  class?: string;
+}
+
+export interface LinkProps {
+  href: string;
+  onclick?: (event: MouseEvent) => void;
+  onnavigate?: ResponsiveLinkNavigateHandler;
+  rel?: string;
+  sameOriginBaseHref?: string | URL;
+  shouldHandleUrl?: (url: URL, anchor: HTMLAnchorElement | null) => boolean;
+  target?: string;
+  window?: Window;
+  class?: string;
+}
+
+export const AsyncStateBoundary: Component<AsyncStateBoundaryProps>;
+export const Button: Component<ButtonProps>;
+export const Link: Component<LinkProps>;
+export const LoadingState: Component<LoadingStateProps>;
+export const Skeleton: Component<SkeletonProps>;
+export const Spinner: Component<SpinnerProps>;
+
+export type {
+  AsyncViewStateStatus,
+  ButtonSize,
+  ButtonVariant,
+  LoadingPlacement,
+  LoadingStateSize,
+  ResponsiveLinkNavigateHandler,
+  ResponsiveLinkNavigationIntent,
+  SkeletonAnimation,
+  SkeletonHeightPreset,
+  SkeletonVariant,
+  SkeletonWidthPreset,
+  SpinnerSize,
+  SpinnerTone,
+} from '../../responsive-primitives/index.js';

--- a/ts/src/svelte/responsive-primitives/index.ts
+++ b/ts/src/svelte/responsive-primitives/index.ts
@@ -1,0 +1,22 @@
+export { default as AsyncStateBoundary } from './AsyncStateBoundary.svelte';
+export { default as Button } from './Button.svelte';
+export { default as Link } from './Link.svelte';
+export { default as LoadingState } from './LoadingState.svelte';
+export { default as Skeleton } from './Skeleton.svelte';
+export { default as Spinner } from './Spinner.svelte';
+
+export type {
+  AsyncViewStateStatus,
+  ButtonSize,
+  ButtonVariant,
+  LoadingPlacement,
+  LoadingStateSize,
+  ResponsiveLinkNavigateHandler,
+  ResponsiveLinkNavigationIntent,
+  SkeletonAnimation,
+  SkeletonHeightPreset,
+  SkeletonVariant,
+  SkeletonWidthPreset,
+  SpinnerSize,
+  SpinnerTone,
+} from '../../responsive-primitives/index.js';

--- a/ts/src/vue/responsive-primitives/index.ts
+++ b/ts/src/vue/responsive-primitives/index.ts
@@ -1,0 +1,484 @@
+import { Fragment, defineComponent, h } from 'vue';
+import type { PropType, VNodeChild } from 'vue';
+
+import {
+  buttonClassName,
+  classifyResponsiveLinkClick,
+  forcedSafeLinkRel,
+  handleResponsiveLinkClick,
+  loadingStateClassName,
+  normalizeAsyncViewState,
+  skeletonClassName,
+  spinnerClassName,
+  spinnerSvgSize,
+  suppressButtonActivation,
+  type AsyncViewStateStatus,
+  type ButtonSize,
+  type ButtonVariant,
+  type LoadingPlacement,
+  type LoadingStateSize,
+  type ResponsiveLinkNavigateHandler,
+  type SkeletonAnimation,
+  type SkeletonHeightPreset,
+  type SkeletonVariant,
+  type SkeletonWidthPreset,
+  type SpinnerSize,
+  type SpinnerTone,
+} from '../../responsive-primitives/index.js';
+
+function slotContent(value: VNodeChild | undefined): VNodeChild[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeClassValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function splitAttrs(attrs: Record<string, unknown>): {
+  attrClass: unknown;
+  onClick: unknown;
+  rest: Record<string, unknown>;
+} {
+  const { class: attrClass, onClick, ...rest } = attrs;
+  return { attrClass, onClick, rest };
+}
+
+function callVueHandler(handler: unknown, event: Event): void {
+  if (Array.isArray(handler)) {
+    for (const item of handler) callVueHandler(item, event);
+    return;
+  }
+  if (typeof handler === 'function') {
+    (handler as (event: Event) => void)(event);
+  }
+}
+
+export const Spinner = defineComponent({
+  name: 'FaceTheoryResponsiveSpinner',
+  inheritAttrs: false,
+  props: {
+    label: { type: String, default: 'Loading' },
+    size: { type: String as PropType<SpinnerSize>, default: 'md' },
+    tone: { type: String as PropType<SpinnerTone>, default: 'primary' },
+  },
+  setup(props, { attrs }) {
+    return () => {
+      const { attrClass, rest } = splitAttrs(attrs);
+      const pixelSize = spinnerSvgSize(props.size);
+      return h(
+        'span',
+        {
+          ...rest,
+          class: [
+            spinnerClassName({
+              className: normalizeClassValue(attrClass),
+              size: props.size,
+              tone: props.tone,
+            }),
+            typeof attrClass === 'string' ? undefined : attrClass,
+          ],
+          role: 'status',
+          'aria-label': props.label,
+          'data-size': props.size,
+          'data-tone': props.tone,
+        },
+        [
+          h(
+            'svg',
+            {
+              class: 'facetheory-rcp-spinner__glyph',
+              width: pixelSize,
+              height: pixelSize,
+              viewBox: '0 0 24 24',
+              fill: 'none',
+              stroke: 'currentColor',
+              'stroke-width': 2,
+              'stroke-linecap': 'round',
+              'stroke-linejoin': 'round',
+              'aria-hidden': true,
+              focusable: false,
+            },
+            [h('path', { d: 'M21 12a9 9 0 1 1-6.219-8.56' })],
+          ),
+          h('span', { class: 'facetheory-rcp-visually-hidden' }, props.label),
+        ],
+      );
+    };
+  },
+});
+
+export const Skeleton = defineComponent({
+  name: 'FaceTheoryResponsiveSkeleton',
+  inheritAttrs: false,
+  props: {
+    animation: {
+      type: String as PropType<SkeletonAnimation>,
+      default: 'pulse',
+    },
+    decorative: { type: Boolean, default: true },
+    height: { type: String as PropType<SkeletonHeightPreset>, required: false },
+    loading: { type: Boolean, default: true },
+    variant: { type: String as PropType<SkeletonVariant>, default: 'text' },
+    width: { type: String as PropType<SkeletonWidthPreset>, required: false },
+  },
+  setup(props, { attrs, slots }) {
+    return () => {
+      if (!props.loading) {
+        return h(Fragment, null, slots.default?.() ?? []);
+      }
+
+      const { attrClass, rest } = splitAttrs(attrs);
+      const a11yProps = props.decorative
+        ? { 'aria-hidden': true }
+        : {
+            role: typeof rest.role === 'string' ? rest.role : 'status',
+            'aria-label':
+              typeof rest['aria-label'] === 'string'
+                ? rest['aria-label']
+                : 'Loading',
+          };
+
+      return h('div', {
+        ...rest,
+        ...a11yProps,
+        class: [
+          skeletonClassName({
+            animation: props.animation,
+            className: normalizeClassValue(attrClass),
+            decorative: props.decorative,
+            height: props.height,
+            loading: props.loading,
+            variant: props.variant,
+            width: props.width,
+          }),
+          typeof attrClass === 'string' ? undefined : attrClass,
+        ],
+        'data-animation': props.animation,
+        'data-loading': 'true',
+      });
+    };
+  },
+});
+
+export const LoadingState = defineComponent({
+  name: 'FaceTheoryResponsiveLoadingState',
+  inheritAttrs: false,
+  props: {
+    fullscreen: { type: Boolean, default: false },
+    label: { type: String, default: 'Loading' },
+    message: { type: null as unknown as PropType<VNodeChild>, required: false },
+    size: { type: String as PropType<LoadingStateSize>, default: 'md' },
+  },
+  setup(props, { attrs, slots }) {
+    return () => {
+      const { attrClass, rest } = splitAttrs(attrs);
+      const spinnerSlot = slots.spinner?.();
+      const defaultSlot = slots.default?.();
+      const message = slots.message?.() ?? slotContent(props.message);
+
+      return h(
+        'div',
+        {
+          ...rest,
+          class: [
+            loadingStateClassName({
+              className: normalizeClassValue(attrClass),
+              fullscreen: props.fullscreen,
+              label: props.label,
+              size: props.size,
+            }),
+            typeof attrClass === 'string' ? undefined : attrClass,
+          ],
+          role: 'status',
+          'aria-live': 'polite',
+          'aria-busy': true,
+          'data-fullscreen': props.fullscreen ? 'true' : undefined,
+        },
+        [
+          h('div', { class: 'facetheory-rcp-loading-state__content' }, [
+            ...(defaultSlot ??
+              spinnerSlot ?? [
+                h(Spinner, { label: props.label, size: props.size }),
+              ]),
+            message.length > 0
+              ? h(
+                  'p',
+                  { class: 'facetheory-rcp-loading-state__message' },
+                  message,
+                )
+              : null,
+          ]),
+        ],
+      );
+    };
+  },
+});
+
+export const AsyncStateBoundary = defineComponent({
+  name: 'FaceTheoryResponsiveAsyncStateBoundary',
+  inheritAttrs: false,
+  props: {
+    errorValue: { type: null as unknown as PropType<unknown>, required: false },
+    loadingMessage: { type: String, required: false },
+    state: {
+      type: String as PropType<AsyncViewStateStatus>,
+      required: true,
+    },
+  },
+  setup(props, { attrs, slots }) {
+    return () => {
+      const { attrClass, rest } = splitAttrs(attrs);
+      const descriptor = normalizeAsyncViewState({
+        error: props.errorValue,
+        loadingMessage: props.loadingMessage,
+        status: props.state,
+      });
+
+      let content: VNodeChild[];
+      if (descriptor.status === 'loading') {
+        content = slots.loading?.() ?? [
+          h(LoadingState, { message: descriptor.loadingMessage ?? 'Loading…' }),
+        ];
+      } else if (descriptor.status === 'idle') {
+        content = slots.idle?.() ?? [];
+      } else if (descriptor.status === 'empty') {
+        content = slots.empty?.() ?? [];
+      } else if (descriptor.status === 'error') {
+        content = slots.error?.({ error: descriptor.error }) ?? [
+          'Something went wrong.',
+        ];
+      } else {
+        content = slots.default?.() ?? [];
+      }
+
+      return h(
+        'section',
+        {
+          ...rest,
+          class: ['facetheory-rcp-async-boundary', attrClass],
+          'data-state': descriptor.status,
+          'aria-busy': descriptor.ariaBusy,
+          'aria-live': descriptor.status === 'loading' ? 'polite' : undefined,
+          role: descriptor.status === 'error' ? 'alert' : rest.role,
+        },
+        content,
+      );
+    };
+  },
+});
+
+export const Button = defineComponent({
+  name: 'FaceTheoryResponsiveButton',
+  inheritAttrs: false,
+  props: {
+    disabled: { type: Boolean, default: false },
+    loading: { type: Boolean, default: false },
+    loadingAnnouncement: { type: String, default: 'Loading' },
+    loadingPlacement: {
+      type: String as PropType<LoadingPlacement>,
+      default: 'replace-prefix',
+    },
+    size: { type: String as PropType<ButtonSize>, default: 'md' },
+    type: {
+      type: String as PropType<'button' | 'submit' | 'reset'>,
+      default: 'button',
+    },
+    variant: { type: String as PropType<ButtonVariant>, default: 'primary' },
+  },
+  setup(props, { attrs, slots }) {
+    return () => {
+      const { attrClass, onClick, rest } = splitAttrs(attrs);
+      const blocked = props.disabled || props.loading;
+      const spinner = slots.spinner?.() ?? [
+        h(Spinner, {
+          label: 'Loading',
+          size: props.size === 'lg' ? 'sm' : 'xs',
+          tone: 'current',
+        }),
+      ];
+
+      const handleClick = (event: MouseEvent): void => {
+        if (blocked) {
+          suppressButtonActivation(event);
+          return;
+        }
+        callVueHandler(onClick, event);
+      };
+
+      return h(
+        'button',
+        {
+          ...rest,
+          type: props.type,
+          class: [
+            buttonClassName({
+              className: normalizeClassValue(attrClass),
+              disabled: props.disabled,
+              loading: props.loading,
+              loadingPlacement: props.loadingPlacement,
+              size: props.size,
+              variant: props.variant,
+            }),
+            typeof attrClass === 'string' ? undefined : attrClass,
+          ],
+          disabled: blocked,
+          'aria-disabled': blocked,
+          'aria-busy': props.loading ? true : undefined,
+          'data-loading': props.loading ? 'true' : undefined,
+          onClick: handleClick,
+        },
+        [
+          props.loading && props.loadingPlacement === 'prepend'
+            ? h(
+                'span',
+                {
+                  class:
+                    'facetheory-rcp-button__spinner facetheory-rcp-button__spinner--prepend',
+                  'aria-hidden': true,
+                },
+                spinner,
+              )
+            : null,
+          props.loading && props.loadingPlacement === 'replace-prefix'
+            ? h(
+                'span',
+                {
+                  class:
+                    'facetheory-rcp-button__spinner facetheory-rcp-button__spinner--prefix',
+                  'aria-hidden': true,
+                },
+                spinner,
+              )
+            : slots.prefix
+              ? h(
+                  'span',
+                  { class: 'facetheory-rcp-button__prefix' },
+                  slots.prefix(),
+                )
+              : null,
+          h(
+            'span',
+            { class: 'facetheory-rcp-button__content' },
+            slots.default?.(),
+          ),
+          props.loading && props.loadingPlacement === 'append'
+            ? h(
+                'span',
+                {
+                  class:
+                    'facetheory-rcp-button__spinner facetheory-rcp-button__spinner--append',
+                  'aria-hidden': true,
+                },
+                spinner,
+              )
+            : slots.suffix
+              ? h(
+                  'span',
+                  { class: 'facetheory-rcp-button__suffix' },
+                  slots.suffix(),
+                )
+              : null,
+          props.loading
+            ? h(
+                'span',
+                {
+                  class: 'facetheory-rcp-visually-hidden',
+                  role: 'status',
+                  'aria-live': 'polite',
+                },
+                props.loadingAnnouncement,
+              )
+            : null,
+        ],
+      );
+    };
+  },
+});
+
+export const Link = defineComponent({
+  name: 'FaceTheoryResponsiveLink',
+  inheritAttrs: false,
+  props: {
+    href: { type: String, required: true },
+    onnavigate: {
+      type: Function as PropType<ResponsiveLinkNavigateHandler>,
+      required: false,
+    },
+    rel: { type: String, required: false },
+    sameOriginBaseHref: {
+      type: [String, URL] as PropType<string | URL>,
+      required: false,
+    },
+    shouldHandleUrl: {
+      type: Function as PropType<
+        (url: URL, anchor: HTMLAnchorElement | null) => boolean
+      >,
+      required: false,
+    },
+    target: { type: String, required: false },
+    window: { type: Object as PropType<Window>, required: false },
+  },
+  setup(props, { attrs, slots }) {
+    return () => {
+      const { attrClass, onClick, rest } = splitAttrs(attrs);
+      const safeRel = forcedSafeLinkRel({
+        href: props.href,
+        rel: props.rel,
+        sameOriginBaseHref: props.sameOriginBaseHref,
+        target: props.target,
+      });
+
+      const handleClick = (event: MouseEvent): void => {
+        callVueHandler(onClick, event);
+        if (event.defaultPrevented) return;
+        if (props.onnavigate === undefined) return;
+
+        const classifierOptions = responsiveLinkClassifierOptions(
+          props.shouldHandleUrl,
+          props.window,
+        );
+        const intent = classifyResponsiveLinkClick(event, classifierOptions);
+        if (!intent) return;
+
+        handleResponsiveLinkClick(event, {
+          ...classifierOptions,
+          onNavigate: props.onnavigate,
+        });
+      };
+
+      return h(
+        'a',
+        {
+          ...rest,
+          class: ['facetheory-rcp-link', attrClass],
+          href: props.href,
+          onClick: handleClick,
+          rel: safeRel,
+          target: props.target,
+        },
+        slots.default?.(),
+      );
+    };
+  },
+});
+
+export type { AsyncViewStateStatus, LoadingPlacement };
+
+function responsiveLinkClassifierOptions(
+  shouldHandleUrl:
+    | ((url: URL, anchor: HTMLAnchorElement | null) => boolean)
+    | undefined,
+  windowValue: Window | undefined,
+): {
+  shouldHandleUrl?: (url: URL, anchor: HTMLAnchorElement | null) => boolean;
+  window?: Window;
+} {
+  const options: {
+    shouldHandleUrl?: (url: URL, anchor: HTMLAnchorElement | null) => boolean;
+    window?: Window;
+  } = {};
+  if (shouldHandleUrl !== undefined) options.shouldHandleUrl = shouldHandleUrl;
+  if (windowValue !== undefined) options.window = windowValue;
+  return options;
+}

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -9,6 +9,7 @@ await import('./unit/ssr-hydration.test.js');
 await import('./unit/ops.test.js');
 await import('./unit/oac-form.test.js');
 await import('./unit/navigation-pending.test.js');
+await import('./unit/responsive-primitives.test.js');
 await import('./unit/strict-csp-harness.test.js');
 await import('./unit/lambda-url.test.js');
 await import('./unit/aws-s3.test.js');

--- a/ts/test/unit/responsive-primitives.test.ts
+++ b/ts/test/unit/responsive-primitives.test.ts
@@ -1,0 +1,410 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { compile } from 'svelte/compiler';
+
+import { createFaceApp } from '../../src/app.js';
+import { createReactFace } from '../../src/adapters/react.js';
+import {
+  AsyncStateBoundary as ReactAsyncStateBoundary,
+  Button as ReactButton,
+  Link as ReactLink,
+  LoadingState as ReactLoadingState,
+  Skeleton as ReactSkeleton,
+  Spinner as ReactSpinner,
+} from '../../src/react/responsive-primitives/index.js';
+import {
+  FACE_NAVIGATION_CLASSIFIER_SOURCE,
+  classifyFaceNavigationAnchorClick,
+} from '../../src/spa.js';
+import { createSvelteFace } from '../../src/svelte/index.js';
+import {
+  RESPONSIVE_PRIMITIVE_CONTRACTS,
+  RESPONSIVE_PRIMITIVES_CSS,
+  RESPONSIVE_LINK_CLASSIFIER_SOURCE,
+  forcedSafeLinkRel,
+  handleResponsiveLinkClick,
+  suppressButtonActivation,
+} from '../../src/responsive-primitives/index.js';
+import type { ResponsivePrimitiveName } from '../../src/responsive-primitives/index.js';
+import { createVueFace, h } from '../../src/vue/index.js';
+import {
+  AsyncStateBoundary as VueAsyncStateBoundary,
+  Button as VueButton,
+  Link as VueLink,
+  LoadingState as VueLoadingState,
+  Skeleton as VueSkeleton,
+  Spinner as VueSpinner,
+} from '../../src/vue/responsive-primitives/index.js';
+
+async function renderReactResponsive(): Promise<string> {
+  const app = createFaceApp({
+    faces: [
+      createReactFace({
+        route: '/',
+        mode: 'ssr',
+        render: () =>
+          React.createElement('main', null, [
+            React.createElement(ReactSpinner, {
+              key: 'spinner',
+              label: 'Loading accounts',
+              size: 'sm',
+            }),
+            React.createElement(ReactSkeleton, {
+              key: 'skeleton',
+              width: 'half',
+              height: 'lg',
+            }),
+            React.createElement(
+              ReactSkeleton,
+              { key: 'gated', loading: false },
+              React.createElement('strong', null, 'Loaded child'),
+            ),
+            React.createElement(ReactLoadingState, {
+              key: 'loading',
+              message: 'Loading fleet',
+              fullscreen: true,
+            }),
+            React.createElement(ReactAsyncStateBoundary, {
+              key: 'boundary',
+              state: 'empty',
+              empty: React.createElement('p', null, 'No records'),
+            }),
+            React.createElement(
+              ReactButton,
+              {
+                key: 'button',
+                loading: true,
+                loadingPlacement: 'append',
+              },
+              'Save',
+            ),
+            React.createElement(
+              ReactLink,
+              {
+                key: 'link',
+                href: 'https://example.com/docs',
+                target: '_blank',
+              },
+              'Docs',
+            ),
+          ]),
+      }),
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  return new TextDecoder().decode(resp.body as Uint8Array);
+}
+
+async function renderVueResponsive(): Promise<string> {
+  const app = createFaceApp({
+    faces: [
+      createVueFace({
+        route: '/',
+        mode: 'ssr',
+        render: () =>
+          h('main', null, [
+            h(VueSpinner, { label: 'Loading accounts', size: 'sm' }),
+            h(VueSkeleton, { width: 'half', height: 'lg' }),
+            h(
+              VueSkeleton,
+              { loading: false },
+              { default: () => h('strong', null, 'Loaded child') },
+            ),
+            h(VueLoadingState, { message: 'Loading fleet', fullscreen: true }),
+            h(
+              VueAsyncStateBoundary,
+              { state: 'empty' },
+              { empty: () => h('p', null, 'No records') },
+            ),
+            h(
+              VueButton,
+              { loading: true, loadingPlacement: 'append' },
+              { default: () => 'Save' },
+            ),
+            h(
+              VueLink,
+              { href: 'https://example.com/docs', target: '_blank' },
+              { default: () => 'Docs' },
+            ),
+          ]),
+      }),
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  return new TextDecoder().decode(resp.body as Uint8Array);
+}
+
+async function renderSvelteComponent(
+  componentName: string,
+  props: Record<string, unknown>,
+): Promise<string> {
+  const componentPath = path.resolve(
+    'src/svelte/responsive-primitives',
+    `${componentName}.svelte`,
+  );
+  const source = await readFile(componentPath, 'utf8');
+  const compiled = compile(source, {
+    generate: 'server',
+    filename: path.basename(componentPath),
+  } as never);
+
+  const dir = path.resolve('.tmp-facetheory-svelte-responsive-primitives');
+  await mkdir(dir, { recursive: true });
+  const coreUrl = pathToFileURL(
+    path.resolve('src/responsive-primitives/index.ts'),
+  ).href;
+  const rewrittenCode = compiled.js.code.replace(
+    /from\s+(['"])\.\.\/\.\.\/responsive-primitives\/index\.js\1/g,
+    `from "${coreUrl}"`,
+  );
+  const file = path.join(
+    dir,
+    `${componentName}-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.mjs`,
+  );
+  await writeFile(file, rewrittenCode, 'utf8');
+
+  try {
+    const mod = await import(pathToFileURL(file).href);
+    const app = createFaceApp({
+      faces: [
+        createSvelteFace({
+          route: '/',
+          mode: 'ssr',
+          render: () => ({ component: mod.default as unknown, props }),
+        }),
+      ],
+    });
+    const resp = await app.handle({ method: 'GET', path: '/' });
+    return new TextDecoder().decode(resp.body as Uint8Array);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('responsive primitives: contract declares neutral/react/vue/svelte parity and reduced-motion CSS', () => {
+  const expected: ResponsivePrimitiveName[] = [
+    'Spinner',
+    'Skeleton',
+    'LoadingState',
+    'AsyncStateBoundary',
+    'Button',
+    'Link',
+  ];
+  assert.deepEqual(
+    RESPONSIVE_PRIMITIVE_CONTRACTS.map((contract) => contract.primitive),
+    expected,
+  );
+
+  for (const contract of RESPONSIVE_PRIMITIVE_CONTRACTS) {
+    assert.equal(contract.frameworks.neutral, true, contract.primitive);
+    assert.equal(contract.frameworks.react, true, contract.primitive);
+    assert.equal(contract.frameworks.vue, true, contract.primitive);
+    assert.equal(contract.frameworks.svelte, true, contract.primitive);
+  }
+
+  assert.equal(
+    RESPONSIVE_LINK_CLASSIFIER_SOURCE,
+    FACE_NAVIGATION_CLASSIFIER_SOURCE,
+  );
+  assert.match(RESPONSIVE_PRIMITIVES_CSS, /prefers-reduced-motion:\s*reduce/);
+  assert.match(
+    RESPONSIVE_PRIMITIVES_CSS,
+    /facetheory-rcp-skeleton--width-half/,
+  );
+  assert.match(RESPONSIVE_PRIMITIVES_CSS, /facetheory-rcp-skeleton--height-lg/);
+});
+
+test('responsive primitives: React adapter renders a11y contract without inline style', async () => {
+  const body = await renderReactResponsive();
+  assert.match(body, /facetheory-rcp-spinner/);
+  assert.match(body, /role="status"/);
+  assert.match(body, /aria-label="Loading accounts"/);
+  assert.match(body, /facetheory-rcp-skeleton--width-half/);
+  assert.match(body, /facetheory-rcp-skeleton--height-lg/);
+  assert.match(body, /aria-hidden="true"/);
+  assert.match(body, /Loaded child/);
+  assert.match(body, /aria-live="polite"/);
+  assert.match(body, /aria-busy="true"/);
+  assert.match(body, /facetheory-rcp-loading-state--fullscreen/);
+  assert.match(body, /facetheory-rcp-button__spinner--append/);
+  assert.match(body, /role="status" aria-live="polite">Loading/);
+  assert.match(body, /rel="noopener noreferrer"/);
+  assert.doesNotMatch(body, /style="/);
+});
+
+test('responsive primitives: Vue adapter renders parity a11y contract without inline style', async () => {
+  const body = await renderVueResponsive();
+  assert.match(body, /facetheory-rcp-spinner/);
+  assert.match(body, /role="status"/);
+  assert.match(body, /aria-label="Loading accounts"/);
+  assert.match(body, /facetheory-rcp-skeleton--width-half/);
+  assert.match(body, /facetheory-rcp-skeleton--height-lg/);
+  assert.match(body, /aria-hidden="true"/);
+  assert.match(body, /Loaded child/);
+  assert.match(body, /aria-live="polite"/);
+  assert.match(body, /aria-busy="true"/);
+  assert.match(body, /facetheory-rcp-loading-state--fullscreen/);
+  assert.match(body, /facetheory-rcp-button__spinner--append/);
+  assert.match(body, /role="status" aria-live="polite">Loading/);
+  assert.match(body, /rel="noopener noreferrer"/);
+  assert.doesNotMatch(body, /style="/);
+});
+
+test('responsive primitives: Svelte adapter renders parity a11y contract without inline style', async () => {
+  const spinner = await renderSvelteComponent('Spinner', {
+    label: 'Loading accounts',
+    size: 'sm',
+  });
+  assert.match(spinner, /facetheory-rcp-spinner/);
+  assert.match(spinner, /role="status"/);
+  assert.match(spinner, /aria-label="Loading accounts"/);
+
+  const skeleton = await renderSvelteComponent('Skeleton', {
+    height: 'lg',
+    width: 'half',
+  });
+  assert.match(skeleton, /facetheory-rcp-skeleton--width-half/);
+  assert.match(skeleton, /facetheory-rcp-skeleton--height-lg/);
+  assert.match(skeleton, /aria-hidden="true"/);
+
+  const loading = await renderSvelteComponent('LoadingState', {
+    fullscreen: true,
+    message: 'Loading fleet',
+  });
+  assert.match(loading, /aria-live="polite"/);
+  assert.match(loading, /aria-busy="true"/);
+  assert.match(loading, /Loading fleet/);
+  assert.match(loading, /facetheory-rcp-loading-state--fullscreen/);
+
+  const boundary = await renderSvelteComponent('AsyncStateBoundary', {
+    loadingMessage: 'Loading boundary',
+    state: 'loading',
+  });
+  assert.match(boundary, /data-state="loading"/);
+  assert.match(boundary, /Loading boundary/);
+
+  const button = await renderSvelteComponent('Button', {
+    loading: true,
+    loadingPlacement: 'append',
+  });
+  assert.match(button, /aria-busy="true"/);
+  assert.match(button, /disabled/);
+  assert.match(button, /facetheory-rcp-button__spinner--append/);
+  assert.match(button, /role="status" aria-live="polite">Loading/);
+
+  const link = await renderSvelteComponent('Link', {
+    href: 'https://example.com/docs',
+    target: '_blank',
+  });
+  assert.match(link, /<a/);
+  assert.match(link, /href="https:\/\/example.com\/docs"/);
+  assert.match(link, /rel="noopener noreferrer"/);
+
+  for (const html of [spinner, skeleton, loading, boundary, button, link]) {
+    assert.doesNotMatch(html, /style="/);
+  }
+});
+
+test('responsive primitives: Link helper reuses shared classifier and only intercepts accepted clicks', () => {
+  const dom = new JSDOM(
+    '<a href="/next">Next</a><a id="external" href="https://other.example/">Other</a>',
+    {
+      url: 'https://app.example/current',
+    },
+  );
+  const win = dom.window as unknown as Window;
+  const anchor = dom.window.document.querySelector('a') as HTMLAnchorElement;
+  const external = dom.window.document.getElementById(
+    'external',
+  ) as HTMLAnchorElement;
+
+  const unboundClick = new dom.window.MouseEvent('click', {
+    bubbles: true,
+    button: 0,
+    cancelable: true,
+  });
+  const classified = classifyFaceNavigationAnchorClick(unboundClick, {
+    window: win,
+  });
+  assert.equal(classified, null, 'classifier requires the event target path');
+
+  let navigated = false;
+  anchor.addEventListener('click', (event) => {
+    const intent = handleResponsiveLinkClick(event, {
+      window: win,
+      onNavigate: (nextIntent) => {
+        navigated = true;
+        assert.equal(
+          nextIntent.classifierSource,
+          FACE_NAVIGATION_CLASSIFIER_SOURCE,
+        );
+        assert.equal(nextIntent.url.pathname, '/next');
+      },
+    });
+    assert.equal(intent?.classifierSource, FACE_NAVIGATION_CLASSIFIER_SOURCE);
+  });
+  const plainClick = new dom.window.MouseEvent('click', {
+    bubbles: true,
+    button: 0,
+    cancelable: true,
+  });
+  assert.equal(anchor.dispatchEvent(plainClick), false);
+  assert.equal(navigated, true);
+  assert.equal(plainClick.defaultPrevented, true);
+
+  let externalNavigated = false;
+  external.addEventListener('click', (event) => {
+    const intent = handleResponsiveLinkClick(event, {
+      window: win,
+      onNavigate: () => {
+        externalNavigated = true;
+      },
+    });
+    assert.equal(intent, null);
+    assert.equal(event.defaultPrevented, false);
+    event.preventDefault();
+  });
+  const externalClick = new dom.window.MouseEvent('click', {
+    bubbles: true,
+    button: 0,
+    cancelable: true,
+  });
+  assert.equal(external.dispatchEvent(externalClick), false);
+  assert.equal(externalNavigated, false);
+});
+
+test('responsive primitives: Button suppression and Link rel helpers are deterministic', () => {
+  let prevented = false;
+  let stopped = false;
+  const event = {
+    preventDefault: () => {
+      prevented = true;
+    },
+    stopPropagation: () => {
+      stopped = true;
+    },
+  };
+
+  suppressButtonActivation(event);
+  assert.equal(prevented, true);
+  assert.equal(stopped, true);
+
+  assert.equal(
+    forcedSafeLinkRel({
+      href: 'https://example.com',
+      rel: 'ugc',
+      target: '_blank',
+    }),
+    'ugc noopener noreferrer',
+  );
+  assert.equal(forcedSafeLinkRel({ href: '/local' }), undefined);
+});


### PR DESCRIPTION
## Milestone
RCP-M3 — Tier B responsive primitives for the Responsive Control Plane contract.

## Linear
THE-1784 — https://linear.app/theorycloud/issue/THE-1784

## Placement decision (D2)
Placed the Tier B vocabulary in a new framework-neutral `ts/src/responsive-primitives/` surface with adapter peers at `ts/src/react/responsive-primitives/`, `ts/src/vue/responsive-primitives/`, and `ts/src/svelte/responsive-primitives/`.

Reason: FaceTheory is not a general design system and `stitch-*` remains a narrow Theory Cloud UI/Stitch surface. These primitives are a responsive-control-plane interaction vocabulary, so they get their own neutral core + per-framework adapter subpaths without putting framework-specific logic in the core or making adapters depend on each other.

## Render modes and adapters affected
- Render modes: additive component/export surface only; no SSR/SSG/ISR/SPA pipeline changes.
- Adapters: React, Vue, Svelte parity for Spinner, Skeleton, LoadingState, AsyncStateBoundary, Button, and Link.
- Core: framework-neutral contracts, CSS class/token surface, Link rel/navigation helpers reusing the shared `spa.ts` classifier.

## Determinism impact
Preserves the FaceTheory rendering contract: primitives emit deterministic markup, no render-time randomness/time reads, no inline `style` attributes for the responsive primitives, preset skeleton size tokens only, and Link classification delegates to `classifyFaceNavigationAnchorClick` / `FACE_NAVIGATION_CLASSIFIER_SOURCE` rather than forking navigation rules.

## Backward compatibility
Additive. New package export subpaths only:
- `./responsive-primitives`
- `./react/responsive-primitives`
- `./vue/responsive-primitives`
- `./svelte/responsive-primitives`

## Per-primitive confirmation
- [x] Spinner — neutral contract + React/Vue/Svelte; `role="status"`; CSS `prefers-reduced-motion` branch disables spin.
- [x] Skeleton — neutral contract + React/Vue/Svelte; decorative `aria-hidden` default; children gated when `loading`; preset width/height classes only; reduced-motion branch disables pulse/wave.
- [x] LoadingState — neutral contract + React/Vue/Svelte; `role="status"`, `aria-live="polite"`, `aria-busy`; spinner/message; fullscreen overlay class; reduced-motion overlay branch.
- [x] AsyncStateBoundary — neutral contract + React/Vue/Svelte composition over LoadingState for `idle | loading | empty | error | success`.
- [x] Button — neutral contract + React/Vue/Svelte; loading sets `aria-busy`, disabled/aria-disabled, handler-level activation suppression, spinner placement (`replace-prefix | prepend | append`), visually-hidden status announcement.
- [x] Link — neutral contract + React/Vue/Svelte; always renders `<a href>`; intercepts only classifier-accepted plain left clicks; React `onNavigate`, Vue/Svelte `onnavigate`; veto support; forces `rel="noopener noreferrer"` for external/`target=_blank`.

## Tasks
- [x] Implement neutral responsive primitive contracts/helpers/CSS vocabulary.
- [x] Implement React adapter parity.
- [x] Implement Vue adapter parity.
- [x] Implement Svelte adapter parity.
- [x] Add package export subpaths.
- [x] Add parity/a11y/reduced-motion tests.
- [x] Add per-framework responsive primitive examples.

## Validation
- `cd ts && npm ci && npm run typecheck && npm test && npm run lint`
  - PASS: `npm ci` added/audited 430 packages; 0 vulnerabilities.
  - PASS: typecheck.
  - PASS: tests — 557 tests, 556 pass, 0 fail, 1 skipped.
  - PASS: lint.
- `bash scripts/verify-version-alignment.sh`
  - PASS: `version-alignment: PASS (3.5.0)`.
- `make rubric`
  - PASS, including typecheck, lint, tests, version alignment, pack/audit/go-version/release-readiness checks.
- `cd ts && npm run build`
  - PASS.
- `cd ts && npm run example:responsive:react && npm run example:responsive:vue && npm run example:responsive:svelte`
  - PASS: React bytes=8907; Vue bytes=8918; Svelte bytes=10287.

## Cross-repo coordination
No sibling-repo edits. Downstream consumers can adopt after a FaceTheory release that includes these new export subpaths.

## Memory / tooling note
`memory_recent` / `memory_append` and `facetheory_lab` GitHub MCP tools were not exposed in this session after tool discovery, so I used local git plus the generic GitHub connector for the PR.