### PR TITLE
fix(release): correct release-train gate no-ops

### DIFF
--- a/scripts/verify-release-pr-postcondition.sh
+++ b/scripts/verify-release-pr-postcondition.sh
@@ -6,6 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 version_line_re='^[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+(-rc(\.[0-9]+)?)?)[[:space:]]*(#.*)?$'
 rc_version_re='^[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$'
 stable_version_re='^[0-9]+\.[0-9]+\.[0-9]+$'
+releasable_subject_re='^(feat|fix|perf)(\([^)]+\))?(!)?: '
 
 parse_version_value() {
   local raw="$1"
@@ -28,19 +29,292 @@ is_stable_version() {
   [[ "$1" =~ ${stable_version_re} ]]
 }
 
-if [[ "${1:-}" == "--self-test" ]]; then
+manifest_version() {
+  local manifest_path="$1"
+
+  python3 - "${manifest_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+version = json.loads(manifest_path.read_text(encoding="utf-8")).get(".", "")
+if not version:
+    raise SystemExit(f"missing release-please version in {manifest_path}")
+print(version)
+PY
+}
+
+baseline_tag_from_manifest() {
+  local manifest_path="$1"
+  local version
+
+  version="$(manifest_version "${manifest_path}")"
+  printf 'v%s\n' "${version#v}"
+}
+
+fetch_base_branch_and_tags() {
+  local base_branch="$1"
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    git fetch --force --tags origin "+refs/heads/${base_branch}:refs/remotes/origin/${base_branch}" >/dev/null 2>&1
+  fi
+}
+
+resolve_base_ref() {
+  local base_branch="$1"
+
+  if git rev-parse --verify --quiet "origin/${base_branch}^{commit}" >/dev/null; then
+    printf 'origin/%s\n' "${base_branch}"
+    return 0
+  fi
+
+  if git rev-parse --verify --quiet "${base_branch}^{commit}" >/dev/null; then
+    printf '%s\n' "${base_branch}"
+    return 0
+  fi
+
+  return 1
+}
+
+has_releasable_commits_since() {
+  local baseline="$1"
+  local base_ref="$2"
+  local commit_subjects
+
+  # Same user-facing predicate as prerelease/readiness CI, anchored on the
+  # manifest-recorded tag and excluding merges:
+  # git log --no-merges --format=%s <baseline>..<base_branch> |
+  #   grep -Eq '^(feat|fix|perf)(\([^)]+\))?(!)?: '
+  commit_subjects="$(git log --no-merges --format=%s "${baseline}..${base_ref}")"
+  grep -Eq "${releasable_subject_re}" <<<"${commit_subjects}"
+}
+
+verify_no_open_release_pr_is_legitimate_noop() {
+  local base_branch="$1"
+  local release_branch="$2"
+  local expected_shape="$3"
+  local noop_message="$4"
+  local manifest_path="$5"
+  local baseline
+  local base_ref
+
+  if ! baseline="$(baseline_tag_from_manifest "${manifest_path}")"; then
+    echo "release-pr-postcondition: FAIL (${noop_message}; could not read ${manifest_path} to derive the ${base_branch} release baseline)" >&2
+    return 1
+  fi
+
+  if ! fetch_base_branch_and_tags "${base_branch}"; then
+    echo "release-pr-postcondition: FAIL (${noop_message}; could not fetch ${base_branch} and tags to check commits since ${baseline})" >&2
+    return 1
+  fi
+
+  if ! git rev-parse --verify --quiet "${baseline}^{commit}" >/dev/null; then
+    echo "release-pr-postcondition: FAIL (${noop_message}; recorded ${base_branch} manifest baseline tag ${baseline} is missing, so no-op cannot be proven)" >&2
+    return 1
+  fi
+
+  if ! base_ref="$(resolve_base_ref "${base_branch}")"; then
+    echo "release-pr-postcondition: FAIL (${noop_message}; could not resolve ${base_branch} to check commits since ${baseline})" >&2
+    return 1
+  fi
+
+  if has_releasable_commits_since "${baseline}" "${base_ref}"; then
+    echo "release-pr-postcondition: FAIL (${noop_message}; expected an open generated ${expected_shape} Release Please PR ${release_branch} -> ${base_branch})" >&2
+    return 1
+  fi
+
+  echo "release-pr-postcondition: PASS (legitimate no-op; nothing user-facing to release on ${base_branch} since ${baseline})"
+}
+
+self_test_commit() {
+  local tree="$1"
+  shift
+  GIT_AUTHOR_NAME="FaceTheory Release Self Test" \
+  GIT_AUTHOR_EMAIL="facetheory-release-self-test@example.invalid" \
+  GIT_AUTHOR_DATE="2026-06-19T00:00:00Z" \
+  GIT_COMMITTER_NAME="FaceTheory Release Self Test" \
+  GIT_COMMITTER_EMAIL="facetheory-release-self-test@example.invalid" \
+  GIT_COMMITTER_DATE="2026-06-19T00:00:00Z" \
+    git commit-tree "${tree}" "$@"
+}
+
+self_test_tree() {
+  local content="$1"
+  local blob
+  blob="$(printf '%s\n' "${content}" | git hash-object -w --stdin)"
+  printf '100644 blob %s\tself-test.txt\n' "${blob}" | git mktree
+}
+
+self_test_version_parser() {
+  local parsed
+
   parsed="$(parse_version_value '1.12.2-rc # x-release-please-version')"
-  [[ "${parsed}" == "1.12.2-rc" ]] && is_rc_version "${parsed}" && ! is_stable_version "${parsed}"
+  [[ "${parsed}" == "1.12.2-rc" ]] || {
+    echo "release-pr-postcondition: FAIL (self-test annotated RC parsed as ${parsed})" >&2
+    return 1
+  }
+  is_rc_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test annotated RC was not accepted as RC)" >&2
+    return 1
+  }
+  ! is_stable_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test annotated RC was accepted as stable)" >&2
+    return 1
+  }
+
   parsed="$(parse_version_value '1.12.2-rc.7 # x-release-please-version')"
