### PR TITLE
feat(ops): surface FaceTheory failure visibility

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -48,7 +48,7 @@ AWS example (`infra/apptheory-ssg-isr-site/`) additionally:
 
 - `x-request-id`: request correlation across edge/origin/logs.
 - `x-facetheory-ssr: 1`: marker for SSR responses in the infra examples.
-- `x-facetheory-isr`: ISR cache state (`hit` | `miss` | `stale` | `wait-hit`; degraded ISR states are documented in the ISR runbook below).
+- `x-facetheory-isr`: ISR cache state (`hit` | `miss` | `stale` | `wait-hit`; `stale-metadata-error` means stale HTML was served because the metadata store failed after a last-known pointer was available).
 
 ### Structured logs and minimal metrics
 
@@ -223,9 +223,11 @@ The workflow guardrails are intentionally fail-closed:
 
 Symptoms:
 - Elevated `x-facetheory-isr: stale` or `x-facetheory-isr: wait-hit`.
+- Any `x-facetheory-isr: stale-metadata-error` response, which indicates a metadata-store read or lease failure was degraded to stale HTML using a last-known pointer.
 
 Checks:
 - CloudWatch logs for request patterns and render durations (`renderMs`).
+- `observability.onError` events with `ctx.phase === "isr-metadata"`; inspect `ctx.errorClass` and the associated `x-request-id` before treating the stale response as healthy.
 - DynamoDB table hot partitions (if tenant+route concentrates traffic).
 - Regeneration time vs lease duration:
   - If regeneration routinely exceeds the lease, you will see contention and repeated stale serving.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -48,17 +48,21 @@ AWS example (`infra/apptheory-ssg-isr-site/`) additionally:
 
 - `x-request-id`: request correlation across edge/origin/logs.
 - `x-facetheory-ssr: 1`: marker for SSR responses in the infra examples.
-- `x-facetheory-isr`: ISR cache state (`hit` | `miss` | `stale` | `wait-hit`).
+- `x-facetheory-isr`: ISR cache state (`hit` | `miss` | `stale` | `wait-hit`; degraded ISR states are documented in the ISR runbook below).
 
 ### Structured logs and minimal metrics
 
 FaceTheory `createFaceApp({ observability: ... })` supports:
 - `observability.log(record)`:
   - `event: "facetheory.request.completed"`
-  - `requestId`, `routePattern`, `mode`, `status`, `durationMs`, `renderMs`, `isrState`, `isStream`
+  - `requestId`, `routePattern`, `mode`, `status`, `durationMs`, `renderMs`, `isrState`, `isStream`, `errorClass`
 - `observability.metric(record)`:
-  - `facetheory.request` counter (tags include `route_pattern`, `mode`, `status`, `isr_state`)
+  - `facetheory.request` counter (tags include `route_pattern`, `mode`, `status`, `isr_state`, `error_class`)
   - `facetheory.render_ms` timing for requests that actually rendered
+- `observability.onError(err, ctx)`:
+  - Receives the original thrown value when FaceTheory converts an internal failure into a deterministic response, fallback fragment, sidecar miss, or degraded ISR state.
+  - The hook is for telemetry only; rendered error HTML remains bounded and does not include the thrown message or stack.
+  - `ctx.phase` names the failure surface (`render`, `stream-preflight`, `resource`, `ssr-hydration-sidecar`, `control-plane-section`, or `isr-metadata`), and `ctx.errorClass` matches the request metric tag.
 
 React streaming readiness (React adapter):
 - `renderReactStream(..., { onReadiness })` emits readiness timing for:

--- a/docs/modes/isr.md
+++ b/docs/modes/isr.md
@@ -69,6 +69,8 @@ See [ISR tenant safety](../features/isr-tenant-safety.md) and [Migration Guide â
 - Fresh entries serve from cache without invoking `render` or `load`.
 - Stale entries serve only after regeneration completes (blocking model â€” no stale-while-revalidate by default).
 - Regeneration is serialized per cache key by a lease: concurrent requests for the same stale entry wait for the lease holder rather than thundering the origin.
+- If the metadata store fails after this Lambda runtime has a serveable last-known pointer for the cache key, FaceTheory serves that stale HTML with `x-facetheory-isr: stale-metadata-error` instead of turning a metadata outage into a 500. The original metadata exception is sent to `observability.onError` with `ctx.phase === "isr-metadata"`.
+- If no serveable entry is known, metadata-store failures still fail closed as 500 responses through the normal error hook path.
 - TTL controls freshness; failure policy (`'serve-stale'` vs `'error'`) and lock-contention policy (`'wait'` vs `'serve-stale'`) are configurable via `FaceIsrOptions`.
 
 ## Related docs

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -15,7 +15,12 @@ import {
   type IsrRenderFreshOptions,
   type IsrRuntime,
 } from './isr.js';
-import { logLevelForStatus, type FaceObservabilityHooks } from './ops.js';
+import {
+  logLevelForStatus,
+  reportFaceError,
+  type FaceErrorPhase,
+  type FaceObservabilityHooks,
+} from './ops.js';
 import {
   buildStrictCspHeader,
   requiresStrictCspDocumentValidation,
@@ -109,8 +114,20 @@ const SAFE_PAYLOAD_TOO_LARGE_HTML = renderHTMLDocument({
 });
 
 const REQUEST_ID_HEADER = 'x-request-id';
+const OBSERVED_ERROR = Symbol('facetheory.observed-error');
+
+interface ObservedFaceError {
+  phase: FaceErrorPhase;
+  value: unknown;
+}
+
+type FaceResponseWithObservedError = FaceResponse & {
+  [OBSERVED_ERROR]?: ObservedFaceError;
+};
 
 class StreamPreflightError extends Error {
+  readonly cause: unknown;
+
   constructor(cause: unknown) {
     super('stream body failed before first chunk');
     this.name = 'StreamPreflightError';
@@ -267,9 +284,11 @@ export class FaceApp {
 
     if (resource) {
       routePattern = routePatternForMatch;
+      let observedError: ObservedFaceError | null = null;
       try {
         response = await resource.handle(ctx);
-      } catch {
+      } catch (err) {
+        observedError = { phase: 'resource', value: err };
         response = internalErrorResponse();
       }
 
@@ -284,6 +303,7 @@ export class FaceApp {
           routePattern,
           mode,
           renderMs,
+          error: observedError,
         },
       );
     }
@@ -382,6 +402,7 @@ export class FaceApp {
         },
       );
     } catch (err) {
+      const observedError = observedErrorFromCaughtRenderError(err);
       response =
         err instanceof StrictCspStreamBodyTooLargeError
           ? strictCspStreamBodyTooLargeResponse()
@@ -397,6 +418,7 @@ export class FaceApp {
           routePattern,
           mode,
           renderMs,
+          error: observedError,
         },
       );
     }
@@ -472,8 +494,12 @@ async function handleSsrHydrationSidecarResource(
     const variant = await runtime.requestVariant(ctx.request);
     const sidecar = await runtime.store.read({ token, variant });
     return jsonResourceResponse(sidecar.data);
-  } catch {
-    return ssrHydrationSidecarFailureResponse();
+  } catch (err) {
+    return withObservedError(
+      ssrHydrationSidecarFailureResponse(),
+      'ssr-hydration-sidecar',
+      err,
+    );
   }
 }
 
