### PR TITLE
Harden FaceTheory strict CSP surfaces

### DIFF
--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -60,17 +60,16 @@ export interface FaceAppOptions {
   strictCsp?: FaceStrictCspOptions;
 }
 
-export interface FaceSsrHydrationSidecarOptions
-  extends Pick<
-    SsrHydrationSidecarStoreOptions,
-    | 'htmlStore'
-    | 'signingSecret'
-    | 'now'
-    | 'ttlSeconds'
-    | 'keyPrefix'
-    | 'dataUrlPrefix'
-    | 'scope'
-  > {
+export interface FaceSsrHydrationSidecarOptions extends Pick<
+  SsrHydrationSidecarStoreOptions,
+  | 'htmlStore'
+  | 'signingSecret'
+  | 'now'
+  | 'ttlSeconds'
+  | 'keyPrefix'
+  | 'dataUrlPrefix'
+  | 'scope'
+> {
   /**
    * Request-derived variant binding used when writing a sidecar during the
    * HTML render and when reading it through the framework-owned resource
@@ -87,9 +86,7 @@ export interface FaceSsrHydrationSidecarOptions
 
 export type FaceSsrHydrationSidecarVariantCallback = (
   request: Readonly<Required<FaceRequest>>,
-) =>
-  | SsrHydrationSidecarVariantInput
-  | Promise<SsrHydrationSidecarVariantInput>;
+) => SsrHydrationSidecarVariantInput | Promise<SsrHydrationSidecarVariantInput>;
 
 export interface FaceStrictCspOptions {
   /**
@@ -158,9 +155,7 @@ export class FaceApp {
         options.strictCsp?.maxStreamingBodyBytes,
       );
     this.ssrHydrationSidecarRuntime = options.ssrHydrationSidecars
-      ? createFaceAppSsrHydrationSidecarRuntime(
-          options.ssrHydrationSidecars,
-        )
+      ? createFaceAppSsrHydrationSidecarRuntime(options.ssrHydrationSidecars)
       : null;
 
     for (const face of options.faces) {
@@ -173,7 +168,10 @@ export class FaceApp {
     }
 
     const resources = this.ssrHydrationSidecarRuntime
-      ? [...this.ssrHydrationSidecarRuntime.routes, ...(options.resources ?? [])]
+      ? [
+          ...this.ssrHydrationSidecarRuntime.routes,
+          ...(options.resources ?? []),
+        ]
       : (options.resources ?? []);
 
     for (const resource of resources) {
@@ -750,17 +748,6 @@ async function toHTTPResponse(
   }
 
   if (requiresStrictCspDocumentValidation(out.csp)) {
-    if (canStreamStrictCspWithNonce(out.csp, req.cspNonce)) {
-      validateStrictCspHead(head, out.csp);
-      const body = streamHTMLDocument({
-        ...documentParts,
-        head,
-        body: await preflightStream(out.html),
-      });
-
-      return { status, headers, cookies, body, isBase64: false };
-    }
-
     const strictBody = await collectStreamAsUtf8Text(
       out.html,
       strictCspMaxStreamingBodyBytes,
@@ -798,23 +785,6 @@ function applyStrictCspResponseHeader(
   if (!requiresStrictCspDocumentValidation(policy)) return;
   if (headers['content-security-policy']?.length) return;
   headers['content-security-policy'] = [buildStrictCspHeader({ cspNonce })];
-}
-
-function canStreamStrictCspWithNonce(
-  policy: FaceRenderResult['csp'],
-  cspNonce: string | null,
-): boolean {
-  return (
-    policy?.inlineScripts === false && Boolean(String(cspNonce ?? '').trim())
-  );
-}
-
-function validateStrictCspHead(
-  head: string,
-  policy: FaceRenderResult['csp'],
-): void {
-  const headOnlyDocument = renderHTMLDocument({ head, body: '' });
-  validateStrictCspDocument(headOnlyDocument, { policy });
 }
 
 async function collectStreamAsUtf8Text(

--- a/ts/src/aws-s3/index.ts
+++ b/ts/src/aws-s3/index.ts
@@ -1,4 +1,8 @@
-import { GetObjectCommand, PutObjectCommand, type S3Client } from '@aws-sdk/client-s3';
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  type S3Client,
+} from '@aws-sdk/client-s3';
 
 import type { S3HtmlStoreClient } from '../isr.js';
 
@@ -7,7 +11,8 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<Uint8Array> {
     typeof value === 'object' &&
     value !== null &&
     Symbol.asyncIterator in (value as Record<string | symbol, unknown>) &&
-    typeof (value as Record<string | symbol, unknown>)[Symbol.asyncIterator] === 'function'
+    typeof (value as Record<string | symbol, unknown>)[Symbol.asyncIterator] ===
+      'function'
   );
 }
 
@@ -21,11 +26,14 @@ function hasTransformToByteArray(
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as { transformToByteArray?: unknown }).transformToByteArray === 'function'
+    typeof (value as { transformToByteArray?: unknown })
+      .transformToByteArray === 'function'
   );
 }
 
-function hasArrayBuffer(value: unknown): value is { arrayBuffer: () => Promise<ArrayBuffer> } {
+function hasArrayBuffer(
+  value: unknown,
+): value is { arrayBuffer: () => Promise<ArrayBuffer> } {
   return (
     typeof value === 'object' &&
     value !== null &&
@@ -42,7 +50,9 @@ async function normalizeGetObjectBody(
   if (isAsyncIterable(body)) return body;
   if (hasTransformToByteArray(body)) return await body.transformToByteArray();
   if (hasArrayBuffer(body)) return new Uint8Array(await body.arrayBuffer());
-  throw new TypeError('S3 getObject body type is not supported by FaceTheory S3HtmlStoreClient');
+  throw new TypeError(
+    'S3 getObject body type is not supported by FaceTheory S3HtmlStoreClient',
+  );
 }
 
 function isNotFoundError(err: unknown): boolean {
@@ -81,6 +91,7 @@ export function createAwsSdkS3HtmlStoreClient(
         return {
           body,
           ...(out.ETag !== undefined ? { etag: out.ETag ?? null } : {}),
+          ...(out.Metadata ? { metadata: { ...out.Metadata } } : {}),
         };
       } catch (err) {
         if (isNotFoundError(err)) return null;
@@ -94,7 +105,9 @@ export function createAwsSdkS3HtmlStoreClient(
           Key: input.key,
           Body: input.body,
           ContentType: input.contentType,
-          ...(input.cacheControl !== undefined ? { CacheControl: input.cacheControl } : {}),
+          ...(input.cacheControl !== undefined
+            ? { CacheControl: input.cacheControl }
+            : {}),
           ...(input.metadata ? { Metadata: { ...input.metadata } } : {}),
         }),
       );
@@ -105,4 +118,3 @@ export function createAwsSdkS3HtmlStoreClient(
     },
   };
 }
-

--- a/ts/src/control-plane.ts
+++ b/ts/src/control-plane.ts
@@ -14,8 +14,10 @@ import {
   methodNotAllowedResourceResponse,
   textResourceResponse,
 } from './resource.js';
+import { buildStrictCspHeader, validateStrictCspDocument } from './security.js';
 import type {
   FaceContext,
+  FaceCspPolicy,
   FaceHeadTag,
   FaceMode,
   FaceModule,
@@ -47,6 +49,11 @@ const NOSNIFF = 'nosniff';
 const CONTROL_PLANE_MODE_HEADER = 'x-facetheory-control-plane-csp-mode';
 const STRICT_CSP_SUPPORTED_HEADER =
   'x-facetheory-control-plane-strict-csp-supported';
+const STRICT_CONTROL_PLANE_CSP: FaceCspPolicy = {
+  inlineScripts: false,
+  inlineStyles: false,
+  rawHead: false,
+};
 
 export interface ControlPlanePresetDescriptor {
   readonly contract: typeof CONTROL_PLANE_PRESET_CONTRACT;
@@ -193,8 +200,9 @@ export interface ControlPlaneBrowserAsset {
   cacheControl?: string | null | undefined;
 }
 
-interface NormalizedControlPlaneDataSection<Data = unknown>
-  extends ControlPlaneDataSection<Data> {
+interface NormalizedControlPlaneDataSection<
+  Data = unknown,
+> extends ControlPlaneDataSection<Data> {
   endpoint: string;
   slug: string;
 }
@@ -267,9 +275,11 @@ export function createControlPlaneAssetRoutes(
 ): FaceResourceRoute[] {
   return assets.map((asset) => {
     const route = normalizePath(asset.route);
-    const body = asset.body instanceof Uint8Array ? asset.body : utf8(asset.body);
+    const body =
+      asset.body instanceof Uint8Array ? asset.body : utf8(asset.body);
     const contentType = asset.contentType ?? JAVASCRIPT_CONTENT_TYPE;
-    const cacheControl = asset.cacheControl === undefined ? NO_STORE : asset.cacheControl;
+    const cacheControl =
+      asset.cacheControl === undefined ? NO_STORE : asset.cacheControl;
 
     return {
       route,
@@ -370,7 +380,13 @@ function createPresetFace(
       if (!gate.ok) return deniedControlPlaneResult(gate, options.cspMode);
 
       const helpers = createShellHelpers(normalized, ctx, gate, options);
-      const base = await baseControlPlaneResult(normalized, ctx, gate, helpers, options);
+      const base = await baseControlPlaneResult(
+        normalized,
+        ctx,
+        gate,
+        helpers,
+        options,
+      );
       if (options.delivery === 'streaming') {
         return {
           ...base,
@@ -420,7 +436,7 @@ async function baseControlPlaneResult(
     'data-facetheory-control-plane-delivery': options.delivery,
   };
   if (options.cspMode === 'strict') {
-    result.csp = { inlineScripts: false, inlineStyles: false, rawHead: false };
+    result.csp = STRICT_CONTROL_PLANE_CSP;
   }
   return result;
 }
@@ -457,7 +473,9 @@ function createShellHelpers(
 function renderDefaultControlPlaneShell(
   helpers: ControlPlaneShellHelpers,
 ): string {
-  const sections = helpers.sections.map((section) => helpers.section(section.id)).join('');
+  const sections = helpers.sections
+    .map((section) => helpers.section(section.id))
+    .join('');
   return `<main data-facetheory-view data-facetheory-control-plane-shell="true">${sections}</main>`;
 }
 
@@ -507,7 +525,12 @@ function createControlPlaneSectionRoutes(
           const gate = await options.gate(ctx);
           if (!gate.ok) return deniedSectionResponse(gate);
           const html = await renderSectionDataHtml(section, ctx, gate);
-          return sectionHtmlResponse(html, ctx.request.method === 'HEAD');
+          return sectionHtmlResponse(
+            html,
+            ctx.request.method === 'HEAD',
+            options.cspMode,
+            ctx.request.cspNonce,
+          );
         },
       });
     }
@@ -532,10 +555,29 @@ async function renderSectionDataHtml<Data>(
   }
 }
 
-function sectionHtmlResponse(html: string, headOnly: boolean): FaceResponse {
+function sectionHtmlResponse(
+  html: string,
+  headOnly: boolean,
+  cspMode: ControlPlaneCspMode,
+  cspNonce: string | null,
+): FaceResponse {
+  const headers: Record<string, string> = { 'x-content-type-options': NOSNIFF };
+  if (cspMode === 'strict') {
+    headers['content-security-policy'] = buildStrictCspHeader({ cspNonce });
+    try {
+      validateStrictCspDocument(html, { policy: STRICT_CONTROL_PLANE_CSP });
+    } catch {
+      return textResourceResponse('', {
+        status: 500,
+        contentType: HTML_FRAGMENT_CONTENT_TYPE,
+        headers,
+      });
+    }
+  }
+
   const response = textResourceResponse(headOnly ? '' : html, {
     contentType: HTML_FRAGMENT_CONTENT_TYPE,
-    headers: { 'x-content-type-options': NOSNIFF },
+    headers,
   });
   return response;
 }
@@ -545,7 +587,8 @@ function deniedSectionResponse(gate: ControlPlaneGateRejected): FaceResponse {
   return jsonResourceResponse(
     {
       error: gate.title ?? 'Forbidden',
-      message: gate.message ?? 'The requested control-plane section is not available.',
+      message:
+        gate.message ?? 'The requested control-plane section is not available.',
     },
     { status, headers: { 'x-content-type-options': NOSNIFF } },
   );
@@ -557,7 +600,8 @@ function deniedControlPlaneResult(
 ): FaceRenderResult {
   const status = normalizeHttpStatus(gate.status ?? 403);
   const title = gate.title ?? (status === 401 ? 'Unauthorized' : 'Forbidden');
-  const message = gate.message ?? 'This control-plane surface is not available.';
+  const message =
+    gate.message ?? 'This control-plane surface is not available.';
   const result: FaceRenderResult = {
     status,
     headers: {
@@ -571,7 +615,7 @@ function deniedControlPlaneResult(
   };
   if (gate.cookies !== undefined) result.cookies = gate.cookies;
   if (cspMode === 'strict') {
-    result.csp = { inlineScripts: false, inlineStyles: false, rawHead: false };
+    result.csp = STRICT_CONTROL_PLANE_CSP;
   }
   return result;
 }
@@ -584,7 +628,9 @@ function staticAssetResponse(input: {
   return {
     status: 200,
     headers: sortHeaderValues({
-      ...(input.cacheControl === null ? {} : { 'cache-control': [input.cacheControl] }),
+      ...(input.cacheControl === null
+        ? {}
+        : { 'cache-control': [input.cacheControl] }),
       'content-type': [input.contentType],
       'x-content-type-options': [NOSNIFF],
     }),
@@ -651,10 +697,7 @@ function slugForId(value: string): string {
 
 function isSlugAsciiAlnum(char: string): boolean {
   const code = char.charCodeAt(0);
-  return (
-    (code >= 48 && code <= 57) ||
-    (code >= 97 && code <= 122)
-  );
+  return (code >= 48 && code <= 57) || (code >= 97 && code <= 122);
 }
 
 function normalizeHttpStatus(value: number): number {
@@ -663,9 +706,12 @@ function normalizeHttpStatus(value: number): number {
   return status;
 }
 
-function sortHeaderValues(headers: Record<string, string[]>): Record<string, string[]> {
+function sortHeaderValues(
+  headers: Record<string, string[]>,
+): Record<string, string[]> {
   const sorted: Record<string, string[]> = {};
-  for (const key of Object.keys(headers).sort()) sorted[key] = headers[key] ?? [];
+  for (const key of Object.keys(headers).sort())
+    sorted[key] = headers[key] ?? [];
   return sorted;
 }
 

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -2,8 +2,13 @@ import { createHash, randomUUID } from 'node:crypto';
 
 import { utf8 } from './bytes.js';
 import { safeJson } from './html.js';
+import {
+  requiresStrictCspDocumentValidation,
+  validateStrictCspDocument,
+} from './security.js';
 import type {
   CookieMap,
+  FaceCspPolicy,
   FaceContext,
   FaceModule,
   FaceResponse,
@@ -35,6 +40,8 @@ const DEFAULT_TENANT_BOUNDARY_HEADERS = [
 const ISR_HYDRATION_QUERY_PARAM = '__facetheory_isr_hydration';
 const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
 const HYDRATION_SIDECAR_CACHE_CONTROL = 'no-store';
+const ISR_HTML_METADATA_CONTENT_SECURITY_POLICY =
+  'facetheory-content-security-policy';
 
 export type IsrFailurePolicy = 'serve-stale' | 'error';
 export type IsrLockContentionPolicy = 'wait' | 'serve-stale';
@@ -55,6 +62,7 @@ export interface HtmlStoreWriteResult {
 export interface HtmlStoreReadResult {
   body: Uint8Array;
   etag?: string | null;
+  metadata?: Record<string, string>;
 }
 
 export interface HtmlStore {
@@ -69,6 +77,8 @@ export interface IsrMetaRecord {
   revalidateSeconds: number;
   status: number;
   contentType: string;
+  contentSecurityPolicy?: string | null;
+  strictCspPolicy?: IsrCachedStrictCspPolicy | null;
   etag: string | null;
   leaseOwner: string | null;
   leaseToken: string | null;
@@ -98,6 +108,8 @@ export interface CommitIsrGenerationInput {
   revalidateSeconds: number;
   status: number;
   contentType: string;
+  contentSecurityPolicy?: string | null;
+  strictCspPolicy?: IsrCachedStrictCspPolicy | null;
   etag?: string | null;
 }
 
@@ -197,7 +209,14 @@ interface PreparedFreshResponse {
   body: Uint8Array;
   status: number;
   contentType: string;
+  contentSecurityPolicy: string | null;
+  strictCspPolicy: IsrCachedStrictCspPolicy | null;
   etag: string | null;
+}
+
+export interface IsrCachedStrictCspPolicy {
+  inlineScripts?: false | undefined;
+  inlineStyles?: false | undefined;
 }
 
 class IsrLeaseConflictError extends Error {
@@ -210,7 +229,11 @@ class IsrLeaseConflictError extends Error {
 export class InMemoryHtmlStore implements HtmlStore {
   private readonly objects = new Map<
     string,
-    { body: Uint8Array; etag: string | null }
+    {
+      body: Uint8Array;
+      etag: string | null;
+      metadata: Record<string, string> | null;
+    }
   >();
 
   async read(key: string): Promise<HtmlStoreReadResult | null> {
@@ -219,6 +242,7 @@ export class InMemoryHtmlStore implements HtmlStore {
     return {
       body: Uint8Array.from(entry.body),
       ...(entry.etag !== null ? { etag: entry.etag } : {}),
+      ...(entry.metadata !== null ? { metadata: { ...entry.metadata } } : {}),
     };
   }
 
@@ -227,6 +251,7 @@ export class InMemoryHtmlStore implements HtmlStore {
     this.objects.set(input.key, {
       body: Uint8Array.from(input.body),
       etag,
+      metadata: input.metadata ? { ...input.metadata } : null,
     });
     return { etag };
   }
@@ -299,6 +324,8 @@ export class InMemoryIsrMetaStore implements IsrMetaStore {
       revalidateSeconds: normalizeRevalidateSeconds(input.revalidateSeconds),
       status: normalizeStatus(input.status),
       contentType: normalizeContentType(input.contentType),
+      contentSecurityPolicy: input.contentSecurityPolicy ?? null,
+      strictCspPolicy: input.strictCspPolicy ?? null,
       etag: input.etag ?? null,
       leaseOwner: null,
       leaseToken: null,
@@ -336,6 +363,7 @@ export interface S3HtmlStoreClient {
   getObject: (input: { bucket: string; key: string }) => Promise<{
     body: Uint8Array | string | AsyncIterable<Uint8Array> | null;
     etag?: string | null;
+    metadata?: Record<string, string>;
   } | null>;
   putObject: (input: {
     bucket: string;
@@ -376,6 +404,7 @@ export class S3HtmlStore implements HtmlStore {
     return {
       body,
       ...(output.etag !== undefined ? { etag: output.etag ?? null } : {}),
+      ...(output.metadata ? { metadata: { ...output.metadata } } : {}),
     };
   }
 
@@ -698,11 +727,13 @@ async function regenerateAndCommit(
       });
     }
 
+    const htmlMetadata = htmlStoreMetadataFromPreparedFreshResponse(prepared);
     const write = await runtimeOptions.htmlStore.write({
       key: htmlPointer,
       body: prepared.body,
       contentType: prepared.contentType,
       cacheControl: blockingIsrCacheControl(revalidateSeconds),
+      ...(htmlMetadata ? { metadata: htmlMetadata } : {}),
     });
     const etag = prepared.etag ?? write.etag ?? null;
 
@@ -715,6 +746,12 @@ async function regenerateAndCommit(
       revalidateSeconds,
       status: prepared.status,
       contentType: prepared.contentType,
+      ...(prepared.contentSecurityPolicy !== null
+        ? { contentSecurityPolicy: prepared.contentSecurityPolicy }
+        : {}),
+      ...(prepared.strictCspPolicy !== null
+        ? { strictCspPolicy: prepared.strictCspPolicy }
+        : {}),
       ...(etag !== null ? { etag } : {}),
     });
 
@@ -726,6 +763,8 @@ async function regenerateAndCommit(
         generatedAt,
         status: prepared.status,
         contentType: prepared.contentType,
+        contentSecurityPolicy: prepared.contentSecurityPolicy,
+        strictCspPolicy: prepared.strictCspPolicy,
         etag,
       },
       prepared.body,
@@ -787,7 +826,14 @@ async function cachedResponseFromRecord(
   if (!html) return null;
 
   const body = Uint8Array.from(html.body);
-  return responseFromStoredHtml(runtimeOptions, record, body, state, nowMs);
+  return responseFromStoredHtml(
+    runtimeOptions,
+    record,
+    body,
+    state,
+    nowMs,
+    html.metadata,
+  );
 }
 
 function responseFromStoredHtml(
@@ -796,8 +842,23 @@ function responseFromStoredHtml(
   body: Uint8Array,
   state: IsrCacheState,
   nowMs: number,
+  htmlMetadata?: Record<string, string> | undefined,
 ): FaceResponse {
   const contentType = normalizeContentType(record.contentType);
+  const contentSecurityPolicy = normalizeOptionalHeaderValue(
+    record.contentSecurityPolicy ??
+      htmlMetadata?.[ISR_HTML_METADATA_CONTENT_SECURITY_POLICY],
+  );
+  const strictCspPolicy = normalizeCachedStrictCspPolicy(
+    record.strictCspPolicy,
+    contentSecurityPolicy,
+  );
+  if (strictCspPolicy !== null) {
+    validateStrictCspDocument(decodeUtf8Html(body), {
+      policy: strictCspPolicy,
+    });
+  }
+
   const isRecordFresh = isFresh(record, nowMs);
   const headers: Headers = {
     'cache-control': [
@@ -810,6 +871,9 @@ function responseFromStoredHtml(
     'content-type': [contentType],
     'x-facetheory-isr': [state],
   };
+  if (contentSecurityPolicy !== null) {
+    headers['content-security-policy'] = [contentSecurityPolicy];
+  }
 
   if (record.etag) {
     headers.etag = [record.etag];
@@ -821,6 +885,15 @@ function responseFromStoredHtml(
     cookies: [],
     body,
     isBase64: false,
+  };
+}
+
+function htmlStoreMetadataFromPreparedFreshResponse(
+  prepared: PreparedFreshResponse,
+): Record<string, string> | undefined {
+  if (prepared.contentSecurityPolicy === null) return undefined;
+  return {
+    [ISR_HTML_METADATA_CONTENT_SECURITY_POLICY]: prepared.contentSecurityPolicy,
   };
 }
 
@@ -1077,6 +1150,8 @@ function createDefaultMetaRecord(
     revalidateSeconds: normalizeRevalidateSeconds(revalidateSeconds),
     status: 200,
     contentType: HTML_CONTENT_TYPE,
+    contentSecurityPolicy: null,
+    strictCspPolicy: null,
     etag: null,
     leaseOwner: null,
     leaseToken: null,
@@ -1152,6 +1227,10 @@ async function prepareFreshResponse(
   const contentType = normalizeContentType(
     firstHeaderValue(headers, 'content-type'),
   );
+  const contentSecurityPolicy = normalizeOptionalHeaderValue(
+    firstHeaderValue(headers, 'content-security-policy'),
+  );
+  const strictCspPolicy = inferCachedStrictCspPolicy(contentSecurityPolicy);
   const etag = firstHeaderValue(headers, 'etag');
   const body = await collectBody(response.body);
 
@@ -1159,8 +1238,83 @@ async function prepareFreshResponse(
     body,
     status,
     contentType,
+    contentSecurityPolicy,
+    strictCspPolicy,
     etag,
   };
+}
+
+function normalizeCachedStrictCspPolicy(
+  policy: IsrCachedStrictCspPolicy | null | undefined,
+  contentSecurityPolicy: string | null,
+): FaceCspPolicy | null {
+  const normalizedPolicy =
+    policy ?? inferCachedStrictCspPolicy(contentSecurityPolicy);
+  if (!normalizedPolicy) return null;
+
+  const cspPolicy: FaceCspPolicy = {};
+  if (normalizedPolicy.inlineScripts === false) {
+    cspPolicy.inlineScripts = false;
+  }
+  if (normalizedPolicy.inlineStyles === false) {
+    cspPolicy.inlineStyles = false;
+  }
+  return requiresStrictCspDocumentValidation(cspPolicy) ? cspPolicy : null;
+}
+
+function inferCachedStrictCspPolicy(
+  contentSecurityPolicy: string | null,
+): IsrCachedStrictCspPolicy | null {
+  if (contentSecurityPolicy === null) return null;
+
+  const directives = parseCspDirectives(contentSecurityPolicy);
+  const scriptDirective =
+    directives.get('script-src') ?? directives.get('default-src');
+  const styleDirective =
+    directives.get('style-src') ?? directives.get('default-src');
+  const policy: IsrCachedStrictCspPolicy = {};
+
+  if (scriptDirective && !directiveAllowsUnsafeInline(scriptDirective)) {
+    policy.inlineScripts = false;
+  }
+  if (styleDirective && !directiveAllowsUnsafeInline(styleDirective)) {
+    policy.inlineStyles = false;
+  }
+
+  return policy.inlineScripts === false || policy.inlineStyles === false
+    ? policy
+    : null;
+}
+
+function parseCspDirectives(value: string): Map<string, string[]> {
+  const directives = new Map<string, string[]>();
+  for (const rawDirective of value.split(';')) {
+    const tokens = rawDirective.trim().split(/\s+/).filter(Boolean);
+    const name = tokens.shift()?.toLowerCase();
+    if (!name || directives.has(name)) continue;
+    directives.set(
+      name,
+      tokens.map((token) => token.toLowerCase()),
+    );
+  }
+  return directives;
+}
+
+function directiveAllowsUnsafeInline(values: readonly string[]): boolean {
+  return values.some(
+    (value) => value.replace(/^'+|'+$/g, '') === 'unsafe-inline',
+  );
+}
+
+function normalizeOptionalHeaderValue(
+  value: string | null | undefined,
+): string | null {
+  const normalized = String(value ?? '').trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function decodeUtf8Html(body: Uint8Array): string {
+  return new TextDecoder('utf-8', { fatal: true }).decode(body);
 }
 
 async function collectBody(body: FaceResponse['body']): Promise<Uint8Array> {

--- a/ts/src/navigation-pending.ts
+++ b/ts/src/navigation-pending.ts
@@ -4,8 +4,10 @@ import {
 } from './spa.js';
 import type { ClassifyFaceNavigationAnchorClickOptions } from './spa.js';
 
-export const NAVIGATION_PENDING_CLASSIFIER_SOURCE = FACE_NAVIGATION_CLASSIFIER_SOURCE;
-export const NAVIGATION_PENDING_ATTRIBUTE = 'data-facetheory-navigation-pending';
+export const NAVIGATION_PENDING_CLASSIFIER_SOURCE =
+  FACE_NAVIGATION_CLASSIFIER_SOURCE;
+export const NAVIGATION_PENDING_ATTRIBUTE =
+  'data-facetheory-navigation-pending';
 export const NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE =
   'data-facetheory-reduced-motion';
 export const NAVIGATION_PENDING_INDICATOR_ATTRIBUTE =
@@ -49,8 +51,8 @@ interface ResolvedNavigationPendingClassNames {
 
 interface ElementSnapshot {
   attributes: Map<string, string | null>;
+  childNodes?: Node[] | undefined;
   element: Element;
-  textContent?: string | null;
 }
 
 interface IndicatorSnapshot extends ElementSnapshot {
@@ -63,8 +65,10 @@ export function startNavigationPending(
   const doc = options.document ?? document;
   const win = options.window ?? doc.defaultView ?? window;
   const classNames = resolveClassNames(options.classNames);
-  const indicatorId = options.indicatorId ?? DEFAULT_NAVIGATION_PENDING_INDICATOR_ID;
-  const indicatorText = options.indicatorText ?? DEFAULT_NAVIGATION_PENDING_TEXT;
+  const indicatorId =
+    options.indicatorId ?? DEFAULT_NAVIGATION_PENDING_INDICATOR_ID;
+  const indicatorText =
+    options.indicatorText ?? DEFAULT_NAVIGATION_PENDING_TEXT;
 
   let indicator: IndicatorSnapshot | null = null;
   let pendingElements: ElementSnapshot[] = [];
@@ -102,13 +106,21 @@ export function startNavigationPending(
 
   const showPending = (
     source: 'link' | 'form',
-    targets: ReadonlyArray<{ element: Element; role: 'link' | 'form' | 'submitter' }>,
+    targets: ReadonlyArray<{
+      element: Element;
+      role: 'link' | 'form' | 'submitter';
+    }>,
   ): void => {
     if (stopped) return;
     clearPending();
 
     for (const target of targets) {
-      markPendingElement(target.element, target.role, classNames, pendingElements);
+      markPendingElement(
+        target.element,
+        target.role,
+        classNames,
+        pendingElements,
+      );
     }
 
     indicator = showIndicator({
@@ -124,7 +136,10 @@ export function startNavigationPending(
   };
 
   const handleClick = (event: MouseEvent): void => {
-    const navigation = classifyFaceNavigationAnchorClick(event, classifyOptions());
+    const navigation = classifyFaceNavigationAnchorClick(
+      event,
+      classifyOptions(),
+    );
     if (!navigation) return;
 
     showPending('link', [{ element: navigation.anchor, role: 'link' }]);
@@ -200,15 +215,19 @@ function showIndicator(options: {
   const resolved = resolveIndicatorElement(options.doc, options.id);
   const existing = resolved.created ? null : resolved.element;
   const element = resolved.element;
-  const snapshot = snapshotElement(element, [
-    'role',
-    'aria-live',
-    'aria-atomic',
-    'class',
-    NAVIGATION_PENDING_ATTRIBUTE,
-    NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE,
-    NAVIGATION_PENDING_INDICATOR_ATTRIBUTE,
-  ]);
+  const snapshot = snapshotElement(
+    element,
+    [
+      'role',
+      'aria-live',
+      'aria-atomic',
+      'class',
+      NAVIGATION_PENDING_ATTRIBUTE,
+      NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE,
+      NAVIGATION_PENDING_INDICATOR_ATTRIBUTE,
+    ],
+    { childNodes: true },
+  );
 
   if (!existing) {
     element.id = resolved.id;
@@ -243,7 +262,9 @@ function resolveIndicatorElement(
   doc: Document,
   requestedId: string,
 ): { created: boolean; element: HTMLElement; id: string } {
-  const normalizedId = String(requestedId || DEFAULT_NAVIGATION_PENDING_INDICATOR_ID);
+  const normalizedId = String(
+    requestedId || DEFAULT_NAVIGATION_PENDING_INDICATOR_ID,
+  );
   const existing = doc.getElementById(normalizedId);
   if (isNavigationPendingIndicator(existing)) {
     return { created: false, element: existing, id: normalizedId };
@@ -280,10 +301,15 @@ function nextAvailableIndicatorElement(
     }
   }
 
-  throw new Error('FaceTheory navigation pending could not allocate indicator id');
+  throw new Error(
+    'FaceTheory navigation pending could not allocate indicator id',
+  );
 }
 
-function warnIndicatorIdCollision(requestedId: string, resolvedId: string): void {
+function warnIndicatorIdCollision(
+  requestedId: string,
+  resolvedId: string,
+): void {
   const warn = globalThis.console?.warn;
   if (typeof warn !== 'function') return;
   warn(
@@ -330,16 +356,19 @@ function markPendingElement(
 function snapshotElement(
   element: Element,
   attributeNames: readonly string[],
+  options: { childNodes?: boolean } = {},
 ): ElementSnapshot {
   const attributes = new Map<string, string | null>();
   for (const name of attributeNames) {
     attributes.set(name, element.getAttribute(name));
   }
-  return {
-    attributes,
-    element,
-    textContent: element.textContent,
-  };
+  const snapshot: ElementSnapshot = { attributes, element };
+  if (options.childNodes === true) {
+    snapshot.childNodes = Array.from(element.childNodes).map((node) =>
+      node.cloneNode(true),
+    );
+  }
+  return snapshot;
 }
 
 function restoreElementSnapshot(snapshot: ElementSnapshot): void {
@@ -351,8 +380,10 @@ function restoreElementSnapshot(snapshot: ElementSnapshot): void {
     }
   }
 
-  if (snapshot.textContent !== undefined) {
-    snapshot.element.textContent = snapshot.textContent;
+  if (snapshot.childNodes !== undefined) {
+    snapshot.element.replaceChildren(
+      ...snapshot.childNodes.map((node) => node.cloneNode(true)),
+    );
   }
 }
 
@@ -387,6 +418,9 @@ function isElement(value: EventTarget | null): value is Element {
   );
 }
 
-function isElementWithTag(value: EventTarget | null, tagName: string): value is Element {
+function isElementWithTag(
+  value: EventTarget | null,
+  tagName: string,
+): value is Element {
   return isElement(value) && value.tagName.toLowerCase() === tagName;
 }

--- a/ts/src/react/responsive-primitives/index.ts
+++ b/ts/src/react/responsive-primitives/index.ts
@@ -7,6 +7,7 @@ import {
   handleResponsiveLinkClick,
   loadingStateClassName,
   normalizeAsyncViewState,
+  sanitizeResponsiveLinkHref,
   skeletonClassName,
   spinnerClassName,
   spinnerSvgSize,
@@ -393,6 +394,7 @@ export function Link(props: LinkProps): React.ReactElement {
     ...rest
   } = props;
   const resolvedHref = href ?? '';
+  const safeHref = sanitizeResponsiveLinkHref(resolvedHref);
   const safeRel = forcedSafeLinkRel({
     href: resolvedHref,
     rel,
@@ -424,7 +426,7 @@ export function Link(props: LinkProps): React.ReactElement {
     {
       ...rest,
       className: ['facetheory-rcp-link', className].filter(Boolean).join(' '),
-      href: resolvedHref,
+      href: safeHref,
       onClick: handleClick,
       rel: safeRel,
       target,

--- a/ts/src/responsive-primitives/index.ts
+++ b/ts/src/responsive-primitives/index.ts
@@ -522,7 +522,26 @@ export function forcedSafeLinkRel(options: LinkRelOptions): string | undefined {
 
 export function linkRequiresNoopener(options: LinkRelOptions): boolean {
   if (options.target === '_blank') return true;
-  return isExternalLinkHref(options.href, options.sameOriginBaseHref);
+  const href = sanitizeResponsiveLinkHref(options.href);
+  if (href === undefined) return false;
+  return isExternalLinkHref(href, options.sameOriginBaseHref);
+}
+
+export function sanitizeResponsiveLinkHref(
+  href: string | null | undefined,
+): string | undefined {
+  const value = String(href ?? '');
+  const scheme = unsafeNormalizedHrefScheme(value);
+  if (scheme === null) return value;
+  if (
+    scheme === 'http' ||
+    scheme === 'https' ||
+    scheme === 'mailto' ||
+    scheme === 'tel'
+  ) {
+    return value;
+  }
+  return undefined;
 }
 
 export function isExternalLinkHref(
@@ -581,4 +600,10 @@ export function handleResponsiveLinkClick(
 
 function isHttpUrlLike(href: string): boolean {
   return /^https?:\/\//i.test(href.trim());
+}
+
+function unsafeNormalizedHrefScheme(href: string): string | null {
+  const normalized = href.trimStart().replace(/[\u0000-\u0020\u007f]+/g, '');
+  const match = /^([A-Za-z][A-Za-z0-9+.-]*):/.exec(normalized);
+  return match?.[1] ? match[1].toLowerCase() : null;
 }

--- a/ts/src/svelte/responsive-primitives/Link.svelte
+++ b/ts/src/svelte/responsive-primitives/Link.svelte
@@ -3,6 +3,7 @@
     classifyResponsiveLinkClick,
     forcedSafeLinkRel,
     handleResponsiveLinkClick,
+    sanitizeResponsiveLinkHref,
     type ResponsiveLinkNavigateHandler,
   } from '../../responsive-primitives/index.js';
 
@@ -20,6 +21,7 @@
   export { className as class };
 
   $: safeRel = forcedSafeLinkRel({ href, rel, sameOriginBaseHref, target });
+  $: safeHref = sanitizeResponsiveLinkHref(href);
   $: resolvedClass = ['facetheory-rcp-link', className].filter(Boolean).join(' ');
 
   function handleClick(event: MouseEvent): void {
@@ -37,7 +39,7 @@
 <a
   {...$$restProps}
   class={resolvedClass}
-  {href}
+  href={safeHref}
   rel={safeRel}
   {target}
   onclick={handleClick}

--- a/ts/src/vue/responsive-primitives/index.ts
+++ b/ts/src/vue/responsive-primitives/index.ts
@@ -8,6 +8,7 @@ import {
   handleResponsiveLinkClick,
   loadingStateClassName,
   normalizeAsyncViewState,
+  sanitizeResponsiveLinkHref,
   skeletonClassName,
   spinnerClassName,
   spinnerSvgSize,
@@ -428,6 +429,7 @@ export const Link = defineComponent({
         sameOriginBaseHref: props.sameOriginBaseHref,
         target: props.target,
       });
+      const safeHref = sanitizeResponsiveLinkHref(props.href);
 
       const handleClick = (event: MouseEvent): void => {
         callVueHandler(onClick, event);
@@ -452,7 +454,7 @@ export const Link = defineComponent({
         {
           ...rest,
           class: ['facetheory-rcp-link', attrClass],
-          href: props.href,
+          href: safeHref,
           onClick: handleClick,
           rel: safeRel,
           target: props.target,

--- a/ts/test/unit/aws-s3.test.ts
+++ b/ts/test/unit/aws-s3.test.ts
@@ -57,6 +57,7 @@ test('aws-s3: getObject forwards body and etag', async () => {
           yield new TextEncoder().encode('hello');
         })(),
         ETag: '"etag"',
+        Metadata: { 'facetheory-content-security-policy': "script-src 'self'" },
       };
     },
   } as unknown as S3Client;
@@ -65,6 +66,9 @@ test('aws-s3: getObject forwards body and etag', async () => {
   const out = await client.getObject({ bucket: 'b', key: 'k' });
   assert.ok(out !== null);
   assert.equal(out.etag, '"etag"');
+  assert.deepEqual(out.metadata, {
+    'facetheory-content-security-policy': "script-src 'self'",
+  });
   const body = await collectBody(out.body ?? new Uint8Array());
   assert.equal(new TextDecoder().decode(body), 'hello');
 });
@@ -100,4 +104,3 @@ test('aws-s3: putObject maps bucket/key/body/contentType/cacheControl/metadata',
   assert.equal(seen.CacheControl, 'public,max-age=0');
   assert.deepEqual(seen.Metadata, { a: '1' });
 });
-

--- a/ts/test/unit/control-plane-guardrails.test.ts
+++ b/ts/test/unit/control-plane-guardrails.test.ts
@@ -21,7 +21,8 @@ async function collect(body: FaceBody): Promise<string> {
   if (body instanceof Uint8Array) return new TextDecoder().decode(body);
   const decoder = new TextDecoder();
   const chunks: string[] = [];
-  for await (const chunk of body) chunks.push(decoder.decode(chunk, { stream: true }));
+  for await (const chunk of body)
+    chunks.push(decoder.decode(chunk, { stream: true }));
   chunks.push(decoder.decode());
   return chunks.join('');
 }
@@ -96,7 +97,10 @@ test('control-plane preset: relaxed mode is the default and strict CSP remains s
   const html = await collect(response.body);
 
   assert.equal(response.status, 200);
-  assert.equal(response.headers['x-facetheory-control-plane-csp-mode']?.[0], 'relaxed');
+  assert.equal(
+    response.headers['x-facetheory-control-plane-csp-mode']?.[0],
+    'relaxed',
+  );
   assert.equal(
     response.headers['x-facetheory-control-plane-strict-csp-supported']?.[0],
     'true',
@@ -113,14 +117,29 @@ test('control-plane preset: strict mode opts into no-inline CSP and external ass
   const app = createDemoApp({ mode: 'strict', delivery: 'client-fill' });
   const result = await handleLambdaUrlEvent(app, {
     rawPath: '/',
-    requestContext: { http: { method: 'GET', path: '/' }, requestId: 'strict-1' },
+    requestContext: {
+      http: { method: 'GET', path: '/' },
+      requestId: 'strict-1',
+    },
   });
 
   assert.equal(result.statusCode, 200);
-  assert.match(result.headers?.['content-security-policy'] ?? '', /script-src 'self'/);
-  assert.match(result.headers?.['content-security-policy'] ?? '', /style-src 'self'/);
-  assert.ok(result.body.includes(`href="${CONTROL_PLANE_RESPONSIVE_PRIMITIVES_STYLESHEET_PATH}"`));
-  assert.ok(result.body.includes(`src="${CONTROL_PLANE_BOOTSTRAP_MODULE_PATH}"`));
+  assert.match(
+    result.headers?.['content-security-policy'] ?? '',
+    /script-src 'self'/,
+  );
+  assert.match(
+    result.headers?.['content-security-policy'] ?? '',
+    /style-src 'self'/,
+  );
+  assert.ok(
+    result.body.includes(
+      `href="${CONTROL_PLANE_RESPONSIVE_PRIMITIVES_STYLESHEET_PATH}"`,
+    ),
+  );
+  assert.ok(
+    result.body.includes(`src="${CONTROL_PLANE_BOOTSTRAP_MODULE_PATH}"`),
+  );
   assert.equal(result.body.includes('<style'), false);
   assert.equal(result.body.includes('__FACETHEORY_DATA__'), false);
 });
@@ -142,7 +161,8 @@ test('control-plane preset: shell-first client-fill leaves section data off crit
               loadCalls += 1;
               return { value: 'loaded' };
             },
-            render: (_ctx, data) => `<p>${String((data as { value: string }).value)}</p>`,
+            render: (_ctx, data) =>
+              `<p>${String((data as { value: string }).value)}</p>`,
           },
         ],
       },
@@ -161,9 +181,85 @@ test('control-plane preset: shell-first client-fill leaves section data off crit
     path: '/_facetheory/control-plane/sections/root-0/slow',
   });
   assert.equal(section.status, 200);
-  assert.equal(section.headers['content-type']?.[0], 'text/html; charset=utf-8');
+  assert.equal(
+    section.headers['content-type']?.[0],
+    'text/html; charset=utf-8',
+  );
   assert.equal(await collect(section.body), '<p>loaded</p>');
   assert.equal(loadCalls, 1);
+});
+
+test('control-plane preset: strict section endpoints emit no-inline CSP headers', async () => {
+  const app = createDemoApp({ mode: 'strict', delivery: 'client-fill' });
+
+  const section = await app.handle({
+    method: 'GET',
+    path: '/_facetheory/control-plane/sections/root-0/agents',
+    cspNonce: 'section-nonce',
+  });
+
+  assert.equal(section.status, 200);
+  assert.equal(
+    section.headers['content-type']?.[0],
+    'text/html; charset=utf-8',
+  );
+  assert.equal(section.headers['x-content-type-options']?.[0], 'nosniff');
+  assert.match(
+    section.headers['content-security-policy']?.[0] ?? '',
+    /script-src 'self' 'nonce-section-nonce'/,
+  );
+  assert.match(
+    section.headers['content-security-policy']?.[0] ?? '',
+    /style-src 'self' 'nonce-section-nonce'/,
+  );
+  assert.equal(
+    await collect(section.body),
+    '<p class="agents-count">2 agents</p>',
+  );
+
+  const head = await app.handle({
+    method: 'HEAD',
+    path: '/_facetheory/control-plane/sections/root-0/agents',
+    cspNonce: 'section-nonce',
+  });
+  assert.equal(head.status, 200);
+  assert.match(
+    head.headers['content-security-policy']?.[0] ?? '',
+    /script-src 'self'/,
+  );
+  assert.equal(await collect(head.body), '');
+});
+
+test('control-plane preset: strict section endpoints fail closed on unsafe fragments', async () => {
+  const app = createControlPlaneApp({
+    csp: { mode: 'strict' },
+    gate: () => ({ ok: true }),
+    faces: [
+      {
+        route: '/',
+        sections: [
+          {
+            id: 'unsafe',
+            read: { bounded: true, tenantScoped: true },
+            load: () => ({}),
+            render: () => '<script>alert("unsafe")</script>',
+          },
+        ],
+      },
+    ],
+  });
+
+  const section = await app.handle({
+    method: 'GET',
+    path: '/_facetheory/control-plane/sections/root-0/unsafe',
+  });
+
+  assert.equal(section.status, 500);
+  assert.match(
+    section.headers['content-security-policy']?.[0] ?? '',
+    /script-src 'self'/,
+  );
+  assert.equal(await collect(section.body), '');
 });
 
 test('control-plane preset: rejects section reads without bounded tenant scope at app construction', () => {
@@ -250,8 +346,16 @@ test('control-plane preset: streaming capability does not block first shell chun
 });
 
 test('control-plane preset: gate rejection is buffered before any shell is returned', async () => {
-  const app = createDemoApp({ mode: 'strict', delivery: 'streaming', gate: 'deny' });
-  const response = await app.handle({ method: 'GET', path: '/', cspNonce: 'gate-nonce' });
+  const app = createDemoApp({
+    mode: 'strict',
+    delivery: 'streaming',
+    gate: 'deny',
+  });
+  const response = await app.handle({
+    method: 'GET',
+    path: '/',
+    cspNonce: 'gate-nonce',
+  });
   assert.equal(response.status, 403);
   assert.ok(response.body instanceof Uint8Array);
   const html = await collect(response.body);
@@ -426,7 +530,7 @@ test('control-plane boundary guardrails: blocks raw data/auth ownership in contr
         {
           path: 'ts/src/control-plane.ts',
           content:
-            "export function normalizeStaffEntitlement(input: unknown) { return input; }\n",
+            'export function normalizeStaffEntitlement(input: unknown) { return input; }\n',
         },
       ]),
     /entitlement normalization/,

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -23,6 +23,10 @@ function decodeBody(body: Uint8Array): string {
   return new TextDecoder().decode(body);
 }
 
+function encodeBody(body: string): Uint8Array {
+  return new TextEncoder().encode(body);
+}
+
 function externalHydrationHref(html: string): string {
   const tag = /<link\b[^>]*__FACETHEORY_DATA_URL__[^>]*>/i.exec(html)?.[0];
   assert.ok(tag, 'expected external hydration link tag');
@@ -648,6 +652,53 @@ class RecordingMetaStore implements IsrMetaStore {
   }
 }
 
+class CspMetadataDroppingMetaStore implements IsrMetaStore {
+  private readonly inner = new InMemoryIsrMetaStore();
+
+  async get(cacheKey: string): Promise<IsrMetaRecord | null> {
+    return dropCspMetadata(await this.inner.get(cacheKey));
+  }
+
+  async tryAcquireLease(
+    input: TryAcquireIsrLeaseInput,
+  ): Promise<TryAcquireIsrLeaseResult> {
+    const result = await this.inner.tryAcquireLease(input);
+    return {
+      ...result,
+      record: dropCspMetadata(result.record) ?? result.record,
+    };
+  }
+
+  async commitGeneration(input: CommitIsrGenerationInput): Promise<void> {
+    const {
+      contentSecurityPolicy: _contentSecurityPolicy,
+      strictCspPolicy: _strictCspPolicy,
+      ...rest
+    } = input;
+    await this.inner.commitGeneration(rest);
+  }
+
+  async releaseLease(input: ReleaseIsrLeaseInput): Promise<void> {
+    await this.inner.releaseLease(input);
+  }
+
+  debugSnapshot(): IsrMetaRecord[] {
+    return this.inner
+      .debugSnapshot()
+      .map((record) => dropCspMetadata(record) ?? record);
+  }
+}
+
+function dropCspMetadata(record: IsrMetaRecord | null): IsrMetaRecord | null {
+  if (record === null) return null;
+  const {
+    contentSecurityPolicy: _contentSecurityPolicy,
+    strictCspPolicy: _strictCspPolicy,
+    ...rest
+  } = record;
+  return rest;
+}
+
 test('isr: metadata commits never include HTML body text', async () => {
   const marker = 'SUPER_SECRET_HTML_PAYLOAD';
   const htmlStore = new InMemoryHtmlStore();
@@ -735,6 +786,14 @@ test('isr: strict CSP hydration writes and serves pointer-derived sidecars', asy
   const sidecarHref = externalHydrationHref(missHtml);
 
   assert.equal(miss.headers['x-facetheory-isr']?.[0], 'miss');
+  assert.match(
+    miss.headers['content-security-policy']?.[0] ?? '',
+    /script-src 'self'/,
+  );
+  assert.match(
+    miss.headers['content-security-policy']?.[0] ?? '',
+    /style-src 'self'/,
+  );
   assert.ok(missHtml.includes('<main>a-1</main>'));
   assert.ok(missHtml.includes('src="/assets/client-entry.js"'));
   assert.equal(missHtml.includes('id="__FACETHEORY_DATA__"'), false);
@@ -761,12 +820,100 @@ test('isr: strict CSP hydration writes and serves pointer-derived sidecars', asy
   const hit = await app.handle({ method: 'GET', path: '/posts/a' });
   const hitHtml = decodeBody(hit.body as Uint8Array);
   assert.equal(hit.headers['x-facetheory-isr']?.[0], 'hit');
+  assert.equal(
+    hit.headers['content-security-policy']?.[0],
+    miss.headers['content-security-policy']?.[0],
+  );
   assert.equal(externalHydrationHref(hitHtml), sidecarHref);
   assert.equal(renderCount, 1);
 
-  const serializedMeta = JSON.stringify(metaStore.debugSnapshot());
+  const records = metaStore.debugSnapshot();
+  assert.equal(records[0]?.strictCspPolicy?.inlineScripts, false);
+  assert.equal(records[0]?.strictCspPolicy?.inlineStyles, false);
+  assert.equal(
+    records[0]?.contentSecurityPolicy,
+    miss.headers['content-security-policy']?.[0],
+  );
+  const serializedMeta = JSON.stringify(records);
   assert.equal(serializedMeta.includes(secret), false);
   assert.equal(serializedMeta.includes('terminator'), false);
+});
+
+test('isr: strict CSP cached HTML is validated before re-emitting stored bodies', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new CspMetadataDroppingMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/strict',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: () => {
+          renderCount += 1;
+          return {
+            csp: {
+              inlineScripts: false,
+              inlineStyles: false,
+              rawHead: false,
+            },
+            html: '<main>strict cached html</main>',
+          };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => 1_000,
+    },
+  });
+
+  const miss = await app.handle({ method: 'GET', path: '/strict' });
+  assert.equal(miss.status, 200);
+  assert.equal(miss.headers['x-facetheory-isr']?.[0], 'miss');
+  assert.match(
+    miss.headers['content-security-policy']?.[0] ?? '',
+    /script-src 'self'/,
+  );
+
+  const record = metaStore.debugSnapshot()[0];
+  assert.ok(record?.htmlPointer);
+  assert.equal(record.strictCspPolicy, undefined);
+  assert.equal(record.contentSecurityPolicy, undefined);
+
+  const stored = await htmlStore.read(record.htmlPointer);
+  assert.ok(stored?.metadata);
+  assert.ok(
+    Object.values(stored.metadata).some((value) =>
+      value.includes("script-src 'self'"),
+    ),
+  );
+
+  const hit = await app.handle({ method: 'GET', path: '/strict' });
+  assert.equal(hit.status, 200);
+  assert.equal(
+    hit.headers['content-security-policy']?.[0],
+    miss.headers['content-security-policy']?.[0],
+  );
+
+  await htmlStore.write({
+    key: record.htmlPointer,
+    body: encodeBody(
+      '<!doctype html><html><head><title>Unsafe</title></head><body><main>tampered</main><script>alert("cached")</script></body></html>',
+    ),
+    contentType: 'text/html; charset=utf-8',
+    metadata: stored.metadata,
+  });
+
+  const tamperedHit = await app.handle({ method: 'GET', path: '/strict' });
+  assert.equal(tamperedHit.status, 500);
+  const tamperedHtml = decodeBody(tamperedHit.body as Uint8Array);
+  assert.ok(tamperedHtml.includes('<h1>Internal Server Error</h1>'));
+  assert.equal(tamperedHtml.includes('tampered'), false);
+  assert.equal(tamperedHtml.includes('alert("cached")'), false);
+  assert.equal(renderCount, 1);
 });
 
 test('isr: strict CSP hydration sidecars are bound to tenant and auth variants', async () => {

--- a/ts/test/unit/navigation-pending.test.ts
+++ b/ts/test/unit/navigation-pending.test.ts
@@ -19,10 +19,7 @@ import {
 
 type DomWindow = Window & typeof globalThis;
 
-function click(
-  win: DomWindow,
-  init: MouseEventInit = {},
-): MouseEvent {
+function click(win: DomWindow, init: MouseEventInit = {}): MouseEvent {
   return new win.MouseEvent('click', {
     bubbles: true,
     button: 0,
@@ -32,7 +29,10 @@ function click(
   });
 }
 
-function pageTransitionEvent(win: DomWindow, type: 'pagehide' | 'pageshow'): Event {
+function pageTransitionEvent(
+  win: DomWindow,
+  type: 'pagehide' | 'pageshow',
+): Event {
   const PageTransitionEventCtor = (
     win as Window & { PageTransitionEvent?: typeof PageTransitionEvent }
   ).PageTransitionEvent;
@@ -69,7 +69,9 @@ test('navigation pending: reuses the FaceTheory SPA navigation classifier source
         win,
         undefined,
       );
-      const classification = classifyFaceNavigationAnchorClick(event, { window: win });
+      const classification = classifyFaceNavigationAnchorClick(event, {
+        window: win,
+      });
       composedClassifierSource = classification?.classifierSource ?? null;
       composedUrl = classification?.url.toString() ?? null;
     });
@@ -80,7 +82,10 @@ test('navigation pending: reuses the FaceTheory SPA navigation classifier source
       NAVIGATION_PENDING_CLASSIFIER_SOURCE,
       FACE_NAVIGATION_CLASSIFIER_SOURCE,
     );
-    assert.equal(NAVIGATION_PENDING_CLASSIFIER_SOURCE, 'facetheory_spa_navigation');
+    assert.equal(
+      NAVIGATION_PENDING_CLASSIFIER_SOURCE,
+      'facetheory_spa_navigation',
+    );
     assert.equal(directClassifierResult, true);
     assert.equal(composedClassifierSource, FACE_NAVIGATION_CLASSIFIER_SOURCE);
     assert.equal(composedUrl, 'https://control.lab.theorymcp.ai/next');
@@ -114,9 +119,14 @@ test('navigation pending: shows an immediate status pill for accepted same-origi
       anchor.classList.contains('facetheory-navigation-pending-control'),
       true,
     );
-    assert.equal(anchor.classList.contains('facetheory-navigation-pending-link'), true);
+    assert.equal(
+      anchor.classList.contains('facetheory-navigation-pending-link'),
+      true,
+    );
 
-    const indicator = doc.getElementById(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID);
+    const indicator = doc.getElementById(
+      DEFAULT_NAVIGATION_PENDING_INDICATOR_ID,
+    );
     assert.ok(indicator instanceof dom.window.HTMLElement);
     assert.equal(indicator.textContent, 'Loading…');
     assert.equal(indicator.getAttribute('role'), 'status');
@@ -158,7 +168,9 @@ test('navigation pending: never reuses a non-indicator element on id collision',
     const controller = startNavigationPending({ document: doc, window: win });
     anchor.dispatchEvent(click(win));
 
-    const collided = doc.getElementById(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID);
+    const collided = doc.getElementById(
+      DEFAULT_NAVIGATION_PENDING_INDICATOR_ID,
+    );
     assert.ok(collided instanceof dom.window.HTMLScriptElement);
     assert.equal(collided.textContent, '');
     assert.equal(
@@ -177,7 +189,10 @@ test('navigation pending: never reuses a non-indicator element on id collision',
     );
     assert.equal(indicator.getAttribute(NAVIGATION_PENDING_ATTRIBUTE), 'link');
     assert.equal(warnings.length, 1);
-    assert.match(warnings[0] ?? '', /already belongs to a non-indicator element/);
+    assert.match(
+      warnings[0] ?? '',
+      /already belongs to a non-indicator element/,
+    );
 
     controller.stop();
     assert.equal(
@@ -253,7 +268,10 @@ test('navigation pending: preserves native behavior for skipped link classificat
       const win = dom.window as unknown as DomWindow;
       const doc = dom.window.document;
       const anchor = doc.querySelector('a');
-      assert.ok(anchor instanceof dom.window.HTMLAnchorElement, skippedCase.name);
+      assert.ok(
+        anchor instanceof dom.window.HTMLAnchorElement,
+        skippedCase.name,
+      );
 
       const controller = startNavigationPending({ document: doc, window: win });
       const event = click(win, skippedCase.event);
@@ -325,7 +343,10 @@ test('navigation pending: observes form submits without taking submit authority'
     assert.equal(controller.isPending(), true);
     assert.equal(form.getAttribute(NAVIGATION_PENDING_ATTRIBUTE), 'form');
     assert.equal(form.getAttribute('aria-busy'), 'true');
-    assert.equal(submitter.getAttribute(NAVIGATION_PENDING_ATTRIBUTE), 'submitter');
+    assert.equal(
+      submitter.getAttribute(NAVIGATION_PENDING_ATTRIBUTE),
+      'submitter',
+    );
     assert.equal(submitter.getAttribute('aria-busy'), 'true');
 
     controller.stop();
@@ -335,7 +356,11 @@ test('navigation pending: observes form submits without taking submit authority'
 });
 
 test('navigation pending: clears pending UI on lifecycle cleanup events', () => {
-  for (const lifecycleEventName of ['pageshow', 'pagehide', 'visibilitychange'] as const) {
+  for (const lifecycleEventName of [
+    'pageshow',
+    'pagehide',
+    'visibilitychange',
+  ] as const) {
     const dom = new JSDOM(
       '<!doctype html><body><a id="next" href="/next">Next</a></body>',
       { url: 'https://control.lab.theorymcp.ai/current' },
@@ -379,6 +404,36 @@ test('navigation pending: clears pending UI on lifecycle cleanup events', () => 
   }
 });
 
+test('navigation pending: clearing marked links preserves nested DOM content', () => {
+  const dom = new JSDOM(
+    '<!doctype html><body><a id="next" href="/next"><span>Next <strong>step</strong></span></a></body>',
+    { url: 'https://control.lab.theorymcp.ai/current' },
+  );
+
+  try {
+    const win = dom.window as unknown as DomWindow;
+    const doc = dom.window.document;
+    const anchor = doc.getElementById('next');
+    assert.ok(anchor instanceof dom.window.HTMLAnchorElement);
+    const before = anchor.innerHTML;
+
+    const controller = startNavigationPending({ document: doc, window: win });
+    anchor.dispatchEvent(click(win));
+    assert.equal(controller.isPending(), true);
+
+    controller.clear();
+
+    assert.equal(controller.isPending(), false);
+    assert.equal(anchor.innerHTML, before);
+    assert.ok(anchor.querySelector('span > strong'));
+    assert.equal(anchor.hasAttribute(NAVIGATION_PENDING_ATTRIBUTE), false);
+    assert.equal(anchor.hasAttribute('aria-busy'), false);
+    controller.stop();
+  } finally {
+    dom.window.close();
+  }
+});
+
 test('navigation pending: marks reduced-motion status without adding motion itself', () => {
   const dom = new JSDOM(
     '<!doctype html><body><a id="next" href="/next">Next</a></body>',
@@ -407,14 +462,18 @@ test('navigation pending: marks reduced-motion status without adding motion itse
     const controller = startNavigationPending({ document: doc, window: win });
     anchor.dispatchEvent(click(win));
 
-    const indicator = doc.getElementById(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID);
+    const indicator = doc.getElementById(
+      DEFAULT_NAVIGATION_PENDING_INDICATOR_ID,
+    );
     assert.ok(indicator instanceof dom.window.HTMLElement);
     assert.equal(
       indicator.getAttribute(NAVIGATION_PENDING_REDUCED_MOTION_ATTRIBUTE),
       'true',
     );
     assert.equal(
-      indicator.classList.contains('facetheory-navigation-pending--reduced-motion'),
+      indicator.classList.contains(
+        'facetheory-navigation-pending--reduced-motion',
+      ),
       true,
     );
 

--- a/ts/test/unit/responsive-primitives.test.ts
+++ b/ts/test/unit/responsive-primitives.test.ts
@@ -30,6 +30,7 @@ import {
   RESPONSIVE_LINK_CLASSIFIER_SOURCE,
   forcedSafeLinkRel,
   handleResponsiveLinkClick,
+  sanitizeResponsiveLinkHref,
   suppressButtonActivation,
 } from '../../src/responsive-primitives/index.js';
 import type { ResponsivePrimitiveName } from '../../src/responsive-primitives/index.js';
@@ -94,6 +95,15 @@ async function renderReactResponsive(): Promise<string> {
               },
               'Docs',
             ),
+            React.createElement(
+              ReactLink,
+              {
+                id: 'react-unsafe-link',
+                key: 'unsafe-link',
+                href: 'java\nscript:alert(1)',
+              },
+              'Unsafe',
+            ),
           ]),
       }),
     ],
@@ -133,6 +143,14 @@ async function renderVueResponsive(): Promise<string> {
               VueLink,
               { href: 'https://example.com/docs', target: '_blank' },
               { default: () => 'Docs' },
+            ),
+            h(
+              VueLink,
+              {
+                id: 'vue-unsafe-link',
+                href: 'data:text/html,<script>alert(1)</script>',
+              },
+              { default: () => 'Unsafe' },
             ),
           ]),
       }),
@@ -238,6 +256,14 @@ test('responsive primitives: React adapter renders a11y contract without inline 
   assert.match(body, /facetheory-rcp-button__spinner--append/);
   assert.match(body, /role="status" aria-live="polite">Loading/);
   assert.match(body, /rel="noopener noreferrer"/);
+  const dom = new JSDOM(body);
+  assert.equal(
+    dom.window.document
+      .getElementById('react-unsafe-link')
+      ?.getAttribute('href'),
+    null,
+  );
+  assert.equal(body.includes('java\nscript'), false);
   assert.doesNotMatch(body, /style="/);
 });
 
@@ -256,6 +282,12 @@ test('responsive primitives: Vue adapter renders parity a11y contract without in
   assert.match(body, /facetheory-rcp-button__spinner--append/);
   assert.match(body, /role="status" aria-live="polite">Loading/);
   assert.match(body, /rel="noopener noreferrer"/);
+  const dom = new JSDOM(body);
+  assert.equal(
+    dom.window.document.getElementById('vue-unsafe-link')?.getAttribute('href'),
+    null,
+  );
+  assert.equal(body.includes('data:text/html'), false);
   assert.doesNotMatch(body, /style="/);
 });
 
@@ -309,8 +341,55 @@ test('responsive primitives: Svelte adapter renders parity a11y contract without
   assert.match(link, /href="https:\/\/example.com\/docs"/);
   assert.match(link, /rel="noopener noreferrer"/);
 
-  for (const html of [spinner, skeleton, loading, boundary, button, link]) {
+  const unsafeLink = await renderSvelteComponent('Link', {
+    href: '\u0000javascript:alert(1)',
+  });
+  const unsafeDom = new JSDOM(unsafeLink);
+  assert.equal(
+    unsafeDom.window.document.querySelector('a')?.getAttribute('href'),
+    null,
+  );
+  assert.equal(unsafeLink.includes('javascript:'), false);
+
+  for (const html of [
+    spinner,
+    skeleton,
+    loading,
+    boundary,
+    button,
+    link,
+    unsafeLink,
+  ]) {
     assert.doesNotMatch(html, /style="/);
+  }
+});
+
+test('responsive primitives: Link href sanitizer rejects dangerous schemes and preserves safe URLs', () => {
+  const unsafe = [
+    'javascript:alert(1)',
+    'JaVaScRiPt:alert(1)',
+    ' java\t\nscript:alert(1)',
+    '\u0000javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    'file:///etc/passwd',
+  ];
+  for (const href of unsafe) {
+    assert.equal(sanitizeResponsiveLinkHref(href), undefined, href);
+  }
+
+  const safe = [
+    'https://example.com/docs',
+    'http://example.com/docs',
+    'mailto:ops@example.test',
+    'tel:+15551234567',
+    '/relative/path',
+    '?tab=agents',
+    '#section',
+    '//cdn.example.com/app.css',
+  ];
+  for (const href of safe) {
+    assert.equal(sanitizeResponsiveLinkHref(href), href, href);
   }
 });
 

--- a/ts/test/unit/streaming.test.ts
+++ b/ts/test/unit/streaming.test.ts
@@ -36,72 +36,6 @@ async function collectBodyChunks(
   return { chunks, full: chunks.join('') };
 }
 
-function extractScriptTags(html: string): string[] {
-  const tags: string[] = [];
-  const lower = html.toLowerCase();
-  let cursor = 0;
-
-  for (;;) {
-    const start = lower.indexOf('<script', cursor);
-    if (start === -1) break;
-    const nameEnd = start + '<script'.length;
-    if (!isHtmlTagBoundary(lower, nameEnd)) {
-      cursor = nameEnd;
-      continue;
-    }
-
-    const startTagEnd = findHtmlTagEnd(html, nameEnd);
-    if (startTagEnd === -1) break;
-    const endStart = findScriptEndTagStart(lower, startTagEnd + 1);
-    if (endStart === -1) break;
-    const endTagEnd = findHtmlTagEnd(html, endStart + '</script'.length);
-    if (endTagEnd === -1) break;
-
-    tags.push(html.slice(start, endTagEnd + 1));
-    cursor = endTagEnd + 1;
-  }
-
-  return tags;
-}
-
-function findScriptEndTagStart(lowerHtml: string, from: number): number {
-  let cursor = from;
-  for (;;) {
-    const start = lowerHtml.indexOf('</script', cursor);
-    if (start === -1) return -1;
-    const nameEnd = start + '</script'.length;
-    if (isHtmlTagBoundary(lowerHtml, nameEnd)) return start;
-    cursor = nameEnd;
-  }
-}
-
-function findHtmlTagEnd(html: string, from: number): number {
-  let quote: '"' | "'" | null = null;
-  for (let index = from; index < html.length; index += 1) {
-    const char = html[index];
-    if (quote) {
-      if (char === quote) quote = null;
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-      continue;
-    }
-    if (char === '>') return index;
-  }
-  return -1;
-}
-
-function isHtmlTagBoundary(html: string, index: number): boolean {
-  if (index >= html.length) return false;
-  const code = html.charCodeAt(index);
-  return code === 47 || code === 62 || isHtmlWhitespace(code);
-}
-
-function isHtmlWhitespace(code: number): boolean {
-  return code === 9 || code === 10 || code === 12 || code === 13 || code === 32;
-}
-
 function extractHydrationHref(html: string): string {
   const tag = /<link\b[^>]*rel="facetheory-hydration"[^>]*>/i.exec(html)?.[0];
   assert.ok(tag, 'expected FaceTheory hydration link');
@@ -313,7 +247,7 @@ test('FaceApp: strict CSP streaming responses are coerced to validated buffered 
   assert.equal(full.includes('__FACETHEORY_DATA__'), false);
 });
 
-test('FaceApp: strict CSP streaming with nonce validates the head and preserves streaming', async () => {
+test('FaceApp: strict CSP streaming with nonce validates the full document before responding', async () => {
   let streamChunksRead = 0;
   const metrics: Array<{ name: string; tags?: Record<string, string> }> = [];
   const logs: Array<{ isStream?: boolean }> = [];
@@ -366,8 +300,8 @@ test('FaceApp: strict CSP streaming with nonce validates the head and preserves 
     cspNonce: 'nonce-strict-stream',
   });
   assert.equal(resp.status, 200);
-  assert.ok(!(resp.body instanceof Uint8Array));
-  assert.equal(streamChunksRead, 1);
+  assert.ok(resp.body instanceof Uint8Array);
+  assert.equal(streamChunksRead, 2);
   assert.match(
     resp.headers['content-security-policy']?.[0] ?? '',
     /script-src 'self' 'nonce-nonce-strict-stream'/,
@@ -380,42 +314,19 @@ test('FaceApp: strict CSP streaming with nonce validates the head and preserves 
   const requestMetric = metrics.find(
     (entry) => entry.name === 'facetheory.request',
   );
-  assert.equal(requestMetric?.tags?.is_stream, '1');
-  assert.equal(logs.at(-1)?.isStream, true);
+  assert.equal(requestMetric?.tags?.is_stream, '0');
+  assert.equal(logs.at(-1)?.isStream, false);
 
-  const iterator = (resp.body as AsyncIterable<Uint8Array>)[
-    Symbol.asyncIterator
-  ]();
-  const firstChunk = await iterator.next();
-  assert.equal(firstChunk.done, false);
-  const first = new TextDecoder().decode(firstChunk.value);
-  assert.ok(first.startsWith('<!doctype html>'));
+  const full = new TextDecoder().decode(resp.body);
+  assert.ok(full.startsWith('<!doctype html>'));
   assert.match(
-    first,
+    full,
     /<head><meta charset="utf-8"><title>Strict streamed title<\/title><link href="\/assets\/app.css" rel="stylesheet"><meta content="new" name="description"><link href="\/_facetheory\/hydration\/strict-stream\.json" id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration" type="application\/json"><script nonce="nonce-strict-stream" src="\/assets\/entry\.js" type="module"><\/script><\/head>/,
   );
-  assert.equal(first.includes('Old title'), false);
-  assert.equal(first.includes('content="old"'), false);
-  assert.equal(first.includes('strict streamed first'), false);
-
-  const rest: Uint8Array[] = [];
-  for (;;) {
-    const next = await iterator.next();
-    if (next.done) break;
-    rest.push(next.value);
-  }
-  const full =
-    first +
-    new TextDecoder().decode(
-      await collectBody(
-        (async function* () {
-          for (const chunk of rest) yield chunk;
-        })(),
-      ),
-    );
+  assert.equal(full.includes('Old title'), false);
+  assert.equal(full.includes('content="old"'), false);
   assert.ok(full.includes('<main>strict streamed first</main>'));
   assert.ok(full.includes('<footer>strict streamed second</footer>'));
-  assert.equal(streamChunksRead, 2);
 });
 
 test('FaceApp: strict CSP streaming uses a default bounded collector', async () => {
@@ -530,6 +441,41 @@ test('FaceApp: strict CSP streaming violations fail before bytes flush', async (
   assert.equal(full.includes('onclick'), false);
 });
 
+test('FaceApp: strict CSP streaming with nonce rejects unsafe body scripts before bytes flush', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/',
+        mode: 'ssr',
+        render: () => ({
+          csp: {
+            inlineScripts: false,
+            inlineStyles: false,
+            rawHead: false,
+          },
+          html: (async function* () {
+            yield utf8('<main>safe first chunk</main>');
+            yield utf8('<script nonce="nonce-stream">alert("unsafe")</script>');
+          })(),
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/',
+    cspNonce: 'nonce-stream',
+  });
+  assert.equal(resp.status, 500);
+  assert.ok(resp.body instanceof Uint8Array);
+
+  const full = new TextDecoder().decode(resp.body);
+  assert.ok(full.includes('<h1>Internal Server Error</h1>'));
+  assert.equal(full.includes('safe first chunk'), false);
+  assert.equal(full.includes('alert("unsafe")'), false);
+});
+
 test('FaceApp: strict React stream externalizes hydration sidecar and keeps bootstrap module external', async () => {
   const htmlStore = new InMemoryHtmlStore();
   const app = createFaceApp({
@@ -562,7 +508,7 @@ test('FaceApp: strict React stream externalizes hydration sidecar and keeps boot
     cspNonce: 'nonce-sidecar-stream',
   });
   assert.equal(resp.status, 200);
-  assert.ok(!(resp.body instanceof Uint8Array));
+  assert.ok(resp.body instanceof Uint8Array);
 
   const { full } = await collectBodyChunks(resp.body);
   assert.ok(full.includes('Strict stream sidecar'));
@@ -588,7 +534,7 @@ test('FaceApp: strict React stream externalizes hydration sidecar and keeps boot
   });
 });
 
-test('react adapter: React 19 shell stream nonces bootstrap and Suspense reveal scripts', async () => {
+test('react adapter: strict CSP shell stream fails closed on Suspense reveal scripts', async () => {
   const nonce = 'nonce-react19-midstream';
   const LazyPanel = React.lazy(async () => {
     await delay(40);
@@ -630,48 +576,14 @@ test('react adapter: React 19 shell stream nonces bootstrap and Suspense reveal 
   });
 
   const resp = await app.handle({ method: 'GET', path: '/', cspNonce: nonce });
-  assert.equal(resp.status, 200);
-  assert.ok(!(resp.body instanceof Uint8Array));
+  assert.equal(resp.status, 500);
+  assert.ok(resp.body instanceof Uint8Array);
 
-  const { chunks, full } = await collectBodyChunks(resp.body);
-  assert.ok(
-    chunks.length >= 4,
-    `expected streamed chunks, received ${String(chunks.length)}`,
-  );
-  assert.ok(full.includes('Control plane shell'));
-  assert.ok(full.includes('Loading data'));
-  assert.ok(full.includes('Late control-plane data'));
-
-  const scriptTags = extractScriptTags(full);
-  assert.ok(scriptTags.length >= 3, scriptTags.join('\n'));
-  assert.ok(
-    scriptTags.some((tag) =>
-      tag.includes('src="/assets/control-plane-entry.js"'),
-    ),
-    scriptTags.join('\n'),
-  );
-  assert.ok(
-    scriptTags.some((tag) => tag.includes('$RT=performance.now()')),
-    scriptTags.join('\n'),
-  );
-  assert.ok(
-    scriptTags.some((tag) => tag.includes('$RC(')),
-    scriptTags.join('\n'),
-  );
-
-  for (const tag of scriptTags) {
-    assert.ok(tag.includes(`nonce="${nonce}"`), tag);
-  }
-
-  const reactScriptChunks = chunks.filter(
-    (chunk) =>
-      chunk.includes('<script') &&
-      (chunk.includes('$RT=') || chunk.includes('$RC(')),
-  );
-  assert.ok(reactScriptChunks.length >= 2, reactScriptChunks.join('\n'));
-  assert.ok(
-    reactScriptChunks.every((chunk) => chunk.includes(`nonce="${nonce}"`)),
-  );
+  const full = new TextDecoder().decode(resp.body);
+  assert.ok(full.includes('<h1>Internal Server Error</h1>'));
+  assert.equal(full.includes('Control plane shell'), false);
+  assert.equal(full.includes('Late control-plane data'), false);
+  assert.equal(full.includes('$RC('), false);
 });
 
 test('react adapter: streaming includes AntD + Emotion styles in head before body', async () => {
@@ -843,7 +755,12 @@ test('react adapter: integrations receive isolated per-render state across the r
       createReactStreamFace({
         route: '/',
         mode: 'ssr',
-        render: () => React.createElement('main', { className: 'from-int' }, 'Request state'),
+        render: () =>
+          React.createElement(
+            'main',
+            { className: 'from-int' },
+            'Request state',
+          ),
         renderOptions: {
           integrations: [
             {
@@ -852,7 +769,9 @@ test('react adapter: integrations receive isolated per-render state across the r
               wrapTree: (tree, _ctx, state) =>
                 React.createElement(
                   'section',
-                  { className: `wrapped-${String((state as { id: number }).id)}` },
+                  {
+                    className: `wrapped-${String((state as { id: number }).id)}`,
+                  },
                   tree,
                 ),
               contribute: (_ctx, state) => ({
@@ -868,7 +787,9 @@ test('react adapter: integrations receive isolated per-render state across the r
                 styleTags: [
                   {
                     cssText: `.from-int-${String((state as { id: number }).id)}{color:rgb(4,5,6);}`,
-                    attrs: { id: `style-state-${String((state as { id: number }).id)}` },
+                    attrs: {
+                      id: `style-state-${String((state as { id: number }).id)}`,
+                    },
                   },
                 ],
               }),


### PR DESCRIPTION
## Summary
- Enforce strict CSP on control-plane section endpoints, including safe fail-closed handling for unsafe fragments.
- Disable the strict CSP streaming nonce fast path so strict streams are fully collected and validated before response/storage.
- Preserve strict CSP metadata for ISR through meta records and cached HTML object metadata, and validate strict cached HTML before re-emitting it.
- Sanitize responsive Link hrefs across React, Vue, Svelte, and the shared helper.
- Preserve nested DOM content when navigation pending state is cleared.

## Validation
- `node --test --import tsx test/unit/control-plane-guardrails.test.ts test/unit/streaming.test.ts test/unit/isr.test.ts test/unit/responsive-primitives.test.ts test/unit/navigation-pending.test.ts test/unit/aws-s3.test.ts`
- `make ts-typecheck`
- `make ts-test`
- `make ts-build`
- `scripts/verify-version-alignment.sh`

## Risk / Notes
- Strict CSP streaming now buffers for full-document validation instead of preserving the nonce-based stream fast path.
- TableTheory ISR metadata cannot carry arbitrary CSP fields, so strict CSP is also persisted in cached HTML object metadata.
- Prettier cannot infer a parser for `src/svelte/responsive-primitives/Link.svelte`; the Svelte edit was validated through tests/build.

References THE-2103