-  [[ "${parsed}" == "1.12.2-rc.7" ]] && is_rc_version "${parsed}"
+  [[ "${parsed}" == "1.12.2-rc.7" ]] || {
+    echo "release-pr-postcondition: FAIL (self-test numbered annotated RC parsed as ${parsed})" >&2
+    return 1
+  }
+  is_rc_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test numbered annotated RC was not accepted as RC)" >&2
+    return 1
+  }
+
   parsed="$(parse_version_value '1.12.2 # x-release-please-version')"
-  [[ "${parsed}" == "1.12.2" ]] && is_stable_version "${parsed}" && ! is_rc_version "${parsed}"
+  [[ "${parsed}" == "1.12.2" ]] || {
+    echo "release-pr-postcondition: FAIL (self-test annotated stable parsed as ${parsed})" >&2
+    return 1
+  }
+  is_stable_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test annotated stable was not accepted as stable)" >&2
+    return 1
+  }
+  ! is_rc_version "${parsed}" || {
+    echo "release-pr-postcondition: FAIL (self-test annotated stable was accepted as RC)" >&2
+    return 1
+  }
+
   if parse_version_value '1.12.2-rcx # x-release-please-version' >/dev/null; then
     echo "release-pr-postcondition: FAIL (self-test malformed RC was parsed)" >&2
-    exit 1
+    return 1
   fi
