### PR TITLE
Premain

### DIFF
--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -76,6 +76,13 @@ jobs:
           manifest-file: .release-please-manifest.premain.json
           skip-github-release: true
 
+      - name: Checkout protected premain verifier code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'premain' || github.sha }}
+
       - name: Verify generated RC release PR postcondition
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -133,6 +133,13 @@ jobs:
           manifest-file: .release-please-manifest.json
           skip-github-release: true
 
+      - name: Checkout protected main verifier code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.sha }}
+
       - name: Verify generated stable release PR postcondition
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/verify-ci-rubric-enforced.sh
+++ b/scripts/verify-ci-rubric-enforced.sh
@@ -26,6 +26,99 @@ require_not_contains() {
   fi
 }
 
+require_release_pr_postcondition_checkout() {
+  local workflow="$1"
+  local protected_branch="$2"
+  local channel="$3"
+
+  if ! python3 - "${workflow}" "${protected_branch}" "${channel}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1])
+protected_branch = sys.argv[2]
+channel = sys.argv[3]
+lines = workflow.read_text(encoding="utf-8").splitlines()
+
+job_start = None
+for index, line in enumerate(lines):
+    if line == "  release-please:":
+        job_start = index
+        break
+if job_start is None:
+    raise SystemExit(f"{workflow}: missing release-please job")
+
+job_end = len(lines)
+for index in range(job_start + 1, len(lines)):
+    line = lines[index]
+    if re.match(r"^  [A-Za-z0-9_-]+:\s*$", line):
+        job_end = index
+        break
+
+job_lines = lines[job_start:job_end]
+script = f"scripts/verify-release-pr-postcondition.sh {channel}"
+postcondition_indexes = [
+    index for index, line in enumerate(job_lines) if script in line
+]
+if not postcondition_indexes:
+    raise SystemExit(f"{workflow}: missing postcondition run for {channel}")
+postcondition_index = postcondition_indexes[0]
+
+release_action_indexes = [
+    index
+    for index, line in enumerate(job_lines[:postcondition_index])
+    if "googleapis/release-please-action@" in line
+]
+if not release_action_indexes:
+    raise SystemExit(
+        f"{workflow}: postcondition for {channel} does not follow release-please"
+    )
+last_release_action_index = max(release_action_indexes)
+
+step_starts = [
+    index
+    for index, line in enumerate(job_lines)
+    if re.match(r"^      - name:", line)
+]
+
+expected_ref = (
+    "ref: ${{ github.event_name == 'workflow_dispatch' && '"
+    + protected_branch
+    + "' || github.sha }}"
+)
+for position, start in enumerate(step_starts):
+    if start <= last_release_action_index or start >= postcondition_index:
+        continue
+    end = step_starts[position + 1] if position + 1 < len(step_starts) else len(job_lines)
+    step_text = "\n".join(job_lines[start:end])
+    if "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2" not in step_text:
+        continue
+    missing = [
+        needle
+        for needle in (
+            "persist-credentials: false",
+            expected_ref,
+        )
+        if needle not in step_text
+    ]
+    if missing:
+        raise SystemExit(
+            f"{workflow}: trusted checkout before {channel} postcondition is missing "
+            + ", ".join(missing)
+        )
+    break
+else:
+    raise SystemExit(
+        f"{workflow}: {channel} postcondition can run without a trusted "
+        f"{protected_branch}/github.sha checkout in the release-please job"
+    )
+PY
+  then
+    fail "${workflow} ${channel} postcondition must checkout trusted ${protected_branch} verifier code"
+  fi
+}
+
 ci=".github/workflows/ci.yml"
 
 require_contains "${ci}" "  release-train-promotion:" "CI must define the release train promotion gate"
@@ -65,6 +158,8 @@ require_contains ".github/workflows/prerelease-pr.yml" "scripts/verify-release-p
   "premain release PR generation must fail closed on release-please no-op"
 require_contains ".github/workflows/release-pr.yml" "scripts/verify-release-pr-postcondition.sh stable" \
   "main release PR generation must fail closed on release-please no-op"
+require_release_pr_postcondition_checkout ".github/workflows/prerelease-pr.yml" "premain" "prerelease"
+require_release_pr_postcondition_checkout ".github/workflows/release-pr.yml" "main" "stable"
 
 if grep -R -Fq 'run: scripts/verify-deterministic-builds.sh' .github/workflows/prerelease.yml .github/workflows/release.yml; then
   fail "release workflows must not run deterministic builds"


### PR DESCRIPTION
Promotes staging to premain for the next FaceTheory RC attempt.

Scope:
- carries the release workflow postcondition checkout fix from PR #329
- includes the ancestry-only staging repair from PR #330 so premain remains an ancestor of staging
- no rubric/deterministic build escalation is expected on premain; this lane should run release hygiene/prerelease checks only

Factory preflight:
- verify-release-train-promotion: PASS for staging -> premain
- verify-release-readiness prerelease: PASS

Release invariant:
- every PR to premain is RC intent
- premain must cut/validate the RC path
- main must not create RCs