### PR TITLE
fix(test): discover unit tests by glob so no suite is orphaned

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -204,6 +204,7 @@
     "lint": "eslint . --max-warnings=0",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "check": "npm run lint && npm run typecheck && npm test",
     "test": "npm run test:unit",
     "test:unit": "tsx test/run-unit.ts",
     "ssg": "tsx src/ssg-cli.ts",

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -1,52 +1,41 @@
-await import('./unit/router.test.js');
-await import('./unit/html.test.js');
-await import('./unit/head.test.js');
-await import('./unit/app.test.js');
-await import('./unit/resource.test.js');
-await import('./unit/spa.test.js');
-await import('./unit/client-hydration.test.js');
-await import('./unit/ssr-hydration.test.js');
-await import('./unit/ops.test.js');
-await import('./unit/oac-form.test.js');
-await import('./unit/navigation-pending.test.js');
-await import('./unit/responsive-primitives.test.js');
-await import('./unit/strict-csp-harness.test.js');
-await import('./unit/control-plane-guardrails.test.js');
-await import('./unit/control-plane-host-contracts-example.test.js');
-await import('./unit/lambda-url.test.js');
-await import('./unit/aws-s3.test.js');
-await import('./unit/ssg.test.js');
-await import('./unit/isr.test.js');
-await import('./unit/tabletheory-isr-meta-store.test.js');
-await import('./unit/react.test.js');
-await import('./unit/vite.test.js');
-await import('./unit/antd.test.js');
-await import('./unit/emotion.test.js');
-await import('./unit/stitch-tokens.test.js');
-await import('./unit/stitch-shell.test.js');
-await import('./unit/stitch-hosted-auth.test.js');
-await import('./unit/stitch-admin.test.js');
-await import('./unit/stitch-admin-wizard.test.js');
-await import('./unit/stitch-admin-wizard-reconciliation-plan.test.js');
-await import('./unit/stitch-admin-wizard-authority-context-strip.test.js');
-await import('./unit/stitch-admin-selectable-card-grid.test.js');
-await import('./unit/stitch-admin-package-source-input.test.js');
-await import('./unit/stitch-admin-wizard-editable-token-input.test.js');
-await import('./unit/stitch-admin-audit-trail.test.js');
-await import('./unit/portal-fixtures.test.js');
-await import('./unit/antd-coverage.test.js');
-await import('./unit/portal-reference.test.js');
-await import('./unit/streaming.test.js');
-await import('./unit/react-stream.test.js');
-await import('./unit/vue.test.js');
-await import('./unit/vue-stitch-shell.test.js');
-await import('./unit/vue-stitch-hosted-auth.test.js');
-await import('./unit/vue-stitch-admin.test.js');
-await import('./unit/svelte.test.js');
-await import('./unit/svelte-stitch-admin.test.js');
-await import('./unit/operator-visibility-example.test.js');
-await import('./unit/vite-ssr-example.test.js');
-await import('./unit/vite-ssr-vue-example.test.js');
-await import('./unit/vite-ssr-svelte-example.test.js');
-await import('./unit/vite-strict-csp-svelte-example.test.js');
-await import('./unit/vite-ssr-svelte-library-example.test.js');
+import { spawn } from 'node:child_process';
+import { glob } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const testRoot = dirname(fileURLToPath(import.meta.url));
+const unitTestFiles: string[] = [];
+
+for await (const testFile of glob('unit/*.test.ts', { cwd: testRoot })) {
+  unitTestFiles.push(testFile);
+}
+
+unitTestFiles.sort();
+
+console.log(`FaceTheory unit test files discovered: ${unitTestFiles.length}`);
+
+const child = spawn(
+  process.execPath,
+  [
+    '--import',
+    'tsx',
+    '--test',
+    '--test-concurrency=1',
+    ...unitTestFiles.map((testFile) => join(testRoot, testFile)),
+  ],
+  { stdio: 'inherit' },
+);
+
+const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+  (resolve, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => resolve({ code, signal }));
+  },
+);
+
+if (result.signal !== null) {
+  console.error(`FaceTheory unit test runner terminated by signal ${result.signal}`);
+  process.exitCode = 1;
+} else {
+  process.exitCode = result.code ?? 1;
+}

--- a/ts/test/run-unit.ts
+++ b/ts/test/run-unit.ts
@@ -6,13 +6,18 @@ import { fileURLToPath } from 'node:url';
 const testRoot = dirname(fileURLToPath(import.meta.url));
 const unitTestFiles: string[] = [];
 
-for await (const testFile of glob('unit/*.test.ts', { cwd: testRoot })) {
+for await (const testFile of glob('unit/**/*.test.ts', { cwd: testRoot })) {
   unitTestFiles.push(testFile);
 }
 
 unitTestFiles.sort();
 
 console.log(`FaceTheory unit test files discovered: ${unitTestFiles.length}`);
+
+if (unitTestFiles.length === 0) {
+  console.error('FaceTheory unit test discovery found no files for unit/**/*.test.ts');
+  process.exit(1);
+}
 
 const child = spawn(
   process.execPath,

--- a/ts/test/unit/apptheory-adapter.test.ts
+++ b/ts/test/unit/apptheory-adapter.test.ts
@@ -61,7 +61,7 @@ test('apptheory adapter: buffered response matches FaceApp status/headers/cookie
 
   assert.equal(appResp.status, faceResp.status);
   assert.deepEqual(appResp.cookies, faceResp.cookies);
-  assert.deepEqual(appResp.headers, stripSetCookie(faceResp.headers));
+  assert.deepEqual(stripSetCookie(appResp.headers), stripSetCookie(faceResp.headers));
 
   const faceBody = faceResp.body;
   assert.ok(faceBody instanceof Uint8Array);


### PR DESCRIPTION
## Milestone
M1 `test-integrity` — every test file on disk runs in CI structurally.

## Linear
Refs THE-2459

## Render modes and adapters affected
Render modes: none (test infrastructure only).
Adapters: AppTheory adapter test coverage is now exercised; no AppTheory repository changes.

## Determinism impact
None — test runner integrity only.

## Changes
- Replaces the hand-maintained `ts/test/run-unit.ts` import list with glob discovery for `ts/test/unit/*.test.ts`.
- Runs discovered unit test files through Node's test runner with `--test-concurrency=1`, preserving deterministic sequential file execution while avoiding cross-file global-state leakage.
- Normalizes the existing AppTheory adapter header assertion so AppTheory's null-prototype response header object compares by header content.
- Adds the documented `npm run check` command for the required lint/typecheck/test validation path.

## Validation
- `cd ts && npm run check` — PASS.
  - Runner output included `FaceTheory unit test files discovered: 53`.
  - Node test summary: `tests 586`, `pass 585`, `fail 0`, `skipped 1`.
- Test-file-count proof:
  - `find ts/test/unit -maxdepth 1 -type f -name '*.test.ts' | wc -l` → `53`.
  - Runner glob discovery count → `53`.
- `scripts/verify-version-alignment.sh` — PASS (`3.8.1`).
- Commit signature verified with `git log -1 --show-signature`.

## Cross-repo coordination
None. The AppTheory adapter suite exposed only a FaceTheory-side test assertion normalization; no AppTheory framework change was needed.

## Forbidden surfaces
No cloud mutation, no AWS/DNS/IAM changes, no secrets, no sibling/parent repo edits, no worktrees/clones, no history rewrite, no branch deletion.