-  echo "release-pr-postcondition: PASS (self-test)"
-  exit 0
+
+  echo "release-pr-postcondition: PASS (self-test VERSION parser; annotated RC accepted and stable/RC mismatches rejected)"
+}
+
+self_test_no_open_release_pr_channel() {
+  local channel="$1"
+  local base_branch="$2"
+  local manifest_path="$3"
+  local expected_shape="$4"
+  local noop_message="$5"
+  local release_branch="$6"
+  local version="999.999.$7"
+  local ref_prefix="refs/facetheory-release-self-test/pr-postcondition/${channel}/$$"
+  local baseline_tag="refs/tags/v${version}"
+  local cleanup_refs=()
+  local test_dir="$(git rev-parse --git-path facetheory-release-self-tests)"
+  local empty_tree noop_tree miss_tree
+  local baseline noop_head miss_head output
+
+  cleanup_release_pr_self_test_refs() {
+    local ref
+    for ref in "${cleanup_refs[@]:-}"; do
+      git update-ref -d "${ref}" >/dev/null 2>&1 || true
+    done
+    if [[ -n "${manifest_path:-}" ]]; then
+      rm -f "${manifest_path}" >/dev/null 2>&1 || true
+    fi
+    trap - RETURN
+  }
+  trap cleanup_release_pr_self_test_refs RETURN
+
+  if git rev-parse --verify --quiet "${baseline_tag}^{commit}" >/dev/null; then
+    echo "release-pr-postcondition: FAIL (self-test baseline tag ${baseline_tag} already exists)" >&2
+    return 1
+  fi
+
+  mkdir -p "${test_dir}"
+  printf '{".": "%s"}\n' "${version}" >"${manifest_path}"
+
+  empty_tree="$(git mktree </dev/null)"
+  noop_tree="$(self_test_tree "${channel} noop docs")"
+  miss_tree="$(self_test_tree "${channel} releasable fix")"
+  baseline="$(self_test_commit "${empty_tree}" -m 'chore: seed release baseline')"
+  noop_head="$(self_test_commit "${noop_tree}" -p "${baseline}" -m 'docs: internal release note')"
+  miss_head="$(self_test_commit "${miss_tree}" -p "${noop_head}" -m 'fix: self-test releasable change')"
+
+  git update-ref "${baseline_tag}" "${baseline}"
+  git update-ref "${ref_prefix}/noop" "${noop_head}"
+  git update-ref "${ref_prefix}/miss" "${miss_head}"
+  cleanup_refs+=("${baseline_tag}" "${ref_prefix}/noop" "${ref_prefix}/miss")
+
+  if ! output="$(
+    (
+      fetch_base_branch_and_tags() { return 0; }
+      resolve_base_ref() { printf '%s\n' "${ref_prefix}/noop"; }
+      verify_no_open_release_pr_is_legitimate_noop \
+        "${base_branch}" \
+        "${release_branch}" \
+        "${expected_shape}" \
+        "${noop_message}" \
+        "${manifest_path}"
+    ) 2>&1
+  )"; then
+    printf '%s\n' "${output}" >&2
+    echo "release-pr-postcondition: FAIL (self-test ${channel} legitimate no-op was rejected)" >&2
+    return 1
+  fi
+  if [[ "${output}" != *"legitimate no-op"* ]]; then
+    printf '%s\n' "${output}" >&2
+    echo "release-pr-postcondition: FAIL (self-test ${channel} no-op did not report legitimate no-op)" >&2
+    return 1
+  fi
+  echo "release-pr-postcondition: PASS (self-test ${channel} empty release-please PR with zero user-facing commits passed)"
+
+  if output="$(
+    (
+      fetch_base_branch_and_tags() { return 0; }
+      resolve_base_ref() { printf '%s\n' "${ref_prefix}/miss"; }
+      verify_no_open_release_pr_is_legitimate_noop \
+        "${base_branch}" \
+        "${release_branch}" \
+        "${expected_shape}" \
+        "${noop_message}" \
+        "${manifest_path}"
+    ) 2>&1
+  )"; then
+    printf '%s\n' "${output}" >&2
+    echo "release-pr-postcondition: FAIL (self-test ${channel} genuine missed release PR was accepted)" >&2
+    return 1
+  fi
+  if [[ "${output}" != *"expected an open generated ${expected_shape} Release Please PR ${release_branch} -> ${base_branch}"* ]]; then
+    printf '%s\n' "${output}" >&2
+    echo "release-pr-postcondition: FAIL (self-test ${channel} genuine miss did not preserve the fail-closed message)" >&2
+    return 1
+  fi
+  echo "release-pr-postcondition: PASS (self-test ${channel} user-facing commit without release-please PR failed closed)"
+}
+
+self_test_no_open_release_prs() {
+  local test_dir="$(git rev-parse --git-path facetheory-release-self-tests)"
+  mkdir -p "${test_dir}"
+  self_test_no_open_release_pr_channel \
+    "prerelease" \
+    "premain" \
+    "${test_dir}/prerelease-manifest-$$.json" \
+    "RC" \
+    "release-please no-op is a failed RC gate" \
+    "release-please--branches--premain" \
+    "101"
+  self_test_no_open_release_pr_channel \
+    "stable" \
+    "main" \
+    "${test_dir}/stable-manifest-$$.json" \
+    "stable" \
+    "release-please no-op is a failed stable gate" \
+    "release-please--branches--main" \
+    "102"
+  rmdir "${test_dir}" >/dev/null 2>&1 || true
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test_version_parser
+  self_test_no_open_release_prs
+  exit $?
 fi
 
 channel="${1:-}"
@@ -50,12 +324,14 @@ case "${channel}" in
     release_branch="release-please--branches--premain"
     expected_shape="RC"
     noop_message="release-please no-op is a failed RC gate"
+    manifest_path=".release-please-manifest.premain.json"
     ;;
   stable)
     base_branch="main"
     release_branch="release-please--branches--main"
     expected_shape="stable"
     noop_message="release-please no-op is a failed stable gate"
+    manifest_path=".release-please-manifest.json"
     ;;
   *)
     echo "release-pr-postcondition: FAIL (usage: $0 prerelease|stable)" >&2
@@ -84,8 +360,13 @@ pr_number="$(
 )"
 
 if [[ -z "${pr_number}" ]]; then
-  echo "release-pr-postcondition: FAIL (${noop_message}; expected an open generated ${expected_shape} Release Please PR ${release_branch} -> ${base_branch})" >&2
-  exit 1
+  verify_no_open_release_pr_is_legitimate_noop \
+    "${base_branch}" \
+    "${release_branch}" \
+    "${expected_shape}" \
+    "${noop_message}" \
+    "${manifest_path}"
+  exit $?
 fi
 
 title="$(gh pr view --repo "${repository}" "${pr_number}" --json title --jq '.title')"

