### PR TITLE
fix(deps): align FaceTheory upstream release pins

### DIFF
--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -11,6 +11,29 @@ This file records the currently pinned versions and the exact install strings we
 - AppTheory (CDK): `v1.12.2`
 - TableTheory (TypeScript): `v1.9.4`
 
+## Compatibility Impact
+
+The AppTheory `v1.12.2` runtime/CDK pins and the TableTheory `v1.9.4` TypeScript pin are a coordinated
+FaceTheory compatibility baseline:
+
+- the AppTheory runtime pin keeps Lambda URL streaming and AppTheory integration examples on the same upstream release
+  line as the deployed reference stacks;
+- the AppTheory CDK pin keeps the SSR and SSG/ISR infrastructure examples aligned with the runtime tarball they deploy;
+- the TableTheory pin keeps ISR cache-entry and regeneration-lease examples on the TableTheory release line FaceTheory
+  validates through the package override below.
+
+Treat future upstream pin moves as dependency compatibility fixes, not release-process bookkeeping. FaceTheory consumers
+install immutable GitHub Release tarballs, so a changed upstream baseline needs a normal RC for review before stable
+promotion.
+
+## Release Watchpoint
+
+A `staging` -> `premain` PR is always RC intent. If upstream pin maintenance reaches `staging` without a
+release-please-eligible `feat:`, `fix:`, or `perf:` commit, `scripts/verify-release-readiness.sh origin/premain
+origin/staging prerelease` must fail rather than silently letting Release Please skip the RC. Do not recover with
+manual tags, manual GitHub Releases, or `Release-As` footers; land a small, truthful compatibility change on `staging`
+and keep the single release lane intact.
+
 ## Release Asset SHA-256
 
 - AppTheory runtime tarball: `86fd1da349ca5aaacba3cbe785f552c6d00d037a0dfb88ecbfd2ff9319e2fd06`


### PR DESCRIPTION
## Summary
- Documents the AppTheory v1.12.2 / TableTheory v1.9.4 compatibility impact behind the upstream pin alignment already on staging.
- Adds the release-train watchpoint that upstream pin maintenance must stay release-please-eligible before staging -> premain RC promotion.
- Preserves the single lane; no versions, manifests, tags, generated changelogs, or package pins changed.

## Validation
- `scripts/verify-release-readiness.sh origin/premain HEAD prerelease`
- `scripts/verify-ci-rubric-enforced.sh`
- `scripts/verify-version-alignment.sh`
- `git diff --check`
- `git diff --check origin/staging...HEAD`
- checked the commit body has no `Release-As:` footer

## Release note
This is a dependency compatibility fix so the next staging -> premain promotion has a real Release Please signal and does not silently skip the intended RC.