@@ -526,6 +552,7 @@ function finishResponse(
     routePattern: string;
     mode: FaceMode | 'none';
     renderMs: number | null;
+    error?: ObservedFaceError | null;
   },
 ): FaceResponse {
   const headers: Headers = { ...(response.headers ?? {}) };
@@ -544,6 +571,20 @@ function finishResponse(
   const isStream = !(out.body instanceof Uint8Array);
 
   const level = logLevelForStatus(out.status);
+  const observedError =
+    context.error ?? observedErrorFromResponse(response) ?? null;
+  const errorClass = observedError
+    ? reportFaceError(hooks, observedError.value, {
+        requestId,
+        method: req.method,
+        path: req.path,
+        routePattern: context.routePattern,
+        mode: context.mode,
+        phase: observedError.phase,
+        status: out.status,
+        isrState,
+      })
+    : null;
 
   hooks?.log?.({
     level,
@@ -558,6 +599,7 @@ function finishResponse(
     renderMs: context.renderMs,
     isrState,
     isStream,
+    errorClass,
   });
 
   hooks?.metric?.({
@@ -570,6 +612,7 @@ function finishResponse(
       status: String(out.status),
       isr_state: isrState ?? '',
       is_stream: isStream ? '1' : '0',
+      error_class: errorClass ?? '',
     },
   });
 
@@ -586,6 +629,33 @@ function finishResponse(
   }
 
   return out;
+}
+
+function withObservedError(
+  response: FaceResponse,
+  phase: FaceErrorPhase,
+  value: unknown,
+): FaceResponse {
+  Object.defineProperty(response, OBSERVED_ERROR, {
+    value: { phase, value },
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return response;
+}
+
+function observedErrorFromResponse(
+  response: FaceResponse,
+): ObservedFaceError | null {
+  return (response as FaceResponseWithObservedError)[OBSERVED_ERROR] ?? null;
+}
+
+function observedErrorFromCaughtRenderError(err: unknown): ObservedFaceError {
+  if (err instanceof StreamPreflightError) {
+    return { phase: 'stream-preflight', value: err.cause };
+  }
+  return { phase: 'render', value: err };
 }
 
 function queryFromPath(path: string): Record<string, string[]> {

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -236,6 +236,7 @@ export class FaceApp {
       ...isrOptions,
       htmlStore: isrOptions.htmlStore ?? new InMemoryHtmlStore(),
       metaStore: isrOptions.metaStore ?? new InMemoryIsrMetaStore(),
+      observability: this.observability ?? isrOptions.observability ?? null,
     });
   }
 

--- a/ts/src/control-plane.ts
+++ b/ts/src/control-plane.ts
@@ -10,6 +10,10 @@ import {
   RESPONSIVE_PRIMITIVES_CLASS_PREFIX,
 } from './responsive-primitives/index.js';
 import {
+  reportFaceError,
+  type FaceObservabilityHooks,
+} from './ops.js';
+import {
   jsonResourceResponse,
   methodNotAllowedResourceResponse,
   textResourceResponse,
@@ -218,6 +222,7 @@ interface NormalizedControlPlaneAppOptions {
   cspMode: ControlPlaneCspMode;
   delivery: ControlPlaneDeliveryCapability;
   gate: ControlPlaneGate;
+  observability: FaceObservabilityHooks | null;
 }
 
 export function createControlPlaneApp(
@@ -332,7 +337,12 @@ function normalizeControlPlaneAppOptions(
     );
   }
 
-  return { cspMode, delivery, gate: options.gate };
+  return {
+    cspMode,
+    delivery,
+    gate: options.gate,
+    observability: options.faceApp?.observability ?? null,
+  };
 }
 
 function normalizeControlPlaneFaces(
@@ -390,7 +400,13 @@ function createPresetFace(
       if (options.delivery === 'streaming') {
         return {
           ...base,
-          html: streamControlPlaneSections(base.html, normalized, ctx, gate),
+          html: streamControlPlaneSections(
+            base.html,
+            normalized,
+            ctx,
+            gate,
+            options.observability,
+          ),
         };
       }
       return base;
@@ -494,6 +510,7 @@ async function* streamControlPlaneSections(
   normalized: NormalizedControlPlaneFace,
   ctx: FaceContext,
   gate: ControlPlaneGateAccepted,
+  observability: FaceObservabilityHooks | null,
 ): AsyncIterable<Uint8Array> {
   if (typeof shell === 'string') {
     yield utf8(shell);
@@ -502,7 +519,12 @@ async function* streamControlPlaneSections(
   }
 
   for (const section of normalized.sections) {
-    const html = await renderSectionDataHtml(section, ctx, gate);
+    const html = await renderSectionDataHtml(
+      section,
+      ctx,
+      gate,
+      observability,
+    );
     yield utf8(
       `<section class="facetheory-control-plane-section facetheory-control-plane-section--streamed" data-facetheory-control-streamed-section="${escapeHtml(section.id)}" data-state="success"><div class="facetheory-control-plane-section__body">${html}</div></section>`,
     );
@@ -524,7 +546,12 @@ function createControlPlaneSectionRoutes(
           }
           const gate = await options.gate(ctx);
           if (!gate.ok) return deniedSectionResponse(gate);
-          const html = await renderSectionDataHtml(section, ctx, gate);
+          const html = await renderSectionDataHtml(
+            section,
+            ctx,
+            gate,
+            options.observability,
+          );
           return sectionHtmlResponse(
             html,
             ctx.request.method === 'HEAD',
@@ -542,6 +569,7 @@ async function renderSectionDataHtml<Data>(
   section: NormalizedControlPlaneDataSection<Data>,
   ctx: FaceContext,
   gate: ControlPlaneGateAccepted,
+  observability: FaceObservabilityHooks | null,
 ): Promise<string> {
   try {
     const data = await section.load(ctx, gate);
@@ -550,9 +578,29 @@ async function renderSectionDataHtml<Data>(
       return section.emptyHtml;
     }
     return rendered;
-  } catch {
+  } catch (err) {
+    reportControlPlaneSectionError(observability, err, section, ctx);
     return section.errorHtml ?? defaultSectionErrorHtml(section);
   }
+}
+
+function reportControlPlaneSectionError<Data>(
+  observability: FaceObservabilityHooks | null,
+  err: unknown,
+  section: NormalizedControlPlaneDataSection<Data>,
+  ctx: FaceContext,
+): void {
+  reportFaceError(observability, err, {
+    requestId: String(ctx.request.headers['x-request-id']?.[0] ?? ''),
+    method: ctx.request.method,
+    path: ctx.request.path,
+    routePattern: section.endpoint,
+    mode: 'none',
+    phase: 'control-plane-section',
+    status: 200,
+    isrState: null,
+    sectionId: section.id,
+  });
 }
 
 function sectionHtmlResponse(

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -42,6 +42,8 @@ const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
 const HYDRATION_SIDECAR_CACHE_CONTROL = 'no-store';
 const ISR_HTML_METADATA_CONTENT_SECURITY_POLICY =
   'facetheory-content-security-policy';
+const ISR_HTML_METADATA_STATUS = 'facetheory-status';
+const ISR_HTML_METADATA_CONTENT_TYPE = 'facetheory-content-type';
 
 export type IsrFailurePolicy = 'serve-stale' | 'error';
 export type IsrLockContentionPolicy = 'wait' | 'serve-stale';
@@ -844,7 +846,13 @@ function responseFromStoredHtml(
   nowMs: number,
   htmlMetadata?: Record<string, string> | undefined,
 ): FaceResponse {
-  const contentType = normalizeContentType(record.contentType);
+  const contentType = normalizeContentType(
+    htmlMetadata?.[ISR_HTML_METADATA_CONTENT_TYPE] ?? record.contentType,
+  );
+  const status = normalizeStatusFromMetadata(
+    htmlMetadata?.[ISR_HTML_METADATA_STATUS],
+    record.status,
+  );
   const contentSecurityPolicy = normalizeOptionalHeaderValue(
     record.contentSecurityPolicy ??
       htmlMetadata?.[ISR_HTML_METADATA_CONTENT_SECURITY_POLICY],
@@ -880,7 +888,7 @@ function responseFromStoredHtml(
   }
 
   return {
-    status: normalizeStatus(record.status),
+    status,
     headers: sortHeaders(headers),
     cookies: [],
     body,
@@ -890,11 +898,16 @@ function responseFromStoredHtml(
 
 function htmlStoreMetadataFromPreparedFreshResponse(
   prepared: PreparedFreshResponse,
-): Record<string, string> | undefined {
-  if (prepared.contentSecurityPolicy === null) return undefined;
-  return {
-    [ISR_HTML_METADATA_CONTENT_SECURITY_POLICY]: prepared.contentSecurityPolicy,
+): Record<string, string> {
+  const metadata: Record<string, string> = {
+    [ISR_HTML_METADATA_STATUS]: String(prepared.status),
+    [ISR_HTML_METADATA_CONTENT_TYPE]: prepared.contentType,
   };
+  if (prepared.contentSecurityPolicy !== null) {
+    metadata[ISR_HTML_METADATA_CONTENT_SECURITY_POLICY] =
+      prepared.contentSecurityPolicy;
+  }
+  return metadata;
 }
 
 function normalizeRuntimeOptions(
@@ -1181,6 +1194,14 @@ function normalizeStatus(value: number): number {
   const int = Math.trunc(Number(value));
   if (!Number.isFinite(int) || int < 100 || int > 599) return 200;
   return int;
+}
+
+function normalizeStatusFromMetadata(
+  metadataValue: string | undefined,
+  fallback: number,
+): number {
+  if (metadataValue === undefined) return normalizeStatus(fallback);
+  return normalizeStatus(Number(metadataValue));
 }
 
 function firstHeaderValue(headers: Headers, key: string): string | null {

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -49,6 +49,7 @@ const ISR_HTML_METADATA_CONTENT_SECURITY_POLICY =
 const ISR_HTML_METADATA_STATUS = 'facetheory-status';
 const ISR_HTML_METADATA_CONTENT_TYPE = 'facetheory-content-type';
 const ISR_STATE_STALE_METADATA_ERROR = 'stale-metadata-error';
+const DEFAULT_LAST_KNOWN_ISR_RECORD_LIMIT = 128;
 
 export type IsrFailurePolicy = 'serve-stale' | 'error';
 export type IsrLockContentionPolicy = 'wait' | 'serve-stale';
@@ -448,12 +449,10 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
   const runtimeOptions = normalizeRuntimeOptions(options);
   const lastKnownRecords = new Map<string, IsrMetaRecord>();
   const rememberRecord = (record: IsrMetaRecord | null): void => {
-    if (!record?.htmlPointer) return;
-    lastKnownRecords.set(record.cacheKey, cloneIsrMetaRecord(record));
+    rememberLastKnownRecord(lastKnownRecords, record);
   };
   const lastKnownRecord = (cacheKey: string): IsrMetaRecord | null => {
-    const record = lastKnownRecords.get(cacheKey);
-    return record ? cloneIsrMetaRecord(record) : null;
+    return readLastKnownRecord(lastKnownRecords, cacheKey);
   };
 
   return {
@@ -883,6 +882,8 @@ async function staleResponseForMetadataFailure(
   record: IsrMetaRecord | null,
   err: unknown,
 ): Promise<FaceResponse | null> {
+  if (runtimeOptions.failurePolicy !== 'serve-stale') return null;
+
   const response = await cachedResponseFromRecord(
     runtimeOptions,
     record,
@@ -903,6 +904,36 @@ async function staleResponseForMetadataFailure(
     isrState: response.headers['x-facetheory-isr']?.[0] ?? null,
   });
   return response;
+}
+
+function rememberLastKnownRecord(
+  records: Map<string, IsrMetaRecord>,
+  record: IsrMetaRecord | null,
+): void {
+  if (!record?.htmlPointer) return;
+
+  if (records.has(record.cacheKey)) {
+    records.delete(record.cacheKey);
+  }
+  records.set(record.cacheKey, cloneIsrMetaRecord(record));
+
+  while (records.size > DEFAULT_LAST_KNOWN_ISR_RECORD_LIMIT) {
+    const oldestCacheKey = records.keys().next().value;
+    if (oldestCacheKey === undefined) break;
+    records.delete(oldestCacheKey);
+  }
+}
+
+function readLastKnownRecord(
+  records: Map<string, IsrMetaRecord>,
+  cacheKey: string,
+): IsrMetaRecord | null {
+  const record = records.get(cacheKey);
+  if (!record) return null;
+
+  records.delete(cacheKey);
+  records.set(cacheKey, record);
+  return cloneIsrMetaRecord(record);
 }
 
 async function waitForRegeneratedRecord(

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -3,6 +3,10 @@ import { createHash, randomUUID } from 'node:crypto';
 import { utf8 } from './bytes.js';
 import { safeJson } from './html.js';
 import {
+  reportFaceError,
+  type FaceObservabilityHooks,
+} from './ops.js';
+import {
   requiresStrictCspDocumentValidation,
   validateStrictCspDocument,
 } from './security.js';
@@ -44,10 +48,16 @@ const ISR_HTML_METADATA_CONTENT_SECURITY_POLICY =
   'facetheory-content-security-policy';
 const ISR_HTML_METADATA_STATUS = 'facetheory-status';
 const ISR_HTML_METADATA_CONTENT_TYPE = 'facetheory-content-type';
+const ISR_STATE_STALE_METADATA_ERROR = 'stale-metadata-error';
 
 export type IsrFailurePolicy = 'serve-stale' | 'error';
 export type IsrLockContentionPolicy = 'wait' | 'serve-stale';
-export type IsrCacheState = 'miss' | 'hit' | 'stale' | 'wait-hit';
+export type IsrCacheState =
+  | 'miss'
+  | 'hit'
+  | 'stale'
+  | 'wait-hit'
+  | typeof ISR_STATE_STALE_METADATA_ERROR;
 
 export interface HtmlStoreWriteInput {
   key: string;
@@ -186,6 +196,7 @@ export interface FaceIsrOptions {
   cacheKey?: (input: IsrCacheKeyInput) => string;
   htmlPointerPrefix?: string;
   cacheControl?: (input: IsrCacheHeaderInput) => string;
+  observability?: FaceObservabilityHooks | null;
 }
 
 interface CreateIsrRuntimeOptions {
@@ -205,6 +216,7 @@ interface CreateIsrRuntimeOptions {
   tenantBoundaryHeaders: readonly string[];
   htmlPointerPrefix: string;
   cacheControl: (input: IsrCacheHeaderInput) => string;
+  observability: FaceObservabilityHooks | null;
 }
 
 interface PreparedFreshResponse {
@@ -434,6 +446,16 @@ export class S3HtmlStore implements HtmlStore {
 
 export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
   const runtimeOptions = normalizeRuntimeOptions(options);
+  const lastKnownRecords = new Map<string, IsrMetaRecord>();
+  const rememberRecord = (record: IsrMetaRecord | null): void => {
+    if (!record?.htmlPointer) return;
+    lastKnownRecords.set(record.cacheKey, cloneIsrMetaRecord(record));
+  };
+  const lastKnownRecord = (cacheKey: string): IsrMetaRecord | null => {
+    const record = lastKnownRecords.get(cacheKey);
+    return record ? cloneIsrMetaRecord(record) : null;
+  };
+
   return {
     handleFace: async (input) => {
       const revalidateSeconds = normalizeRevalidateSeconds(
@@ -477,7 +499,20 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
       }
 
       const currentNow = runtimeOptions.now();
-      const existing = await runtimeOptions.metaStore.get(cacheKey);
+      let existing: IsrMetaRecord | null;
+      try {
+        existing = await runtimeOptions.metaStore.get(cacheKey);
+        rememberRecord(existing);
+      } catch (err) {
+        const stale = await staleResponseForMetadataFailure(
+          runtimeOptions,
+          input,
+          lastKnownRecord(cacheKey),
+          err,
+        );
+        if (stale) return stale;
+        throw err;
+      }
 
       if (existing && isFresh(existing, currentNow)) {
         const cachedFresh = await cachedResponseFromRecord(
@@ -487,17 +522,33 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
           currentNow,
           false,
         );
-        if (cachedFresh) return cachedFresh;
+        if (cachedFresh) {
+          rememberRecord(existing);
+          return cachedFresh;
+        }
       }
 
       const leaseOwner = runtimeOptions.createLeaseOwner();
-      const acquire = await runtimeOptions.metaStore.tryAcquireLease({
-        cacheKey,
-        leaseOwner,
-        nowMs: currentNow,
-        leaseDurationMs: runtimeOptions.leaseDurationMs,
-        fallbackRevalidateSeconds: revalidateSeconds,
-      });
+      let acquire: TryAcquireIsrLeaseResult;
+      try {
+        acquire = await runtimeOptions.metaStore.tryAcquireLease({
+          cacheKey,
+          leaseOwner,
+          nowMs: currentNow,
+          leaseDurationMs: runtimeOptions.leaseDurationMs,
+          fallbackRevalidateSeconds: revalidateSeconds,
+        });
+        rememberRecord(acquire.record);
+      } catch (err) {
+        const stale = await staleResponseForMetadataFailure(
+          runtimeOptions,
+          input,
+          existing ?? lastKnownRecord(cacheKey),
+          err,
+        );
+        if (stale) return stale;
+        throw err;
+      }
 
       if (acquire.acquired && acquire.leaseToken) {
         return regenerateAndCommit(
@@ -508,6 +559,7 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
           acquire.leaseToken,
           revalidateSeconds,
           existing ?? acquire.record,
+          rememberRecord,
         );
       }
 
@@ -515,12 +567,25 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
       if (runtimeOptions.lockContentionPolicy === 'wait') {
         const deadline =
           runtimeOptions.now() + runtimeOptions.regenerationWaitTimeoutMs;
-        const waited = await waitForRegeneratedRecord(
-          runtimeOptions,
-          cacheKey,
-          staleRecord.generatedAt,
-          deadline,
-        );
+        let waited: IsrMetaRecord | null;
+        try {
+          waited = await waitForRegeneratedRecord(
+            runtimeOptions,
+            cacheKey,
+            staleRecord.generatedAt,
+            deadline,
+          );
+          rememberRecord(waited);
+        } catch (err) {
+          const stale = await staleResponseForMetadataFailure(
+            runtimeOptions,
+            input,
+            staleRecord,
+            err,
+          );
+          if (stale) return stale;
+          throw err;
+        }
         if (waited) {
           const cached = await cachedResponseFromRecord(
             runtimeOptions,
@@ -533,13 +598,26 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
         }
       }
 
-      const retryAcquire = await runtimeOptions.metaStore.tryAcquireLease({
-        cacheKey,
-        leaseOwner,
-        nowMs: runtimeOptions.now(),
-        leaseDurationMs: runtimeOptions.leaseDurationMs,
-        fallbackRevalidateSeconds: revalidateSeconds,
-      });
+      let retryAcquire: TryAcquireIsrLeaseResult;
+      try {
+        retryAcquire = await runtimeOptions.metaStore.tryAcquireLease({
+          cacheKey,
+          leaseOwner,
+          nowMs: runtimeOptions.now(),
+          leaseDurationMs: runtimeOptions.leaseDurationMs,
+          fallbackRevalidateSeconds: revalidateSeconds,
+        });
+        rememberRecord(retryAcquire.record);
+      } catch (err) {
+        const stale = await staleResponseForMetadataFailure(
+          runtimeOptions,
+          input,
+          staleRecord,
+          err,
+        );
+        if (stale) return stale;
+        throw err;
+      }
       if (retryAcquire.acquired && retryAcquire.leaseToken) {
         return regenerateAndCommit(
           runtimeOptions,
@@ -549,6 +627,7 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
           retryAcquire.leaseToken,
           revalidateSeconds,
           staleRecord,
+          rememberRecord,
         );
       }
 
@@ -688,6 +767,7 @@ async function regenerateAndCommit(
   leaseToken: string,
   revalidateSeconds: number,
   staleRecord: IsrMetaRecord,
+  rememberRecord: (record: IsrMetaRecord | null) => void,
 ): Promise<FaceResponse> {
   const generatedAt = runtimeOptions.now();
   const htmlPointer = buildHtmlPointer(
@@ -757,18 +837,21 @@ async function regenerateAndCommit(
       ...(etag !== null ? { etag } : {}),
     });
 
+    const committedRecord: IsrMetaRecord = {
+      ...createDefaultMetaRecord(cacheKey, revalidateSeconds),
+      htmlPointer,
+      generatedAt,
+      status: prepared.status,
+      contentType: prepared.contentType,
+      contentSecurityPolicy: prepared.contentSecurityPolicy,
+      strictCspPolicy: prepared.strictCspPolicy,
+      etag,
+    };
+    rememberRecord(committedRecord);
+
     return responseFromStoredHtml(
       runtimeOptions,
-      {
-        ...createDefaultMetaRecord(cacheKey, revalidateSeconds),
-        htmlPointer,
-        generatedAt,
-        status: prepared.status,
-        contentType: prepared.contentType,
-        contentSecurityPolicy: prepared.contentSecurityPolicy,
-        strictCspPolicy: prepared.strictCspPolicy,
-        etag,
-      },
+      committedRecord,
       prepared.body,
       'miss',
       runtimeOptions.now(),
@@ -794,6 +877,34 @@ async function regenerateAndCommit(
   }
 }
 
+async function staleResponseForMetadataFailure(
+  runtimeOptions: CreateIsrRuntimeOptions,
+  input: HandleIsrFaceInput,
+  record: IsrMetaRecord | null,
+  err: unknown,
+): Promise<FaceResponse | null> {
+  const response = await cachedResponseFromRecord(
+    runtimeOptions,
+    record,
+    ISR_STATE_STALE_METADATA_ERROR,
+    runtimeOptions.now(),
+    true,
+  );
+  if (!response) return null;
+
+  reportFaceError(runtimeOptions.observability, err, {
+    requestId: String(input.ctx.request.headers['x-request-id']?.[0] ?? ''),
+    method: input.ctx.request.method,
+    path: input.ctx.request.path,
+    routePattern: input.routePattern,
+    mode: 'isr',
+    phase: 'isr-metadata',
+    status: response.status,
+    isrState: response.headers['x-facetheory-isr']?.[0] ?? null,
+  });
+  return response;
+}
+
 async function waitForRegeneratedRecord(
   runtimeOptions: CreateIsrRuntimeOptions,
   cacheKey: string,
@@ -816,12 +927,12 @@ async function waitForRegeneratedRecord(
 
 async function cachedResponseFromRecord(
   runtimeOptions: CreateIsrRuntimeOptions,
-  record: IsrMetaRecord,
+  record: IsrMetaRecord | null,
   state: IsrCacheState,
   nowMs: number,
   allowStale: boolean,
 ): Promise<FaceResponse | null> {
-  if (!record.htmlPointer) return null;
+  if (!record?.htmlPointer) return null;
   if (!allowStale && !isFresh(record, nowMs)) return null;
 
   const html = await runtimeOptions.htmlStore.read(record.htmlPointer);
@@ -953,6 +1064,7 @@ function normalizeRuntimeOptions(
     cacheControl:
       input.cacheControl ??
       ((options) => blockingIsrCacheControl(options.revalidateSeconds)),
+    observability: input.observability ?? null,
   };
 }
 

--- a/ts/src/lambda-url.ts
+++ b/ts/src/lambda-url.ts
@@ -40,13 +40,15 @@ export interface LambdaUrlResponseMetadata {
 
 export interface LambdaResponseWriter {
   writeHead: (metadata: LambdaUrlResponseMetadata) => void;
-  write: (chunk: Uint8Array) => void;
-  end: () => void;
+  write: (chunk: Uint8Array) => boolean | void | Promise<boolean | void>;
+  drain?: () => Promise<void>;
+  end: () => void | Promise<void>;
 }
 
 export interface LambdaWritableStream {
-  write: (chunk: Uint8Array | string) => void;
+  write: (chunk: Uint8Array | string) => boolean | void;
   end: (chunk?: Uint8Array | string) => void;
+  once?: (event: 'drain', listener: () => void) => unknown;
   setHeader?: (name: string, value: string | string[]) => void;
   statusCode?: number;
 }
@@ -157,16 +159,39 @@ export async function writeFaceResponseToLambdaWriter(
 
   if (response.body instanceof Uint8Array) {
     if (response.body.length > 0) {
-      writer.write(response.body);
+      await writeLambdaChunk(writer, response.body);
     }
-    writer.end();
+    await writer.end();
     return;
   }
 
   for await (const chunk of response.body) {
-    writer.write(chunk);
+    await writeLambdaChunk(writer, chunk);
   }
-  writer.end();
+  await writer.end();
+}
+
+async function writeLambdaChunk(
+  writer: LambdaResponseWriter,
+  chunk: Uint8Array,
+): Promise<void> {
+  const accepted = await writer.write(chunk);
+  if (accepted === false) {
+    await waitForWriterDrain(writer);
+  }
+}
+
+async function waitForWriterDrain(
+  writer: LambdaResponseWriter,
+): Promise<void> {
+  if (typeof writer.drain === 'function') {
+    await writer.drain();
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
 }
 
 export function createLambdaUrlStreamingHandler<
@@ -219,15 +244,24 @@ function createStreamWriter(
     }
   };
 
-  const write = (chunk: Uint8Array): void => {
-    stream.write(chunk);
+  const write = (chunk: Uint8Array): boolean | void => {
+    return stream.write(chunk);
   };
+
+  const drain =
+    typeof stream.once === 'function'
+      ? async (): Promise<void> => {
+          await new Promise<void>((resolve) => {
+            stream.once?.('drain', resolve);
+          });
+        }
+      : undefined;
 
   const end = (): void => {
     stream.end();
   };
 
-  return { writeHead, write, end };
+  return drain ? { writeHead, write, drain, end } : { writeHead, write, end };
 }
 
 function getDefaultAwsLambdaGlobal(): AwsLambdaGlobalLike {

--- a/ts/src/lambda-url.ts
+++ b/ts/src/lambda-url.ts
@@ -45,10 +45,24 @@ export interface LambdaResponseWriter {
   end: () => void | Promise<void>;
 }
 
+type LambdaWritableStreamEvent = 'drain' | 'error' | 'close';
+type LambdaWritableStreamListener = (...args: unknown[]) => void;
+
 export interface LambdaWritableStream {
   write: (chunk: Uint8Array | string) => boolean | void;
   end: (chunk?: Uint8Array | string) => void;
-  once?: (event: 'drain', listener: () => void) => unknown;
+  once?: (
+    event: LambdaWritableStreamEvent,
+    listener: LambdaWritableStreamListener,
+  ) => unknown;
+  off?: (
+    event: LambdaWritableStreamEvent,
+    listener: LambdaWritableStreamListener,
+  ) => unknown;
+  removeListener?: (
+    event: LambdaWritableStreamEvent,
+    listener: LambdaWritableStreamListener,
+  ) => unknown;
   setHeader?: (name: string, value: string | string[]) => void;
   statusCode?: number;
 }
@@ -248,20 +262,89 @@ function createStreamWriter(
     return stream.write(chunk);
   };
 
-  const drain =
-    typeof stream.once === 'function'
-      ? async (): Promise<void> => {
-          await new Promise<void>((resolve) => {
-            stream.once?.('drain', resolve);
-          });
-        }
-      : undefined;
+  const drain = createStreamDrainWaiter(stream);
 
   const end = (): void => {
     stream.end();
   };
 
   return drain ? { writeHead, write, drain, end } : { writeHead, write, end };
+}
+
+function createStreamDrainWaiter(
+  stream: LambdaWritableStream,
+): (() => Promise<void>) | undefined {
+  if (typeof stream.once !== 'function') return undefined;
+
+  let terminalError: Error | null = null;
+  let didClose = false;
+  const onTerminalError = (err: unknown): void => {
+    terminalError = normalizeStreamError(err);
+  };
+  const onTerminalClose = (): void => {
+    didClose = true;
+  };
+  stream.once('error', onTerminalError);
+  stream.once('close', onTerminalClose);
+
+  return async (): Promise<void> => {
+    if (terminalError) throw terminalError;
+    if (didClose) throw closedBeforeDrainError();
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const resolveOnce = (): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve();
+      };
+      const rejectOnce = (err: Error): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(err);
+      };
+      const onDrain = (): void => resolveOnce();
+      const onError = (err: unknown): void => {
+        rejectOnce(normalizeStreamError(err));
+      };
+      const onClose = (): void => {
+        rejectOnce(closedBeforeDrainError());
+      };
+      const cleanup = (): void => {
+        removeStreamListener(stream, 'drain', onDrain);
+        removeStreamListener(stream, 'error', onError);
+        removeStreamListener(stream, 'close', onClose);
+      };
+
+      stream.once?.('drain', onDrain);
+      stream.once?.('error', onError);
+      stream.once?.('close', onClose);
+    });
+  };
+}
+
+function removeStreamListener(
+  stream: LambdaWritableStream,
+  event: LambdaWritableStreamEvent,
+  listener: LambdaWritableStreamListener,
+): void {
+  if (typeof stream.off === 'function') {
+    stream.off(event, listener);
+    return;
+  }
+  stream.removeListener?.(event, listener);
+}
+
+function normalizeStreamError(err: unknown): Error {
+  return err instanceof Error
+    ? err
+    : new Error(`Lambda response stream error before drain: ${String(err)}`);
+}
+
+function closedBeforeDrainError(): Error {
+  return new Error('Lambda response stream closed before drain');
 }
 
 function getDefaultAwsLambdaGlobal(): AwsLambdaGlobalLike {

--- a/ts/src/ops.ts
+++ b/ts/src/ops.ts
@@ -2,6 +2,28 @@ import type { FaceMode } from './types.js';
 
 export type FaceLogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+export type FaceErrorPhase =
+  | 'resource'
+  | 'render'
+  | 'stream-preflight'
+  | 'ssr-hydration-sidecar'
+  | 'control-plane-section'
+  | 'control-plane-section-validation'
+  | 'isr-metadata';
+
+export interface FaceErrorContext {
+  requestId: string;
+  method: string;
+  path: string;
+  routePattern: string;
+  mode: FaceMode | 'none';
+  phase: FaceErrorPhase;
+  status: number | null;
+  errorClass: string;
+  isrState: string | null;
+  sectionId?: string | undefined;
+}
+
 export interface FaceRequestCompletedLogRecord {
   level: FaceLogLevel;
   event: 'facetheory.request.completed';
@@ -15,6 +37,7 @@ export interface FaceRequestCompletedLogRecord {
   renderMs: number | null;
   isrState: string | null;
   isStream: boolean;
+  errorClass: string | null;
 }
 
 export interface FaceMetricRecord {
@@ -39,6 +62,14 @@ export interface FaceObservabilityHooks {
    * Minimal metrics sink (counters / histograms depending on backend).
    */
   metric?: (record: FaceMetricRecord) => void;
+
+  /**
+   * Error sink for failures that FaceTheory converts into deterministic
+   * responses, fallback fragments, or degraded ISR states. The original thrown
+   * value is delivered unchanged so hosts can preserve stack/cause fidelity in
+   * their own telemetry without leaking it into rendered HTML.
+   */
+  onError?: (err: unknown, ctx: FaceErrorContext) => void;
 }
 
 export function logLevelForStatus(status: number): FaceLogLevel {
@@ -49,3 +80,36 @@ export function logLevelForStatus(status: number): FaceLogLevel {
   return 'info';
 }
 
+export function errorClassFor(err: unknown): string {
+  if (err && typeof err === 'object') {
+    const name = (err as { name?: unknown }).name;
+    const normalizedName = normalizeErrorClassPart(name);
+    if (normalizedName) return normalizedName;
+    const ctorName = normalizeErrorClassPart(
+      (err as { constructor?: { name?: unknown } }).constructor?.name,
+    );
+    if (ctorName) return ctorName;
+    return 'Object';
+  }
+
+  const typeName = normalizeErrorClassPart(typeof err);
+  return typeName ? `NonError_${typeName}` : 'Unknown';
+}
+
+export function reportFaceError(
+  hooks: FaceObservabilityHooks | null | undefined,
+  err: unknown,
+  ctx: Omit<FaceErrorContext, 'errorClass'>,
+): string {
+  const errorClass = errorClassFor(err);
+  hooks?.onError?.(err, { ...ctx, errorClass });
+  return errorClass;
+}
+
+function normalizeErrorClassPart(value: unknown): string | null {
+  const normalized = String(value ?? '')
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return normalized.length > 0 ? normalized : null;
+}

--- a/ts/src/tabletheory/index.ts
+++ b/ts/src/tabletheory/index.ts
@@ -17,6 +17,11 @@ import type {
 const DEFAULT_STATUS = 200;
 const DEFAULT_CONTENT_TYPE = 'text/html; charset=utf-8';
 
+// TableTheory's current FaceTheory ISR metadata model does not expose
+// status/contentType fields. Until that schema grows, the adapter keeps
+// deterministic defaults here and FaceTheory restores response status and
+// content type from HTML object metadata on cache hits.
+
 function normalizeRevalidateSeconds(value: number): number {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return 0;

--- a/ts/test/unit/app.test.ts
+++ b/ts/test/unit/app.test.ts
@@ -133,13 +133,16 @@ test('FaceApp: propagates x-request-id and injects one when missing', async () =
 });
 
 test('FaceApp: load/render errors return deterministic 500 HTML', async () => {
+  const loadError = new Error('sensitive load message');
+  const renderError = new Error('sensitive render message');
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
   const app = createFaceApp({
     faces: [
       {
         route: '/load-error',
         mode: 'ssr',
         load: async () => {
-          throw new Error('sensitive load message');
+          throw loadError;
         },
         render: () => ({ html: '<div>unreachable</div>' }),
       },
@@ -147,10 +150,17 @@ test('FaceApp: load/render errors return deterministic 500 HTML', async () => {
         route: '/render-error',
         mode: 'ssr',
         render: async () => {
-          throw new Error('sensitive render message');
+          throw renderError;
         },
       },
     ],
+    observability: {
+      onError: (err, ctx) =>
+        observedErrors.push({
+          err,
+          ctx: ctx as unknown as Record<string, unknown>,
+        }),
+    },
   });
 
   const loadResp = await app.handle({ method: 'GET', path: '/load-error' });
@@ -176,6 +186,13 @@ test('FaceApp: load/render errors return deterministic 500 HTML', async () => {
   assert.ok(loadHtml.includes('data-facetheory-error="true"'));
   assert.ok(!loadHtml.includes('sensitive load message'));
   assert.ok(!loadHtml.includes('sensitive render message'));
+  assert.equal(observedErrors.length, 2);
+  assert.equal(observedErrors[0]?.err, loadError);
+  assert.equal(observedErrors[0]?.ctx.phase, 'render');
+  assert.equal(observedErrors[0]?.ctx.routePattern, '/load-error');
+  assert.equal(observedErrors[1]?.err, renderError);
+  assert.equal(observedErrors[1]?.ctx.phase, 'render');
+  assert.equal(observedErrors[1]?.ctx.routePattern, '/render-error');
 });
 
 test('FaceApp: merges set-cookie header values and cookies array without joining', async () => {
@@ -821,7 +838,61 @@ test('parseCookiesFromHeaders: preserves special keys without prototype mutation
   assert.equal(({} as Record<string, unknown>)['polluted'], undefined);
 });
 
+
+test('FaceApp: onError receives original resource and sidecar exceptions', async () => {
+  const resourceError = new Error('sensitive resource failure');
+  const sidecarError = new Error('sensitive sidecar failure');
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+
+  const app = createFaceApp({
+    faces: [],
+    resources: [
+      {
+        route: '/resource',
+        handle: () => {
+          throw resourceError;
+        },
+      },
+    ],
+    ssrHydrationSidecars: {
+      htmlStore: new RecordingHtmlStore(),
+      signingSecret: SIDECAR_SIGNING_SECRET,
+      requestVariant: () => {
+        throw sidecarError;
+      },
+    },
+    observability: {
+      onError: (err, ctx) =>
+        observedErrors.push({
+          err,
+          ctx: ctx as unknown as Record<string, unknown>,
+        }),
+    },
+  });
+
+  const resource = await app.handle({ method: 'GET', path: '/resource' });
+  const sidecar = await app.handle({
+    method: 'GET',
+    path: '/_facetheory/ssr-data/not-a-valid-token',
+  });
+
+  assert.equal(resource.status, 500);
+  assert.equal(sidecar.status, 404);
+  assert.equal(observedErrors.length, 2);
+  assert.equal(observedErrors[0]?.err, resourceError);
+  assert.equal(observedErrors[0]?.ctx.phase, 'resource');
+  assert.equal(observedErrors[0]?.ctx.routePattern, '/resource');
+  assert.equal(observedErrors[1]?.err, sidecarError);
+  assert.equal(observedErrors[1]?.ctx.phase, 'ssr-hydration-sidecar');
+  assert.equal(
+    observedErrors[1]?.ctx.routePattern,
+    '/_facetheory/ssr-data/{token}',
+  );
+});
+
 test('FaceApp: streaming body error before first chunk falls back to buffered 500', async () => {
+  const streamError = new Error('stream failed before bytes');
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
   const app = createFaceApp({
     faces: [
       {
@@ -830,7 +901,7 @@ test('FaceApp: streaming body error before first chunk falls back to buffered 50
         render: () => ({
           html: (async function* () {
             await Promise.resolve();
-            throw new Error('stream failed before bytes');
+            throw streamError;
             // Unreachable, but required to satisfy eslint `require-yield`.
             // This test depends on the stream failing before the first chunk.
             yield new Uint8Array();
@@ -838,6 +909,13 @@ test('FaceApp: streaming body error before first chunk falls back to buffered 50
         }),
       },
     ],
+    observability: {
+      onError: (err, ctx) =>
+        observedErrors.push({
+          err,
+          ctx: ctx as unknown as Record<string, unknown>,
+        }),
+    },
   });
 
   const resp = await app.handle({ method: 'GET', path: '/' });
@@ -849,4 +927,7 @@ test('FaceApp: streaming body error before first chunk falls back to buffered 50
       '<h1>Internal Server Error</h1>',
     ),
   );
+  assert.equal(observedErrors.length, 1);
+  assert.equal(observedErrors[0]?.err, streamError);
+  assert.equal(observedErrors[0]?.ctx.phase, 'stream-preflight');
 });

--- a/ts/test/unit/aws-s3.test.ts
+++ b/ts/test/unit/aws-s3.test.ts
@@ -57,7 +57,11 @@ test('aws-s3: getObject forwards body and etag', async () => {
           yield new TextEncoder().encode('hello');
         })(),
         ETag: '"etag"',
-        Metadata: { 'facetheory-content-security-policy': "script-src 'self'" },
+        Metadata: {
+          'facetheory-content-security-policy': "script-src 'self'",
+          'facetheory-content-type': 'application/problem+json',
+          'facetheory-status': '404',
+        },
       };
     },
   } as unknown as S3Client;
@@ -68,6 +72,8 @@ test('aws-s3: getObject forwards body and etag', async () => {
   assert.equal(out.etag, '"etag"');
   assert.deepEqual(out.metadata, {
     'facetheory-content-security-policy': "script-src 'self'",
+    'facetheory-content-type': 'application/problem+json',
+    'facetheory-status': '404',
   });
   const body = await collectBody(out.body ?? new Uint8Array());
   assert.equal(new TextDecoder().decode(body), 'hello');
@@ -92,7 +98,10 @@ test('aws-s3: putObject maps bucket/key/body/contentType/cacheControl/metadata',
     body,
     contentType: 'text/html; charset=utf-8',
     cacheControl: 'public,max-age=0',
-    metadata: { a: '1' },
+    metadata: {
+      'facetheory-content-type': 'application/problem+json',
+      'facetheory-status': '404',
+    },
   });
 
   assert.equal(out.etag, '"put-etag"');
@@ -102,5 +111,8 @@ test('aws-s3: putObject maps bucket/key/body/contentType/cacheControl/metadata',
   assert.deepEqual(seen.Body, body);
   assert.equal(seen.ContentType, 'text/html; charset=utf-8');
   assert.equal(seen.CacheControl, 'public,max-age=0');
-  assert.deepEqual(seen.Metadata, { a: '1' });
+  assert.deepEqual(seen.Metadata, {
+    'facetheory-content-type': 'application/problem+json',
+    'facetheory-status': '404',
+  });
 });

--- a/ts/test/unit/control-plane-host-contracts-example.test.ts
+++ b/ts/test/unit/control-plane-host-contracts-example.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { createControlPlaneApp } from '../../src/control-plane.js';
 import {
   createHostOwnedControlPlaneExampleApp,
   HOST_SUPPLIED_TABLETHEORY_SECTION_READ_CONTRACT,
@@ -52,4 +53,56 @@ test('control-plane host-contract example avoids client globals and time-varying
   assert.ok(!source.includes('document.'));
   assert.ok(!source.includes('@aws-sdk/client-dynamodb'));
   assert.ok(!source.includes('@aws-sdk/lib-dynamodb'));
+});
+
+
+test('control-plane sections report original load/render exceptions to onError', async () => {
+  const sectionError = new Error('sensitive control-plane section failure');
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+
+  const app = createControlPlaneApp({
+    gate: () => ({ ok: true }),
+    faces: [
+      {
+        route: '/',
+        sections: [
+          {
+            id: 'broken-section',
+            title: 'Broken section',
+            read: { bounded: true, tenantScoped: true },
+            errorHtml: '<p data-state="fallback">Section fallback</p>',
+            load: () => {
+              throw sectionError;
+            },
+            render: () => '<p>unreachable</p>',
+          },
+        ],
+      },
+    ],
+    faceApp: {
+      observability: {
+        onError: (err, ctx) =>
+          observedErrors.push({
+            err,
+            ctx: ctx as unknown as Record<string, unknown>,
+          }),
+      },
+    },
+  });
+
+  const response = await app.handle({
+    method: 'GET',
+    path: '/_facetheory/control-plane/sections/root-0/broken-section',
+    headers: { 'x-request-id': ['cp-error-1'] },
+  });
+  const body = await collect(response.body);
+
+  assert.equal(response.status, 200);
+  assert.ok(body.includes('Section fallback'));
+  assert.equal(body.includes('sensitive control-plane section failure'), false);
+  assert.equal(observedErrors.length, 1);
+  assert.equal(observedErrors[0]?.err, sectionError);
+  assert.equal(observedErrors[0]?.ctx.phase, 'control-plane-section');
+  assert.equal(observedErrors[0]?.ctx.sectionId, 'broken-section');
+  assert.equal(observedErrors[0]?.ctx.requestId, 'cp-error-1');
 });

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -699,6 +699,53 @@ function dropCspMetadata(record: IsrMetaRecord | null): IsrMetaRecord | null {
   return rest;
 }
 
+class StatusContentTypeDroppingMetaStore implements IsrMetaStore {
+  private readonly inner = new InMemoryIsrMetaStore();
+
+  async get(cacheKey: string): Promise<IsrMetaRecord | null> {
+    return dropStatusContentType(await this.inner.get(cacheKey));
+  }
+
+  async tryAcquireLease(
+    input: TryAcquireIsrLeaseInput,
+  ): Promise<TryAcquireIsrLeaseResult> {
+    const result = await this.inner.tryAcquireLease(input);
+    return {
+      ...result,
+      record: dropStatusContentType(result.record) ?? result.record,
+    };
+  }
+
+  async commitGeneration(input: CommitIsrGenerationInput): Promise<void> {
+    await this.inner.commitGeneration({
+      ...input,
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+    });
+  }
+
+  async releaseLease(input: ReleaseIsrLeaseInput): Promise<void> {
+    await this.inner.releaseLease(input);
+  }
+
+  debugSnapshot(): IsrMetaRecord[] {
+    return this.inner
+      .debugSnapshot()
+      .map((record) => dropStatusContentType(record) ?? record);
+  }
+}
+
+function dropStatusContentType(
+  record: IsrMetaRecord | null,
+): IsrMetaRecord | null {
+  if (record === null) return null;
+  return {
+    ...record,
+    status: 200,
+    contentType: 'text/html; charset=utf-8',
+  };
+}
+
 test('isr: metadata commits never include HTML body text', async () => {
   const marker = 'SUPER_SECRET_HTML_PAYLOAD';
   const htmlStore = new InMemoryHtmlStore();
@@ -738,6 +785,64 @@ test('isr: metadata commits never include HTML body text', async () => {
         typeof commit.htmlPointer === 'string' && commit.htmlPointer.length > 0,
     ),
   );
+});
+
+test('isr: cache hits preserve status and content type from HTML metadata', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new StatusContentTypeDroppingMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/api/missing',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: () => {
+          renderCount += 1;
+          return {
+            status: 404,
+            headers: { 'content-type': 'application/problem+json' },
+            html: '{"error":"missing"}',
+          };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => 1_000,
+    },
+  });
+
+  const miss = await app.handle({ method: 'GET', path: '/api/missing' });
+  assert.equal(miss.status, 404);
+  assert.equal(miss.headers['content-type']?.[0], 'application/problem+json');
+  assert.equal(miss.headers['x-facetheory-isr']?.[0], 'miss');
+
+  const record = metaStore.debugSnapshot()[0];
+  assert.ok(record?.htmlPointer);
+  assert.equal(record.status, 200);
+  assert.equal(record.contentType, 'text/html; charset=utf-8');
+
+  const stored = await htmlStore.read(record.htmlPointer);
+  assert.deepEqual(stored?.metadata, {
+    'facetheory-content-type': 'application/problem+json',
+    'facetheory-status': '404',
+  });
+
+  const hit = await app.handle({ method: 'GET', path: '/api/missing' });
+  assert.equal(hit.status, miss.status);
+  assert.equal(
+    hit.headers['content-type']?.[0],
+    miss.headers['content-type']?.[0],
+  );
+  assert.equal(hit.headers['x-facetheory-isr']?.[0], 'hit');
+  assert.equal(
+    decodeBody(hit.body as Uint8Array),
+    decodeBody(miss.body as Uint8Array),
+  );
+  assert.equal(renderCount, 1);
 });
 
 test('isr: strict CSP hydration writes and serves pointer-derived sidecars', async () => {

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -944,6 +944,129 @@ test('isr: metadata get failure serves last-known stale entry with degraded stat
   );
 });
 
+test('isr: metadata get failure honors error policy instead of serving stale', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new ToggleableFailingMetaStore();
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+
+  let nowMs = 40_000;
+  let renderCount = 0;
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/meta-error-policy',
+        mode: 'isr',
+        revalidateSeconds: 1,
+        render: () => {
+          const seq = ++renderCount;
+          return { html: `<main>error-policy-${seq}</main>` };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => nowMs,
+      failurePolicy: 'error',
+    },
+    observability: {
+      onError: (err, ctx) =>
+        observedErrors.push({
+          err,
+          ctx: ctx as unknown as Record<string, unknown>,
+        }),
+    },
+  });
+
+  const warm = await app.handle({
+    method: 'GET',
+    path: '/meta-error-policy',
+  });
+  assert.ok(decodeBody(warm.body as Uint8Array).includes('error-policy-1'));
+  assert.equal(warm.headers['x-facetheory-isr']?.[0], 'miss');
+
+  nowMs = 41_000;
+  const metadataError = new Error('metadata read unavailable for error policy');
+  metaStore.getError = metadataError;
+  const response = await app.handle({
+    method: 'GET',
+    path: '/meta-error-policy',
+    headers: { 'x-request-id': ['meta-error-policy-failure'] },
+  });
+
+  assert.equal(response.status, 500);
+  assert.equal(response.headers['x-facetheory-isr'], undefined);
+  const body = decodeBody(response.body as Uint8Array);
+  assert.ok(body.includes('<h1>Internal Server Error</h1>'));
+  assert.equal(body.includes('error-policy-1'), false);
+  assert.equal(renderCount, 1);
+  assert.equal(observedErrors.length, 1);
+  assert.equal(observedErrors[0]?.err, metadataError);
+  assert.equal(observedErrors[0]?.ctx.phase, 'render');
+  assert.equal(observedErrors[0]?.ctx.requestId, 'meta-error-policy-failure');
+});
+
+test('isr: metadata-failure last-known records evict least-recent cache keys', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new ToggleableFailingMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/meta-lru',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: (ctx) => {
+          renderCount += 1;
+          const variant = ctx.request.query.v?.[0] ?? 'missing';
+          return { html: `<main>meta-lru-${variant}</main>` };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => 50_000,
+    },
+  });
+
+  for (let index = 0; index <= 128; index += 1) {
+    const response = await app.handle({
+      method: 'GET',
+      path: `/meta-lru?v=${String(index)}`,
+    });
+    assert.equal(response.headers['x-facetheory-isr']?.[0], 'miss');
+    assert.ok(
+      decodeBody(response.body as Uint8Array).includes(
+        `meta-lru-${String(index)}`,
+      ),
+    );
+  }
+  assert.equal(renderCount, 129);
+
+  metaStore.getError = new Error('metadata unavailable after cap');
+  const evicted = await app.handle({ method: 'GET', path: '/meta-lru?v=0' });
+  assert.equal(evicted.status, 500);
+  assert.equal(evicted.headers['x-facetheory-isr'], undefined);
+  assert.equal(
+    decodeBody(evicted.body as Uint8Array).includes('meta-lru-0'),
+    false,
+  );
+
+  const retained = await app.handle({
+    method: 'GET',
+    path: '/meta-lru?v=128',
+  });
+  assert.equal(retained.status, 200);
+  assert.equal(
+    retained.headers['x-facetheory-isr']?.[0],
+    'stale-metadata-error',
+  );
+  assert.ok(decodeBody(retained.body as Uint8Array).includes('meta-lru-128'));
+  assert.equal(renderCount, 129);
+});
+
 test('isr: lease failure serves current stale entry with degraded state', async () => {
   const htmlStore = new InMemoryHtmlStore();
   const metaStore = new ToggleableFailingMetaStore();

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -699,6 +699,36 @@ function dropCspMetadata(record: IsrMetaRecord | null): IsrMetaRecord | null {
   return rest;
 }
 
+class ToggleableFailingMetaStore implements IsrMetaStore {
+  private readonly inner = new InMemoryIsrMetaStore();
+  getError: unknown = null;
+  acquireError: unknown = null;
+
+  async get(cacheKey: string): Promise<IsrMetaRecord | null> {
+    if (this.getError !== null) throw this.getError;
+    return await this.inner.get(cacheKey);
+  }
+
+  async tryAcquireLease(
+    input: TryAcquireIsrLeaseInput,
+  ): Promise<TryAcquireIsrLeaseResult> {
+    if (this.acquireError !== null) throw this.acquireError;
+    return await this.inner.tryAcquireLease(input);
+  }
+
+  async commitGeneration(input: CommitIsrGenerationInput): Promise<void> {
+    await this.inner.commitGeneration(input);
+  }
+
+  async releaseLease(input: ReleaseIsrLeaseInput): Promise<void> {
+    await this.inner.releaseLease(input);
+  }
+
+  debugSnapshot(): IsrMetaRecord[] {
+    return this.inner.debugSnapshot();
+  }
+}
+
 class StatusContentTypeDroppingMetaStore implements IsrMetaStore {
   private readonly inner = new InMemoryIsrMetaStore();
 
@@ -843,6 +873,173 @@ test('isr: cache hits preserve status and content type from HTML metadata', asyn
     decodeBody(miss.body as Uint8Array),
   );
   assert.equal(renderCount, 1);
+});
+
+test('isr: metadata get failure serves last-known stale entry with degraded state', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new ToggleableFailingMetaStore();
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+  const metrics: Array<Record<string, unknown>> = [];
+
+  let nowMs = 10_000;
+  let renderCount = 0;
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/meta-read',
+        mode: 'isr',
+        revalidateSeconds: 1,
+        render: () => {
+          const seq = ++renderCount;
+          return { html: `<main>read-${seq}</main>` };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => nowMs,
+    },
+    observability: {
+      onError: (err, ctx) =>
+        observedErrors.push({
+          err,
+          ctx: ctx as unknown as Record<string, unknown>,
+        }),
+      metric: (record) => metrics.push(record as unknown as Record<string, unknown>),
+    },
+  });
+
+  const warm = await app.handle({ method: 'GET', path: '/meta-read' });
+  assert.ok(decodeBody(warm.body as Uint8Array).includes('read-1'));
+  assert.equal(warm.headers['x-facetheory-isr']?.[0], 'miss');
+
+  nowMs = 11_000;
+  const metadataError = new Error('metadata read unavailable');
+  metaStore.getError = metadataError;
+  const stale = await app.handle({
+    method: 'GET',
+    path: '/meta-read',
+    headers: { 'x-request-id': ['meta-read-failure'] },
+  });
+
+  assert.equal(stale.status, 200);
+  assert.ok(decodeBody(stale.body as Uint8Array).includes('read-1'));
+  assert.equal(
+    stale.headers['x-facetheory-isr']?.[0],
+    'stale-metadata-error',
+  );
+  assert.equal(renderCount, 1);
+  assert.equal(observedErrors.length, 1);
+  assert.equal(observedErrors[0]?.err, metadataError);
+  assert.equal(observedErrors[0]?.ctx.phase, 'isr-metadata');
+  assert.equal(observedErrors[0]?.ctx.requestId, 'meta-read-failure');
+
+  const degradedMetric = metrics
+    .filter((metric) => metric.name === 'facetheory.request')
+    .at(-1);
+  assert.equal(
+    (degradedMetric?.tags as Record<string, string> | undefined)?.isr_state,
+    'stale-metadata-error',
+  );
+});
+
+test('isr: lease failure serves current stale entry with degraded state', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new ToggleableFailingMetaStore();
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+
+  let nowMs = 20_000;
+  let renderCount = 0;
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/meta-lease',
+        mode: 'isr',
+        revalidateSeconds: 1,
+        render: () => {
+          const seq = ++renderCount;
+          return { html: `<main>lease-${seq}</main>` };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => nowMs,
+    },
+    observability: {
+      onError: (err, ctx) =>
+        observedErrors.push({
+          err,
+          ctx: ctx as unknown as Record<string, unknown>,
+        }),
+    },
+  });
+
+  await app.handle({ method: 'GET', path: '/meta-lease' });
+  nowMs = 21_000;
+  const leaseError = new Error('lease unavailable');
+  metaStore.acquireError = leaseError;
+
+  const stale = await app.handle({
+    method: 'GET',
+    path: '/meta-lease',
+    headers: { 'x-request-id': ['meta-lease-failure'] },
+  });
+
+  assert.equal(stale.status, 200);
+  assert.ok(decodeBody(stale.body as Uint8Array).includes('lease-1'));
+  assert.equal(
+    stale.headers['x-facetheory-isr']?.[0],
+    'stale-metadata-error',
+  );
+  assert.equal(renderCount, 1);
+  assert.equal(observedErrors.length, 1);
+  assert.equal(observedErrors[0]?.err, leaseError);
+  assert.equal(observedErrors[0]?.ctx.phase, 'isr-metadata');
+  assert.equal(observedErrors[0]?.ctx.requestId, 'meta-lease-failure');
+});
+
+test('isr: metadata failure without a serveable entry returns 500 through onError', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new ToggleableFailingMetaStore();
+  const metadataError = new Error('metadata unavailable before warm');
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+  metaStore.getError = metadataError;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/no-entry',
+        mode: 'isr',
+        revalidateSeconds: 1,
+        render: () => ({ html: '<main>unreachable</main>' }),
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      now: () => 30_000,
+    },
+    observability: {
+      onError: (err, ctx) =>
+        observedErrors.push({
+          err,
+          ctx: ctx as unknown as Record<string, unknown>,
+        }),
+    },
+  });
+
+  const response = await app.handle({ method: 'GET', path: '/no-entry' });
+  assert.equal(response.status, 500);
+  assert.equal(response.headers['x-facetheory-isr'], undefined);
+  const body = decodeBody(response.body as Uint8Array);
+  assert.ok(body.includes('<h1>Internal Server Error</h1>'));
+  assert.equal(body.includes('metadata unavailable before warm'), false);
+  assert.equal(observedErrors.length, 1);
+  assert.equal(observedErrors[0]?.err, metadataError);
+  assert.equal(observedErrors[0]?.ctx.phase, 'render');
 });
 
 test('isr: strict CSP hydration writes and serves pointer-derived sidecars', async () => {

--- a/ts/test/unit/lambda-url.test.ts
+++ b/ts/test/unit/lambda-url.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import test from 'node:test';
 
 import { createFaceApp } from '../../src/app.js';
@@ -53,6 +54,28 @@ function extractHydrationHref(html: string): string {
   const href = /\bhref="([^"]+)"/i.exec(tag)?.[1];
   assert.ok(href, 'expected FaceTheory hydration href');
   return href;
+}
+
+async function withTimeout<T>(
+  input: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    input.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
 }
 
 test('lambdaUrlEventToFaceRequest: maps Lambda URL event shape deterministically', () => {
@@ -282,6 +305,84 @@ test('writeFaceResponseToLambdaWriter: waits for drain when writes apply backpre
     'end',
   ]);
 });
+
+for (const terminalEvent of ['close', 'error'] as const) {
+  test(`createLambdaUrlStreamingHandler: stops drain wait on raw stream ${terminalEvent} before drain`, async () => {
+    const app = createFaceApp({
+      faces: [
+        {
+          route: '/',
+          mode: 'ssr',
+          render: () => ({
+            html: streamFromString('<main>backpressure</main>'),
+          }),
+        },
+      ],
+    });
+
+    const events: string[] = [];
+    const emitter = new EventEmitter();
+    const terminalError = new Error('client disconnected before drain');
+    const rawStream: LambdaWritableStream = {
+      write: (chunk) => {
+        const text =
+          typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+        events.push(`write:${text}`);
+        setImmediate(() => {
+          if (terminalEvent === 'error') {
+            emitter.emit('error', terminalError);
+            return;
+          }
+          emitter.emit('close');
+        });
+        return false;
+      },
+      end: () => {
+        events.push('end');
+      },
+      once: (event, listener) => {
+        emitter.once(event, listener);
+        return emitter;
+      },
+      off: (event, listener) => {
+        emitter.off(event, listener);
+        return emitter;
+      },
+    };
+
+    const awslambda: AwsLambdaGlobalLike = {
+      streamifyResponse: (impl) => {
+        return async (event, context) => {
+          await impl(event, rawStream, context);
+        };
+      },
+    };
+
+    const handler = createLambdaUrlStreamingHandler({ app, awslambda });
+
+    await assert.rejects(
+      withTimeout(
+        handler(
+          {
+            rawPath: '/',
+            requestContext: { http: { method: 'GET' } },
+          },
+          {},
+        ),
+        1_000,
+      ),
+      (err) => {
+        if (terminalEvent === 'error') return err === terminalError;
+        return (
+          err instanceof Error &&
+          err.message.includes('Lambda response stream closed before drain')
+        );
+      },
+    );
+    assert.ok(events.some((entry) => entry.startsWith('write:')));
+    assert.equal(events.includes('end'), false);
+  });
+}
 
 test('handleLambdaUrlEvent: serves emitted SSR hydration sidecar URL as raw JSON without rerendering', async () => {
   const htmlStore = new RecordingHtmlStore();

--- a/ts/test/unit/lambda-url.test.ts
+++ b/ts/test/unit/lambda-url.test.ts
@@ -197,6 +197,92 @@ test('writeFaceResponseToLambdaWriter: writes head once before first body bytes'
   assert.ok(firstChunk.includes('</head><body>'));
 });
 
+test('writeFaceResponseToLambdaWriter: waits for drain when writes apply backpressure', async () => {
+  const events: string[] = [];
+  const sourceChunks = [utf8('alpha'), utf8('beta'), utf8('gamma')];
+
+  async function* body(): AsyncIterable<Uint8Array> {
+    for (const [index, chunk] of sourceChunks.entries()) {
+      events.push(`source:${String(index)}`);
+      yield chunk;
+    }
+  }
+
+  const writtenChunks: Uint8Array[] = [];
+  let pendingBackpressure = false;
+  let bufferedWrites = 0;
+  let maxBufferedWrites = 0;
+  let drainCount = 0;
+
+  const writer: LambdaResponseWriter = {
+    writeHead: () => {
+      events.push('head');
+    },
+    write: (chunk) => {
+      if (pendingBackpressure) {
+        throw new Error('next chunk was written before drain resolved');
+      }
+
+      const text = new TextDecoder().decode(chunk);
+      events.push(`write:${text}`);
+      writtenChunks.push(chunk);
+      pendingBackpressure = true;
+      bufferedWrites += 1;
+      maxBufferedWrites = Math.max(maxBufferedWrites, bufferedWrites);
+      return false;
+    },
+    drain: async () => {
+      assert.equal(pendingBackpressure, true);
+      events.push('drain:start');
+      drainCount += 1;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      pendingBackpressure = false;
+      bufferedWrites -= 1;
+      events.push('drain:end');
+    },
+    end: () => {
+      assert.equal(pendingBackpressure, false);
+      events.push('end');
+    },
+  };
+
+  await writeFaceResponseToLambdaWriter(
+    {
+      status: 200,
+      headers: { 'content-type': ['text/plain; charset=utf-8'] },
+      cookies: [],
+      body: body(),
+      isBase64: false,
+    },
+    writer,
+  );
+
+  assert.equal(drainCount, sourceChunks.length);
+  assert.equal(maxBufferedWrites, 1);
+  assert.equal(
+    new TextDecoder().decode(Buffer.concat(writtenChunks.map((chunk) => Buffer.from(chunk)))),
+    'alphabetagamma',
+  );
+  assert.deepEqual(events, [
+    'head',
+    'source:0',
+    'write:alpha',
+    'drain:start',
+    'drain:end',
+    'source:1',
+    'write:beta',
+    'drain:start',
+    'drain:end',
+    'source:2',
+    'write:gamma',
+    'drain:start',
+    'drain:end',
+    'end',
+  ]);
+});
+
 test('handleLambdaUrlEvent: serves emitted SSR hydration sidecar URL as raw JSON without rerendering', async () => {
   const htmlStore = new RecordingHtmlStore();
   let loadCount = 0;

--- a/ts/test/unit/ops.test.ts
+++ b/ts/test/unit/ops.test.ts
@@ -44,11 +44,53 @@ test('FaceApp: observability hooks receive request + ISR state + render duration
   assert.equal(logs[1]?.requestId, 'req-2');
   assert.equal(logs[1]?.isrState, 'hit');
   assert.equal(logs[1]?.renderMs, null);
+  assert.equal(logs[1]?.errorClass, null);
 
   const requestMetrics = metrics.filter((m) => m.name === 'facetheory.request');
   assert.equal(requestMetrics.length, 2);
+  assert.equal(
+    (requestMetrics[0]?.tags as Record<string, string> | undefined)?.error_class,
+    '',
+  );
 
   const renderMetrics = metrics.filter((m) => m.name === 'facetheory.render_ms');
   assert.equal(renderMetrics.length, 1);
 });
 
+
+
+test('FaceApp: request metrics tag deterministic render errors by class', async () => {
+  const renderError = new TypeError('sensitive typed failure');
+  const errors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+  const metrics: Array<Record<string, unknown>> = [];
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/boom',
+        mode: 'ssr',
+        render: () => {
+          throw renderError;
+        },
+      },
+    ],
+    observability: {
+      onError: (err, ctx) => errors.push({ err, ctx: ctx as unknown as Record<string, unknown> }),
+      metric: (record) => metrics.push(record as unknown as Record<string, unknown>),
+    },
+  });
+
+  const response = await app.handle({ method: 'GET', path: '/boom' });
+  assert.equal(response.status, 500);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0]?.err, renderError);
+  assert.equal(errors[0]?.ctx.errorClass, 'TypeError');
+  assert.equal(errors[0]?.ctx.phase, 'render');
+
+  const requestMetric = metrics.find((m) => m.name === 'facetheory.request');
+  assert.ok(requestMetric);
+  assert.equal(
+    (requestMetric.tags as Record<string, string>).error_class,
+    'TypeError',
+  );
+});


### PR DESCRIPTION
## Milestone
Framework Strengthening — FaceTheory M2 failure-visibility

## Linear
Project: FaceTheory Product Strengthening Program 2026-07 / Framework Strengthening initiative

- THE-2460 — https://linear.app/theorycloud/issue/THE-2460/ft-strengthen-9-add-an-onerror-observability-hook-and-stop-swallowing
- THE-2461 — https://linear.app/theorycloud/issue/THE-2461/ft-strengthen-2-preserve-isr-status-and-content-type-across-cache-hits
- THE-2462 — https://linear.app/theorycloud/issue/THE-2462/ft-strengthen-3-serve-stale-on-isr-metadata-store-failure-instead-of
- THE-2463 — https://linear.app/theorycloud/issue/THE-2463/ft-strengthen-4-honor-writable-backpressure-in-lambda-url-streaming

## Summary
- Adds `FaceObservabilityHooks.onError(err, ctx)` and request metric `error_class` tagging for previously silent failure paths, including resource, render/stream-preflight, SSR hydration sidecar, and control-plane section failures.
- Persists ISR response status and content type in HTML object metadata so cache HIT responses preserve non-200 and non-HTML outputs even while the TableTheory metadata schema keeps deterministic defaults.
- Serves last-known stale ISR HTML with `x-facetheory-isr: stale-metadata-error` when metadata-store operations fail, `failurePolicy` permits stale serving, and a serveable pointer is known; no-entry or `failurePolicy: 'error'` failures still surface through the deterministic 500/onError path.
- Bounds the warm-Lambda last-known ISR metadata pointer map with deterministic LRU eviction so request-controlled query strings cannot grow it without limit.
- Makes Lambda URL streaming respect writable backpressure by awaiting drain when `write()` returns `false` while bailing on raw-stream `error`/`close` before drain.

## Render modes and adapters affected
- Render modes: SSR/resource/control-plane failure visibility, ISR cache/degraded paths, Lambda URL streaming response writing.
- Adapters: core-only behavior; no React/Vue/Svelte adapter-specific API changes.

## Determinism impact
- Preserves rendered byte order and content for normal buffered/streaming paths.
- Intentional visible changes are limited to ISR HIT status/content-type restoration from object metadata and degraded ISR state header `stale-metadata-error` when serving stale on metadata-store failure.
- `failurePolicy: 'error'` now keeps correctness-over-availability semantics for metadata-store failures instead of reusing stale HTML.
- No new nondeterministic render source or client hydration behavior introduced.

## Backward compatibility
Additive; no intentional 3.x consumer break.

## Validation
- `cd ts && npm run check`
  - `FaceTheory unit test files discovered: 53`
  - `ℹ tests 598`
  - `ℹ pass 597`
  - `ℹ fail 0`
  - `ℹ skipped 1`
  - `ℹ duration_ms 33520.032207`
- `cd ts && node --import tsx test/unit/isr.test.ts`
  - `ℹ tests 23`
  - `ℹ pass 23`
  - `ℹ fail 0`
  - `ℹ skipped 0`
  - `ℹ duration_ms 164.576759`
- `cd ts && node --import tsx test/unit/lambda-url.test.ts`
  - `ℹ tests 11`
  - `ℹ pass 11`
  - `ℹ fail 0`
  - `ℹ skipped 0`
  - `ℹ duration_ms 12.284675`
- `scripts/verify-version-alignment.sh`
  - `version-alignment: PASS (3.8.1)`

## Signature verification
`git log --show-signature --format=fuller --max-count=5` reports Good git signatures for all five M2 commits with ED25519 key `SHA256:q7HPwpHpeTN3JDe9vzuMxby+Nc1n4trLrVNWUL7pzE8`, including head `a7a06677d46e0b1d38e5dd76ee236a50e9525b35`.

## Cross-repo coordination
No cross-repo changes. TableTheory status/contentType schema growth remains a tracking follow-up only; this PR uses FaceTheory-owned S3 HTML object metadata for the M2 round-trip.

## Risks / follow-ups
- `onError` hook implementations should avoid throwing; this PR reports original exceptions but does not make host observability sinks authoritative for response rendering.
- Consider a later TableTheory schema-source follow-up for ISR status/contentType metadata once coordinated with the TableTheory steward.
- Optional review note left as follow-up: `FaceErrorPhase` includes `control-plane-section-validation`, but wiring strict-CSP section-fragment validation into that phase would require changing the control-plane section response path; kept out of this bounded M2 review fix.