--- a/scripts/verify-release-publish-postcondition.sh
+++ b/scripts/verify-release-publish-postcondition.sh
@@ -3,6 +3,338 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+releasable_subject_re='^(feat|fix|perf)(\([^)]+\))?(!)?: '
+
+is_rc_tag() {
+  [[ "${1:-}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]
+}
+
+is_stable_tag() {
+  [[ "${1:-}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+manifest_version() {
+  local manifest_path="$1"
+
+  python3 - "${manifest_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+version = json.loads(manifest_path.read_text(encoding="utf-8")).get(".", "")
+if not version:
+    raise SystemExit(f"missing release-please version in {manifest_path}")
+print(version)
+PY
+}
+
+baseline_tag_from_manifest() {
+  local manifest_path="$1"
+  local version
+
+  version="$(manifest_version "${manifest_path}")"
+  printf 'v%s\n' "${version#v}"
+}
+
+fetch_base_branch_and_tags() {
+  local base_branch="$1"
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    git fetch --force --tags origin "+refs/heads/${base_branch}:refs/remotes/origin/${base_branch}" >/dev/null 2>&1
+  fi
+}
+
+resolve_base_ref() {
+  local base_branch="$1"
+
+  if git rev-parse --verify --quiet "origin/${base_branch}^{commit}" >/dev/null; then
+    printf 'origin/%s\n' "${base_branch}"
+    return 0
+  fi
+
+  if git rev-parse --verify --quiet "${base_branch}^{commit}" >/dev/null; then
+    printf '%s\n' "${base_branch}"
+    return 0
+  fi
+
+  return 1
+}
+
+has_releasable_commits_since() {
+  local baseline="$1"
+  local base_ref="$2"
+  local commit_subjects
+
+  # Same user-facing predicate as prerelease/readiness CI, anchored on the
+  # manifest-recorded tag and excluding merges:
+  # git log --no-merges --format=%s <baseline>..<base_branch> |
+  #   grep -Eq '^(feat|fix|perf)(\([^)]+\))?(!)?: '
+  commit_subjects="$(git log --no-merges --format=%s "${baseline}..${base_ref}")"
+  grep -Eq "${releasable_subject_re}" <<<"${commit_subjects}"
+}
+
+is_published_stable_release() {
+  local tag="$1"
+  local repository="${GITHUB_REPOSITORY:-}"
+  local release_state
+
+  if command -v gh >/dev/null 2>&1; then
+    local gh_args=()
+    if [[ -n "${repository}" ]]; then
+      gh_args=(--repo "${repository}")
+    fi
+    if release_state="$(
+      gh release view "${tag}" \
+        "${gh_args[@]}" \
+        --json isDraft,isPrerelease \
+        --jq 'if (.isDraft == false and .isPrerelease == false) then "published-stable" else "" end' \
+        2>/dev/null
+    )" && [[ "${release_state}" == "published-stable" ]]; then
+      return 0
+    fi
+  fi
+
+  [[ -n "${repository}" ]] || return 1
+
+  python3 - "${repository}" "${tag}" <<'PY'
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+repository = sys.argv[1]
+tag = sys.argv[2]
+parts = repository.split("/", 1)
+if len(parts) != 2 or not all(parts):
+    raise SystemExit(1)
+owner, name = parts
+api_base = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+url = (
+    f"{api_base}/repos/"
+    f"{urllib.parse.quote(owner, safe='')}/"
+    f"{urllib.parse.quote(name, safe='')}/"
+    f"releases/tags/{urllib.parse.quote(tag, safe='')}"
+)
+headers = {
+    "Accept": "application/vnd.github+json",
+    "User-Agent": "facetheory-release-publish-postcondition",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+if token:
+    headers["Authorization"] = f"Bearer {token}"
+request = urllib.request.Request(url, headers=headers)
+try:
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+    raise SystemExit(1)
+
+if payload.get("draft") is False and payload.get("prerelease") is False:
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+stable_already_published_noop_is_legitimate() {
+  local baseline
+  local base_ref
+
+  if ! baseline="$(baseline_tag_from_manifest "${stable_manifest_path:-.release-please-manifest.json}")"; then
+    return 1
+  fi
+
+  if [[ "${baseline}" != "${expected_tag}" ]]; then
+    return 1
+  fi
+
+  if ! is_stable_tag "${baseline}"; then
+    return 1
+  fi
+
+  if ! is_published_stable_release "${baseline}"; then
+    return 1
+  fi
+
+  if ! fetch_base_branch_and_tags "main"; then
+    return 1
+  fi
+
+  if ! git rev-parse --verify --quiet "${baseline}^{commit}" >/dev/null; then
+    return 1
+  fi
+
+  if ! base_ref="$(resolve_base_ref "main")"; then
+    return 1
+  fi
+
+  if has_releasable_commits_since "${baseline}" "${base_ref}"; then
+    return 1
+  fi
+
+  echo "release-publish-postcondition: PASS (already published ${baseline}; legitimate no-op)"
+}
+
+require_created_tag() {
+  local expected_shape="$1"
+
+  if [[ "${release_created}" != "true" ]]; then
+    if [[ "${expected_shape}" == "stable" ]] && stable_already_published_noop_is_legitimate; then
+      return 0
+    fi
+
+    echo "release-publish-postcondition: FAIL (release-please no-op is a failed ${expected_shape} publish gate; release_created=${release_created:-<empty>})" >&2
+    return 1
+  fi
+
+  if [[ -z "${tag_name}" ]]; then
+    echo "release-publish-postcondition: FAIL (${expected_shape} publish gate created a release without tag_name)" >&2
+    return 1
+  fi
+
+  if [[ "${tag_name}" != "${expected_tag}" ]]; then
+    echo "release-publish-postcondition: FAIL (${expected_shape} tag ${tag_name} != expected ${expected_tag})" >&2
+    return 1
+  fi
+}
+
+verify_stable_publish_postcondition() {
+  if is_rc_tag "${expected_tag}"; then
+    if [[ "${release_created}" == "true" ]]; then
+      echo "release-publish-postcondition: FAIL (main must never create or advertise RC tag ${tag_name:-<empty>})" >&2
+      return 1
+    fi
+    echo "release-publish-postcondition: PASS (pending stable PR generation from RC handoff ${expected_tag})"
+    return 0
+  fi
+
+  if [[ "${release_created}" != "true" ]]; then
+    require_created_tag "stable"
+    return $?
+  fi
+
+  require_created_tag "stable" || return 1
+  if ! is_stable_tag "${tag_name}"; then
+    echo "release-publish-postcondition: FAIL (stable tag ${tag_name} is not stable-shaped)" >&2
+    return 1
+  fi
+  echo "release-publish-postcondition: PASS (stable ${tag_name})"
+}
+
+self_test_commit() {
+  local tree="$1"
+  shift
+  GIT_AUTHOR_NAME="FaceTheory Release Self Test" \
+  GIT_AUTHOR_EMAIL="facetheory-release-self-test@example.invalid" \
+  GIT_AUTHOR_DATE="2026-06-19T00:00:00Z" \
+  GIT_COMMITTER_NAME="FaceTheory Release Self Test" \
+  GIT_COMMITTER_EMAIL="facetheory-release-self-test@example.invalid" \
+  GIT_COMMITTER_DATE="2026-06-19T00:00:00Z" \
+    git commit-tree "${tree}" "$@"
+}
+
+self_test_tree() {
+  local content="$1"
+  local blob
+  blob="$(printf '%s\n' "${content}" | git hash-object -w --stdin)"
+  printf '100644 blob %s\tself-test.txt\n' "${blob}" | git mktree
+}
+
+self_test_stable_already_published_noop() {
+  local version="999.999.201"
+  local baseline_tag="refs/tags/v${version}"
+  local ref_prefix="refs/facetheory-release-self-test/publish-postcondition/stable/$$"
+  local manifest_path="$(git rev-parse --git-path facetheory-release-self-tests/publish-stable-manifest-$$.json)"
+  local cleanup_refs=()
+  local empty_tree noop_tree miss_tree
+  local baseline noop_head miss_head output
+
+  cleanup_release_publish_self_test_refs() {
+    local ref
+    for ref in "${cleanup_refs[@]:-}"; do
+      git update-ref -d "${ref}" >/dev/null 2>&1 || true
+    done
+    if [[ -n "${manifest_path:-}" ]]; then
+      rm -f "${manifest_path}" >/dev/null 2>&1 || true
+    fi
+    rmdir "$(git rev-parse --git-path facetheory-release-self-tests)" >/dev/null 2>&1 || true
+    trap - RETURN
+  }
+  trap cleanup_release_publish_self_test_refs RETURN
+
+  if git rev-parse --verify --quiet "${baseline_tag}^{commit}" >/dev/null; then
+    echo "release-publish-postcondition: FAIL (self-test baseline tag ${baseline_tag} already exists)" >&2
+    return 1
+  fi
+
+  mkdir -p "$(git rev-parse --git-path facetheory-release-self-tests)"
+  printf '{".": "%s"}\n' "${version}" >"${manifest_path}"
+
+  empty_tree="$(git mktree </dev/null)"
+  noop_tree="$(self_test_tree 'stable publish noop docs')"
+  miss_tree="$(self_test_tree 'stable publish releasable perf')"
+  baseline="$(self_test_commit "${empty_tree}" -m 'chore: seed stable baseline')"
+  noop_head="$(self_test_commit "${noop_tree}" -p "${baseline}" -m 'docs: internal release note')"
+  miss_head="$(self_test_commit "${miss_tree}" -p "${noop_head}" -m 'perf: self-test releasable change')"
+
+  git update-ref "${baseline_tag}" "${baseline}"
+  git update-ref "${ref_prefix}/noop" "${noop_head}"
+  git update-ref "${ref_prefix}/miss" "${miss_head}"
+  cleanup_refs+=("${baseline_tag}" "${ref_prefix}/noop" "${ref_prefix}/miss")
+
+  expected_tag="v${version}"
+  release_created="false"
+  tag_name=""
+
+  if ! output="$(
+    (
+      stable_manifest_path="${manifest_path}"
+      fetch_base_branch_and_tags() { return 0; }
+      resolve_base_ref() { printf '%s\n' "${ref_prefix}/noop"; }
+      is_published_stable_release() { [[ "${1:-}" == "v${version}" ]]; }
+      verify_stable_publish_postcondition
+    ) 2>&1
+  )"; then
+    printf '%s\n' "${output}" >&2
+    echo "release-publish-postcondition: FAIL (self-test stable already-published no-op was rejected)" >&2
+    return 1
+  fi
+  if [[ "${output}" != *"already published v${version}; legitimate no-op"* ]]; then
+    printf '%s\n' "${output}" >&2
+    echo "release-publish-postcondition: FAIL (self-test stable no-op did not report already-published tolerance)" >&2
+    return 1
+  fi
+  echo "release-publish-postcondition: PASS (self-test stable already-published tag with zero user-facing commits passed)"
+
+  if output="$(
+    (
+      stable_manifest_path="${manifest_path}"
+      fetch_base_branch_and_tags() { return 0; }
+      resolve_base_ref() { printf '%s\n' "${ref_prefix}/miss"; }
+      is_published_stable_release() { [[ "${1:-}" == "v${version}" ]]; }
+      verify_stable_publish_postcondition
+    ) 2>&1
+  )"; then
+    printf '%s\n' "${output}" >&2
+    echo "release-publish-postcondition: FAIL (self-test stable genuine miss was accepted)" >&2
+    return 1
+  fi
+  if [[ "${output}" != *"release-publish-postcondition: FAIL (release-please no-op is a failed stable publish gate; release_created=false)"* ]]; then
+    printf '%s\n' "${output}" >&2
+    echo "release-publish-postcondition: FAIL (self-test stable genuine miss did not preserve the fail-closed message)" >&2
+    return 1
+  fi
+  echo "release-publish-postcondition: PASS (self-test stable already-published tag with a user-facing commit failed closed)"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  self_test_stable_already_published_noop
+  exit $?
+fi
+
 channel="${1:-}"
 release_created="${2:-}"
 tag_name="${3:-}"
@@ -17,37 +349,10 @@ esac
 
 expected_tag="v$(./scripts/read-version.sh)"
 
-is_rc_tag() {
-  [[ "${1:-}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+-rc(\.[0-9]+)?$ ]]
-}
-
-is_stable_tag() {
-  [[ "${1:-}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]
-}
-
-require_created_tag() {
-  local expected_shape="$1"
-
-  if [[ "${release_created}" != "true" ]]; then
-    echo "release-publish-postcondition: FAIL (release-please no-op is a failed ${expected_shape} publish gate; release_created=${release_created:-<empty>})" >&2
-    exit 1
-  fi
-
-  if [[ -z "${tag_name}" ]]; then
-    echo "release-publish-postcondition: FAIL (${expected_shape} publish gate created a release without tag_name)" >&2
-    exit 1
-  fi
-
-  if [[ "${tag_name}" != "${expected_tag}" ]]; then
-    echo "release-publish-postcondition: FAIL (${expected_shape} tag ${tag_name} != expected ${expected_tag})" >&2
-    exit 1
-  fi
-}
-
 case "${channel}" in
   prerelease)
     if is_rc_tag "${expected_tag}"; then
-      require_created_tag "RC"
+      require_created_tag "RC" || exit 1
       if ! is_rc_tag "${tag_name}"; then
         echo "release-publish-postcondition: FAIL (prerelease tag ${tag_name} is not RC-shaped)" >&2
         exit 1
@@ -64,20 +369,6 @@ case "${channel}" in
     echo "release-publish-postcondition: PASS (pending RC PR generation for ${expected_tag})"
     ;;
   stable)
-    if is_rc_tag "${expected_tag}"; then
-      if [[ "${release_created}" == "true" ]]; then
-        echo "release-publish-postcondition: FAIL (main must never create or advertise RC tag ${tag_name:-<empty>})" >&2
-        exit 1
-      fi
-      echo "release-publish-postcondition: PASS (pending stable PR generation from RC handoff ${expected_tag})"
-      exit 0
-    fi
-
-    require_created_tag "stable"
-    if ! is_stable_tag "${tag_name}"; then
-      echo "release-publish-postcondition: FAIL (stable tag ${tag_name} is not stable-shaped)" >&2
-      exit 1
-    fi
-    echo "release-publish-postcondition: PASS (stable ${tag_name})"
+    verify_stable_publish_postcondition || exit 1
     ;;
 esac

--- a/scripts/verify-release-train-promotion.sh
+++ b/scripts/verify-release-train-promotion.sh
@@ -11,10 +11,12 @@ github_repository="${GITHUB_REPOSITORY:-}"
 github_head_repository=""
 pr_title=""
 remote="origin"
+self_test="false"
 
 usage() {
   cat <<'USAGE'
 usage: scripts/verify-release-train-promotion.sh --base <branch> --head <branch> [--base-ref <ref>] [--head-sha <sha>] [--github-repository owner/name] [--github-head-repository owner/name] [--pr-title <title>]
+       scripts/verify-release-train-promotion.sh --self-test
 USAGE
 }
 
@@ -27,6 +29,7 @@ while [[ $# -gt 0 ]]; do
     --github-repository) github_repository="${2:-}"; shift 2 ;;
     --github-head-repository) github_head_repository="${2:-}"; shift 2 ;;
     --pr-title) pr_title="${2:-}"; shift 2 ;;
+    --self-test) self_test="true"; shift ;;
     --help|-h) usage; exit 0 ;;
     *) echo "release-train-promotion: FAIL (unknown argument $1)" >&2; usage >&2; exit 1 ;;
   esac
@@ -46,36 +49,6 @@ normalize_branch() {
   value="${value#refs/heads/}"
   printf '%s\n' "${value}"
 }
-
-base="$(normalize_branch "${base}")"
-head="$(normalize_branch "${head}")"
-
-[[ -n "${base}" ]] || fail "missing PR base branch"
-[[ -n "${head}" ]] || fail "missing PR head branch"
-
-if [[ -z "${github_head_repository}" ]]; then
-  github_head_repository="${github_repository}"
-fi
-
-case "${base}" in
-  staging|premain|main) ;;
-  *)
-    pass "non-release target ${head} -> ${base}"
-    exit 0
-    ;;
-esac
-
-if [[ -z "${github_repository}" ]]; then
-  if command -v gh >/dev/null 2>&1; then
-    github_repository="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
-  else
-    fail "GITHUB_REPOSITORY is required"
-  fi
-fi
-
-if [[ ! "${github_repository}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-  fail "GitHub repository must be owner/name, got ${github_repository}"
-fi
 
 require_ref() {
   local ref="$1"
@@ -104,6 +77,19 @@ is_ancestor_ref() {
   git merge-base --is-ancestor "${ancestor}" "${descendant}"
 }
 
+target_has_no_extra_non_merge_content() {
+  local source_ref="$1"
+  local target_ref="$2"
+  local extra_count
+
+  # Release-train promotion requires the protected target to carry no content
+  # outside the promoted source. Literal ancestry can over-reject when the target
+  # has a merge commit whose non-merge commits are already in the source, so
+  # inspect source..target and ignore merge commits only for that benign shape.
+  extra_count="$(git rev-list --no-merges --count "${source_ref}..${target_ref}")"
+  [[ "${extra_count}" == "0" ]]
+}
+
 require_protected_ancestor() {
   local ancestor_branch="$1"
   local descendant_branch="$2"
@@ -111,9 +97,13 @@ require_protected_ancestor() {
   local ancestor_ref descendant_ref
   ancestor_ref="$(release_ref "${ancestor_branch}")"
   descendant_ref="$(release_ref "${descendant_branch}")"
-  if ! is_ancestor_ref "${ancestor_ref}" "${descendant_ref}"; then
-    fail "${description}: ${ancestor_branch} is not an ancestor of ${descendant_branch}"
+  if is_ancestor_ref "${ancestor_ref}" "${descendant_ref}"; then
+    return 0
   fi
+  if target_has_no_extra_non_merge_content "${descendant_ref}" "${ancestor_ref}"; then
+    return 0
+  fi
+  fail "${description}: ${ancestor_branch} is not an ancestor of ${descendant_branch}"
 }
 
 api_compare_status() {
@@ -179,6 +169,152 @@ require_title_rc() {
     fail "premain Release Please PR must advertise an RC: ${pr_title}"
   fi
 }
+
+self_test_commit() {
+  local tree="$1"
+  shift
+  GIT_AUTHOR_NAME="FaceTheory Release Self Test" \
+  GIT_AUTHOR_EMAIL="facetheory-release-self-test@example.invalid" \
+  GIT_AUTHOR_DATE="2026-06-19T00:00:00Z" \
+  GIT_COMMITTER_NAME="FaceTheory Release Self Test" \
+  GIT_COMMITTER_EMAIL="facetheory-release-self-test@example.invalid" \
+  GIT_COMMITTER_DATE="2026-06-19T00:00:00Z" \
+    git commit-tree "${tree}" "$@"
+}
+
+self_test_tree() {
+  local content="$1"
+  local blob
+  blob="$(printf '%s\n' "${content}" | git hash-object -w --stdin)"
+  printf '100644 blob %s\tself-test.txt\n' "${blob}" | git mktree
+}
+
+self_test_release_train_promotion() {
+  local test_remote="facetheory-release-self-test/$$"
+  local ref_prefix="refs/remotes/${test_remote}"
+  local cleanup_refs=()
+  local empty_tree content_tree rogue_tree
+  local baseline source target_merge rogue_target output
+
+  cleanup_release_train_self_test_refs() {
+    local ref
+    for ref in "${cleanup_refs[@]:-}"; do
+      git update-ref -d "${ref}" >/dev/null 2>&1 || true
+    done
+    trap - RETURN
+  }
+  trap cleanup_release_train_self_test_refs RETURN
+
+  empty_tree="$(git mktree </dev/null)"
+  content_tree="$(self_test_tree 'source content')"
+  rogue_tree="$(self_test_tree 'rogue target content')"
+  baseline="$(self_test_commit "${empty_tree}" -m 'chore: seed release-train baseline')"
+  source="$(self_test_commit "${content_tree}" -p "${baseline}" -m 'fix: source content')"
+  target_merge="$(self_test_commit "${content_tree}" -p "${baseline}" -p "${source}" -m 'Merge source content into target')"
+  rogue_target="$(self_test_commit "${rogue_tree}" -p "${baseline}" -m 'fix: rogue target content')"
+
+  git update-ref "${ref_prefix}/staging" "${source}"
+  git update-ref "${ref_prefix}/premain" "${target_merge}"
+  cleanup_refs+=("${ref_prefix}/staging" "${ref_prefix}/premain")
+
+  if ! output="$(
+    (
+      remote="${test_remote}"
+      require_protected_ancestor "premain" "staging" "self-test staging -> premain benign divergence"
+    ) 2>&1
+  )"; then
+    printf '%s\n' "${output}" >&2
+    echo "release-train-promotion: FAIL (self-test benign merge-commit divergence was rejected)" >&2
+    return 1
+  fi
+  echo "release-train-promotion: PASS (self-test benign merge-commit divergence accepted)"
+
+  git update-ref "${ref_prefix}/premain" "${rogue_target}"
+  if output="$(
+    (
+      remote="${test_remote}"
+      require_protected_ancestor "premain" "staging" "self-test staging -> premain rogue target content"
+    ) 2>&1
+  )"; then
+    printf '%s\n' "${output}" >&2
+    echo "release-train-promotion: FAIL (self-test rogue target non-merge content was accepted)" >&2
+    return 1
+  fi
+  if [[ "${output}" != *"self-test staging -> premain rogue target content: premain is not an ancestor of staging"* ]]; then
+    printf '%s\n' "${output}" >&2
+    echo "release-train-promotion: FAIL (self-test rogue target non-merge content did not preserve the fail-closed message)" >&2
+    return 1
+  fi
+  echo "release-train-promotion: PASS (self-test rogue target non-merge content failed closed)"
+
+  git update-ref "${ref_prefix}/main" "${source}"
+  git update-ref "${ref_prefix}/staging" "${target_merge}"
+  cleanup_refs+=("${ref_prefix}/main")
+  if ! output="$(
+    (
+      remote="${test_remote}"
+      require_protected_ancestor "staging" "main" "self-test main -> staging benign divergence"
+    ) 2>&1
+  )"; then
+    printf '%s\n' "${output}" >&2
+    echo "release-train-promotion: FAIL (self-test main -> staging benign divergence was rejected)" >&2
+    return 1
+  fi
+  echo "release-train-promotion: PASS (self-test main -> staging benign divergence accepted)"
+
+  git update-ref "${ref_prefix}/staging" "${rogue_target}"
+  if output="$(
+    (
+      remote="${test_remote}"
+      require_protected_ancestor "staging" "main" "self-test main -> staging rogue target content"
+    ) 2>&1
+  )"; then
+    printf '%s\n' "${output}" >&2
+    echo "release-train-promotion: FAIL (self-test main -> staging rogue target non-merge content was accepted)" >&2
+    return 1
+  fi
+  if [[ "${output}" != *"self-test main -> staging rogue target content: staging is not an ancestor of main"* ]]; then
+    printf '%s\n' "${output}" >&2
+    echo "release-train-promotion: FAIL (self-test main -> staging rogue target content did not preserve the fail-closed message)" >&2
+    return 1
+  fi
+  echo "release-train-promotion: PASS (self-test main -> staging rogue target non-merge content failed closed)"
+}
+
+if [[ "${self_test}" == "true" ]]; then
+  self_test_release_train_promotion
+  exit $?
+fi
+
+base="$(normalize_branch "${base}")"
+head="$(normalize_branch "${head}")"
+
+[[ -n "${base}" ]] || fail "missing PR base branch"
+[[ -n "${head}" ]] || fail "missing PR head branch"
+
+if [[ -z "${github_head_repository}" ]]; then
+  github_head_repository="${github_repository}"
+fi
+
+case "${base}" in
+  staging|premain|main) ;;
+  *)
+    pass "non-release target ${head} -> ${base}"
+    exit 0
+    ;;
+esac
+
+if [[ -z "${github_repository}" ]]; then
+  if command -v gh >/dev/null 2>&1; then
+    github_repository="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+  else
+    fail "GITHUB_REPOSITORY is required"
+  fi
+fi
+
+if [[ ! "${github_repository}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  fail "GitHub repository must be owner/name, got ${github_repository}"
+fi
 
 if [[ "${base}" == "staging" ]]; then
   case "${head}" in


### PR DESCRIPTION
## Summary
- allow release-train topology gates to accept merge-commit-only divergence when the protected target has no non-merge content beyond the promoted source
- distinguish legitimate Release Please no-op runs from genuine missed RC/stable release PRs using the manifest-recorded baseline tag and the release-readiness feat/fix/perf predicate
- allow stable publish postcondition reruns only when the expected stable GitHub Release is already published and there are no releasable commits since the manifest baseline

## Step 0 audit findings
- `scripts/verify-release-train-promotion.sh` had the topology bug in `require_protected_ancestor`: it required literal ancestry and over-rejected benign merge-commit divergence.
- `scripts/verify-release-pr-postcondition.sh` had the no-op bug in both prerelease and stable channels: missing generated Release Please PR always failed, even when no user-facing release was owed.
- `scripts/verify-release-publish-postcondition.sh` had the stable publish no-op bug: `release_created=false` always failed on the stable publish path.
- The `main -> staging` back-merge edge was present; it used the same over-strict helper, so the helper fix now preserves rejection of target-only non-merge content while accepting benign merge-only divergence.

## Validation
- `bash scripts/verify-release-train-promotion.sh --self-test`
- `bash scripts/verify-release-pr-postcondition.sh --self-test`
- `bash scripts/verify-release-publish-postcondition.sh --self-test`
- `bash scripts/verify-version-alignment.sh`
- `bash scripts/verify-ci-rubric-enforced.sh`
- `bash scripts/test-release-workflow-changelog-preservation.sh`
- `make ts-typecheck && make ts-lint && make ts-test`
- `bash scripts/verify-ts-pack.sh`
- `bash scripts/verify-deterministic-builds.sh`
- live no-op checks against `v3.8.0` on `origin/premain` / `origin/main` passed

## Known CI blocker outside this PR scope
- Local `make rubric` currently fails in `SEC-1` because npm audit reports existing `esbuild`, `undici`, and `vite` advisories from the current dependency graph. This PR intentionally does not change pins/dependencies per release-gate-fix scope.
