### PR TITLE
feat: strengthen FaceTheory contract guards

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -116,7 +116,7 @@ These contracts shape every adapter and delivery mode. If you change one of thes
 
 | Interface           | Purpose                              | Notes                                                                                                                                                                                                                                                           |
 | ------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FaceModule`        | Route definition                     | Uses `route`, `mode`, optional `load`, optional `generateStaticParams`, and `render`. SSG params must resolve to normal route segments; dot-segments such as `.` and `..` are rejected.                                                                         |
+| `FaceModule`        | Route definition                     | Uses `route`, `mode`, optional `load`, optional `generateStaticParams`, and `render`. `createFaceApp()` rejects empty routes, non-function `render`, and modes outside `ssr`, `ssg`, or `isr`. SSG params must resolve to normal route segments; dot-segments such as `.` and `..` are rejected. |
 | `FaceResourceRoute` | Raw resource route                   | Uses `route` and `handle`. The handler receives the same normalized `FaceContext` route params/proxy/request shape as a Face and returns a raw `FaceResponse` directly. Resource routes do not declare a `mode` and are not document-rendered.                  |
 | `FaceMode`          | Rendering mode                       | One of `ssr`, `ssg`, or `isr`.                                                                                                                                                                                                                                  |
 | `FaceRequest`       | Normalized request input             | Supports headers, cookies, query, body, base64 marker, and optional `cspNonce`.                                                                                                                                                                                 |
@@ -788,6 +788,7 @@ Observability is optional, but the hook surface is part of the public runtime co
 `createFaceApp({ observability })` supports:
 
 - `observability.log(record)` for `facetheory.request.completed`
+- `observability.log(record)` for construction warnings with `event: "facetheory.app.contract.warning"`, `level: "warn"`, a stable `warningCode`, and the affected `routePattern` / `mode`. Current warnings cover ISR Faces without `revalidateSeconds` and SSG parameter routes without `generateStaticParams`; they remain warnings in the 3.x train and escalate in the planned v4 contract pass.
 - `observability.metric(record)` for request and render timing metrics
 - `observability.now()` to override the clock used for durations
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -100,6 +100,50 @@ Why this is incorrect:
 - It omits the coordinated HTML and metadata stores that blocking ISR expects in production.
 - If the page renders tenant-specific HTML, it also omits the explicit `tenantKey` or custom `cacheKey` required to partition that cache. FaceTheory fails closed when known tenant boundary headers reach ISR without such a partition.
 
+
+## Pattern: Pick an explicit trailing-slash policy
+
+Problem:
+You need route matching, redirects, CloudFront behavior, and SSG output paths to
+agree on whether `/docs` and `/docs/` are the same URL.
+
+**CORRECT**
+
+```ts
+import { createFaceApp } from "@theory-cloud/facetheory";
+
+const app = createFaceApp({
+  faces,
+  trailingSlash: "redirect",
+});
+```
+
+Why this is correct:
+
+- FaceTheory's default is `"strict"`, which preserves existing behavior exactly:
+  `/docs` and `/docs/` are distinct paths.
+- `"redirect"` returns a deterministic `308` from `/docs/` to `/docs` when the
+  canonical route exists. This is the recommended production policy because it
+  makes accidental alternate URLs explicit without silently changing cache keys.
+- `"normalize"` matches both forms silently. Use it only when upstream routing
+  already canonicalizes the URL and you intentionally want FaceTheory to accept
+  either spelling.
+- For SSG output, align the app policy with the repository CLI's
+  `--trailing-slash` flag. The recommended `"redirect"` policy pairs with
+  `--trailing-slash never` so generated objects and runtime canonical URLs both
+  use `/docs` rather than `/docs/`.
+
+**INCORRECT**
+
+```ts
+const app = createFaceApp({ faces, trailingSlash: "normalize" });
+```
+
+Why this is incorrect:
+
+- It silently accepts two URLs for the same Face. That can hide CloudFront, S3,
+  or SSG output drift unless another layer is already enforcing canonical URLs.
+
 ## Pattern: Use resource response helpers for raw routes
 
 Problem:

--- a/docs/features/isr-tenant-safety.md
+++ b/docs/features/isr-tenant-safety.md
@@ -10,9 +10,21 @@ ISR computes a cache key from the path, query, and (optionally) headers / cookie
 
 ## The fail-closed behavior
 
-When FaceTheory's ISR runtime sees a known tenant-boundary header — for example `x-tenant-id` or `x-facetheory-tenant` — and the Face has not configured a `tenantKey` or custom `cacheKey` that explicitly accounts for it, the runtime refuses to serve cached HTML and emits an error response instead.
+When FaceTheory's ISR runtime sees a known tenant-boundary header — by default `x-tenant-id` or `x-facetheory-tenant` — and the Face has not configured a `tenantKey` or custom `cacheKey` that explicitly accounts for it, the runtime refuses to serve cached HTML and emits an error response instead.
 
 This is intentional. The framework cannot tell whether the rendered HTML is tenant-invariant or tenant-varying, so the safe default is to fail and force the consumer to declare intent.
+
+If a deployment uses additional tenant-like headers, register them with `tenantBoundaryHeaders`. The default headers remain active; the configured names extend the fail-closed list rather than replacing it.
+
+```typescript
+isr: {
+  htmlStore,
+  metaStore,
+  tenantBoundaryHeaders: ['x-org-id', 'x-account-id'],
+},
+```
+
+Custom tenant headers must be registered here, stripped before ISR, or included in an explicit `tenantKey` / custom `cacheKey` partition.
 
 ## Tenant-invariant deployments
 

--- a/docs/features/isr-tenant-safety.md
+++ b/docs/features/isr-tenant-safety.md
@@ -6,7 +6,7 @@ Blocking ISR is **fail-closed** when known tenant-boundary headers reach FaceThe
 
 ## The hazard
 
-ISR computes a cache key from the path, query, and (optionally) headers / cookies / a tenant key. If the cache key doesn't include the tenant dimension but the rendered HTML varies per tenant, the first request from one tenant pollutes the cache and the next request from a different tenant serves the wrong page.
+ISR computes a cache key from the path, query, and (optionally) headers / cookies / a tenant key. By default, any request cookie folds into an hashed variant digest so unknown cookie variance fails safe by partitioning the cache entry. If the cache key doesn't include the tenant dimension but the rendered HTML varies per tenant, the first request from one tenant pollutes the cache and the next request from a different tenant serves the wrong page.
 
 ## The fail-closed behavior
 
@@ -49,6 +49,22 @@ If the cached HTML varies per tenant, choose one of:
   ```
 
   The cache key must include every request-varying dimension that affects the cached HTML.
+
+## Cookie request variants
+
+By default, the built-in ISR cache key folds all request cookies into a digest. This is the fail-safe posture: an unexpected session or personalization cookie partitions the cache instead of allowing a potentially personalized render to be shared.
+
+If a deployment knows that only specific cookies affect the ISR HTML, set `varyCookies` to that allowlist:
+
+```typescript
+isr: {
+  htmlStore,
+  metaStore,
+  varyCookies: ['session'],
+},
+```
+
+Requests that differ only in non-listed cookies share the same cache entry; requests that differ in a listed cookie partition. Keep the list complete for every cookie that can affect the rendered HTML.
 
 ## Migration
 

--- a/docs/modes/isr.md
+++ b/docs/modes/isr.md
@@ -64,6 +64,23 @@ Blocking ISR is **fail-closed** when known tenant-boundary headers (e.g. `x-tena
 
 See [ISR tenant safety](../features/isr-tenant-safety.md) and [Migration Guide → Adopt ISR tenant fail-closed defaults](../migration-guide.md).
 
+## Cookie request variants
+
+The built-in ISR cache key includes all request cookies in a hashed variant by default. This preserves the fail-safe behavior for unknown personalization cookies. To share entries across non-render-affecting cookies, configure an allowlist:
+
+```typescript
+export const app = createFaceApp({
+  faces,
+  isr: {
+    htmlStore,
+    metaStore,
+    varyCookies: ['session'],
+  },
+});
+```
+
+With `varyCookies`, only listed cookies partition the default cache key; absent `varyCookies` keeps the all-cookies default.
+
 ## What ISR guarantees
 
 - Fresh entries serve from cache without invoking `render` or `load`.

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -20,6 +20,7 @@ import {
   reportFaceError,
   type FaceErrorPhase,
   type FaceObservabilityHooks,
+  type FaceRequestCompletedLogRecord,
 } from './ops.js';
 import {
   buildStrictCspHeader,
@@ -37,6 +38,7 @@ import {
 } from './ssr-hydration.js';
 import type {
   FaceContext,
+  FaceContractWarningLogRecord,
   FaceExternalHydration,
   FaceHydration,
   FaceMode,
@@ -61,8 +63,25 @@ export interface FaceAppOptions {
   resources?: FaceResourceRoute[];
   isr?: FaceIsrOptions;
   ssrHydrationSidecars?: FaceSsrHydrationSidecarOptions;
-  observability?: FaceObservabilityHooks;
+  observability?: FaceAppObservabilityHooks;
   strictCsp?: FaceStrictCspOptions;
+}
+
+export type FaceAppLogRecord =
+  | FaceRequestCompletedLogRecord
+  | (FaceContractWarningLogRecord &
+      Partial<Omit<FaceRequestCompletedLogRecord, 'event'>>);
+
+export type FaceAppLogHook = (record: FaceAppLogRecord) => void;
+
+export interface FaceAppObservabilityHooks
+  extends Omit<FaceObservabilityHooks, 'log'> {
+  /**
+   * Structured request completion records and construction-time contract
+   * warnings. Contract warnings remain warnings until the planned v4 contract
+   * escalation.
+   */
+  log?: FaceAppLogHook;
 }
 
 export interface FaceSsrHydrationSidecarOptions extends Pick<
@@ -159,7 +178,7 @@ export class FaceApp {
   private readonly resourceByPattern: Map<string, FaceResourceRoute>;
   private readonly isrRuntime: IsrRuntime | null;
   private readonly ssrHydrationSidecarRuntime: FaceAppSsrHydrationSidecarRuntime | null;
-  private readonly observability: FaceObservabilityHooks | null;
+  private readonly observability: FaceAppObservabilityHooks | null;
   private readonly strictCspMaxStreamingBodyBytes: number;
 
   constructor(options: FaceAppOptions) {
@@ -175,13 +194,16 @@ export class FaceApp {
       ? createFaceAppSsrHydrationSidecarRuntime(options.ssrHydrationSidecars)
       : null;
 
+    const constructionWarnings: FaceContractWarningLogRecord[] = [];
+
     for (const face of options.faces) {
-      const pattern = normalizePath(face.route);
+      const pattern = validateFaceContract(face);
       if (this.faceByPattern.has(pattern)) {
         throw new Error(`duplicate face route: ${pattern}`);
       }
       this.router.add(pattern);
       this.faceByPattern.set(pattern, face);
+      constructionWarnings.push(...faceContractWarnings(face, pattern));
     }
 
     const resources = this.ssrHydrationSidecarRuntime
@@ -228,16 +250,17 @@ export class FaceApp {
     const hasIsrFace = options.faces.some((face) => face.mode === 'isr');
     if (!hasIsrFace) {
       this.isrRuntime = null;
-      return;
+    } else {
+      const isrOptions = options.isr ?? {};
+      this.isrRuntime = createIsrRuntime({
+        ...isrOptions,
+        htmlStore: isrOptions.htmlStore ?? new InMemoryHtmlStore(),
+        metaStore: isrOptions.metaStore ?? new InMemoryIsrMetaStore(),
+        observability: this.observability ?? isrOptions.observability ?? null,
+      });
     }
 
-    const isrOptions = options.isr ?? {};
-    this.isrRuntime = createIsrRuntime({
-      ...isrOptions,
-      htmlStore: isrOptions.htmlStore ?? new InMemoryHtmlStore(),
-      metaStore: isrOptions.metaStore ?? new InMemoryIsrMetaStore(),
-      observability: this.observability ?? isrOptions.observability ?? null,
-    });
+    emitFaceContractWarnings(this.observability, constructionWarnings);
   }
 
   async handle(request: FaceRequest): Promise<FaceResponse> {
@@ -428,6 +451,82 @@ export class FaceApp {
 
 export function createFaceApp(options: FaceAppOptions): FaceApp {
   return new FaceApp(options);
+}
+
+function validateFaceContract(face: FaceModule): string {
+  const route = String((face as { route?: unknown }).route ?? '').trim();
+  if (!route) {
+    throw new Error('face route must be a non-empty string');
+  }
+
+  const mode = (face as { mode?: unknown }).mode;
+  if (mode !== 'ssr' && mode !== 'ssg' && mode !== 'isr') {
+    throw new Error(
+      `invalid face mode for route "${route}": expected ssr, ssg, or isr`,
+    );
+  }
+
+  if (typeof (face as { render?: unknown }).render !== 'function') {
+    throw new Error(`face render for route "${route}" must be a function`);
+  }
+
+  return normalizePath(route);
+}
+
+function faceContractWarnings(
+  face: FaceModule,
+  routePattern: string,
+): FaceContractWarningLogRecord[] {
+  const warnings: FaceContractWarningLogRecord[] = [];
+
+  if (face.mode === 'isr' && face.revalidateSeconds === undefined) {
+    warnings.push({
+      level: 'warn',
+      event: 'facetheory.app.contract.warning',
+      warningCode: 'isr.revalidate_seconds_missing',
+      routePattern,
+      mode: face.mode,
+      message:
+        `ISR face "${routePattern}" does not declare revalidateSeconds; ` +
+        'this remains a construction warning until the v4 contract escalation.',
+    });
+  }
+
+  if (
+    face.mode === 'ssg' &&
+    routePatternHasParams(routePattern) &&
+    typeof face.generateStaticParams !== 'function'
+  ) {
+    warnings.push({
+      level: 'warn',
+      event: 'facetheory.app.contract.warning',
+      warningCode: 'ssg.generate_static_params_missing',
+      routePattern,
+      mode: face.mode,
+      message:
+        `SSG param face "${routePattern}" does not declare generateStaticParams; ` +
+        'this remains a construction warning until the v4 contract escalation.',
+    });
+  }
+
+  return warnings;
+}
+
+function routePatternHasParams(routePattern: string): boolean {
+  return routePattern.split('/').some((segment) => {
+    const trimmed = segment.trim();
+    return trimmed.startsWith('{') && trimmed.endsWith('}') && trimmed.length > 2;
+  });
+}
+
+function emitFaceContractWarnings(
+  hooks: FaceAppObservabilityHooks | null,
+  warnings: readonly FaceContractWarningLogRecord[],
+): void {
+  const log = hooks?.log as FaceAppLogHook | undefined;
+  for (const warning of warnings) {
+    log?.(warning);
+  }
 }
 
 function createFaceAppSsrHydrationSidecarRuntime(

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -27,7 +27,12 @@ import {
   requiresStrictCspDocumentValidation,
   validateStrictCspDocument,
 } from './security.js';
-import { routePatternConflict, Router } from './router.js';
+import {
+  canonicalizePathForTrailingSlashPolicy,
+  normalizeTrailingSlashPolicy,
+  routePatternConflict,
+  Router,
+} from './router.js';
 import { jsonResourceResponse, textResourceResponse } from './resource.js';
 import {
   createSsrHydrationSidecarStore,
@@ -48,6 +53,7 @@ import type {
   FaceRequest,
   FaceResponse,
   Headers,
+  TrailingSlashPolicy,
 } from './types.js';
 import {
   canonicalizeHeaders,
@@ -65,6 +71,7 @@ export interface FaceAppOptions {
   ssrHydrationSidecars?: FaceSsrHydrationSidecarOptions;
   observability?: FaceAppObservabilityHooks;
   strictCsp?: FaceStrictCspOptions;
+  trailingSlash?: TrailingSlashPolicy;
 }
 
 export type FaceAppLogRecord =
@@ -180,9 +187,11 @@ export class FaceApp {
   private readonly ssrHydrationSidecarRuntime: FaceAppSsrHydrationSidecarRuntime | null;
   private readonly observability: FaceAppObservabilityHooks | null;
   private readonly strictCspMaxStreamingBodyBytes: number;
+  private readonly trailingSlash: TrailingSlashPolicy;
 
   constructor(options: FaceAppOptions) {
-    this.router = new Router();
+    this.trailingSlash = normalizeTrailingSlashPolicy(options.trailingSlash);
+    this.router = new Router({ trailingSlash: this.trailingSlash });
     this.faceByPattern = new Map();
     this.resourceByPattern = new Map();
     this.observability = options.observability ?? null;
@@ -197,7 +206,10 @@ export class FaceApp {
     const constructionWarnings: FaceContractWarningLogRecord[] = [];
 
     for (const face of options.faces) {
-      const pattern = validateFaceContract(face);
+      const pattern = canonicalizePathForTrailingSlashPolicy(
+        validateFaceContract(face),
+        this.trailingSlash,
+      );
       if (this.faceByPattern.has(pattern)) {
         throw new Error(`duplicate face route: ${pattern}`);
       }
@@ -214,7 +226,10 @@ export class FaceApp {
       : (options.resources ?? []);
 
     for (const resource of resources) {
-      const pattern = normalizePath(resource.route);
+      const pattern = canonicalizePathForTrailingSlashPolicy(
+        resource.route,
+        this.trailingSlash,
+      );
       if (this.resourceByPattern.has(pattern)) {
         throw new Error(`duplicate resource route: ${pattern}`);
       }
@@ -274,6 +289,27 @@ export class FaceApp {
     let routePattern = '';
     let mode: FaceMode | 'none' = 'none';
     let renderMs: number | null = null;
+
+    const trailingSlashRedirectPath = this.router.redirectPath(
+      normalizedReq.path,
+    );
+    if (trailingSlashRedirectPath !== null) {
+      return finishResponse(
+        hooks,
+        now,
+        startedAt,
+        requestId,
+        normalizedReq,
+        redirectResponse(
+          withQueryString(trailingSlashRedirectPath, normalizedReq.query),
+        ),
+        {
+          routePattern: trailingSlashRedirectPath,
+          mode,
+          renderMs,
+        },
+      );
+    }
 
     let response: FaceResponse;
     const match = this.router.match(normalizedReq.path);
@@ -1017,6 +1053,24 @@ async function preflightStream(
       yield next.value;
     }
   })();
+}
+
+function withQueryString(path: string, query: Record<string, string[]>): string {
+  const params = new URLSearchParams();
+  for (const [key, values] of Object.entries(query)) {
+    for (const value of values) {
+      params.append(key, value);
+    }
+  }
+  const queryString = params.toString();
+  return queryString ? `${path}?${queryString}` : path;
+}
+
+function redirectResponse(location: string): FaceResponse {
+  return textResponse(308, 'Permanent Redirect', {
+    location: [location],
+    'content-type': ['text/plain; charset=utf-8'],
+  });
 }
 
 function textResponse(

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -197,6 +197,7 @@ export interface FaceIsrOptions {
   tenantKey?: (ctx: FaceContext) => string | null | undefined;
   cacheKey?: (input: IsrCacheKeyInput) => string;
   varyCookies?: string[];
+  tenantBoundaryHeaders?: string[];
   htmlPointerPrefix?: string;
   cacheControl?: (input: IsrCacheHeaderInput) => string;
   observability?: FaceObservabilityHooks | null;
@@ -1107,7 +1108,9 @@ function normalizeRuntimeOptions(
     cacheKey,
     hasExplicitCacheKey,
     varyCookies,
-    tenantBoundaryHeaders: DEFAULT_TENANT_BOUNDARY_HEADERS,
+    tenantBoundaryHeaders: normalizeTenantBoundaryHeaders(
+      input.tenantBoundaryHeaders,
+    ),
     htmlPointerPrefix: normalizeObjectPrefix(input.htmlPointerPrefix ?? 'isr'),
     cacheControl:
       input.cacheControl ??
@@ -1120,6 +1123,21 @@ function normalizeVaryCookies(varyCookies: readonly string[]): readonly string[]
   return [...new Set(varyCookies.map((name) => String(name).trim()))].filter(
     (name) => name.length > 0,
   );
+}
+
+function normalizeTenantBoundaryHeaders(
+  tenantBoundaryHeaders: readonly string[] | undefined,
+): readonly string[] {
+  const configured = Array.isArray(tenantBoundaryHeaders)
+    ? tenantBoundaryHeaders
+    : [];
+  return [
+    ...new Set(
+      [...DEFAULT_TENANT_BOUNDARY_HEADERS, ...configured]
+        .map((name) => String(name).trim().toLowerCase())
+        .filter((name) => name.length > 0),
+    ),
+  ];
 }
 
 function assertPartitionedTenantBoundary(

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -148,6 +148,7 @@ export interface IsrCacheKeyInput {
   query: Query;
   headers?: Headers;
   cookies?: CookieMap;
+  varyCookies?: readonly string[];
 }
 
 export interface IsrCacheControlOptions {
@@ -195,6 +196,7 @@ export interface FaceIsrOptions {
   lockContentionPolicy?: IsrLockContentionPolicy;
   tenantKey?: (ctx: FaceContext) => string | null | undefined;
   cacheKey?: (input: IsrCacheKeyInput) => string;
+  varyCookies?: string[];
   htmlPointerPrefix?: string;
   cacheControl?: (input: IsrCacheHeaderInput) => string;
   observability?: FaceObservabilityHooks | null;
@@ -214,6 +216,7 @@ interface CreateIsrRuntimeOptions {
   hasExplicitTenantKey: boolean;
   cacheKey: (input: IsrCacheKeyInput) => string;
   hasExplicitCacheKey: boolean;
+  varyCookies: readonly string[] | null;
   tenantBoundaryHeaders: readonly string[];
   htmlPointerPrefix: string;
   cacheControl: (input: IsrCacheHeaderInput) => string;
@@ -471,14 +474,18 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
       const query = hydrationSidecarPointer.present
         ? queryWithoutHydrationSidecar(input.ctx.request.query)
         : input.ctx.request.query;
-      const cacheKey = runtimeOptions.cacheKey({
+      const cacheKeyInput: IsrCacheKeyInput = {
         tenant,
         routePattern: normalizePath(input.routePattern),
         params: input.ctx.params,
         query,
         headers: input.ctx.request.headers,
         cookies: input.ctx.request.cookies,
-      });
+      };
+      if (runtimeOptions.varyCookies !== null) {
+        cacheKeyInput.varyCookies = runtimeOptions.varyCookies;
+      }
+      const cacheKey = runtimeOptions.cacheKey(cacheKeyInput);
 
       if (hydrationSidecarPointer.present) {
         if (
@@ -681,7 +688,7 @@ function requestVariantKeyParts(input: IsrCacheKeyInput): string[] {
   );
   if (authHeadersDigest) parts.push(`auth=${authHeadersDigest}`);
 
-  const cookiesDigest = digestCookies(input.cookies);
+  const cookiesDigest = digestCookies(input.cookies, input.varyCookies);
   if (cookiesDigest) parts.push(`cookies=${cookiesDigest}`);
   return parts;
 }
@@ -706,9 +713,15 @@ function digestSelectedHeaders(
   return digestVariantLines(lines);
 }
 
-function digestCookies(cookies: CookieMap | undefined): string | null {
+function digestCookies(
+  cookies: CookieMap | undefined,
+  varyCookies?: readonly string[],
+): string | null {
   if (!cookies) return null;
-  const lines = Object.keys(cookies)
+  const cookieNames =
+    varyCookies === undefined ? Object.keys(cookies) : [...varyCookies];
+  const lines = [...new Set(cookieNames)]
+    .filter((name) => Object.hasOwn(cookies, name))
     .sort((left, right) => left.localeCompare(right))
     .map((name) => `${name}=${String(cookies[name])}`);
   return digestVariantLines(lines);
@@ -1063,6 +1076,9 @@ function normalizeRuntimeOptions(
   const cacheKey =
     typeof input.cacheKey === 'function' ? input.cacheKey : defaultIsrCacheKey;
   const hasExplicitCacheKey = typeof input.cacheKey === 'function';
+  const varyCookies = Array.isArray(input.varyCookies)
+    ? normalizeVaryCookies(input.varyCookies)
+    : null;
 
   return {
     htmlStore,
@@ -1090,6 +1106,7 @@ function normalizeRuntimeOptions(
     hasExplicitTenantKey,
     cacheKey,
     hasExplicitCacheKey,
+    varyCookies,
     tenantBoundaryHeaders: DEFAULT_TENANT_BOUNDARY_HEADERS,
     htmlPointerPrefix: normalizeObjectPrefix(input.htmlPointerPrefix ?? 'isr'),
     cacheControl:
@@ -1097,6 +1114,12 @@ function normalizeRuntimeOptions(
       ((options) => blockingIsrCacheControl(options.revalidateSeconds)),
     observability: input.observability ?? null,
   };
+}
+
+function normalizeVaryCookies(varyCookies: readonly string[]): readonly string[] {
+  return [...new Set(varyCookies.map((name) => String(name).trim()))].filter(
+    (name) => name.length > 0,
+  );
 }
 
 function assertPartitionedTenantBoundary(

--- a/ts/src/router.ts
+++ b/ts/src/router.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from './types.js';
+import { normalizePath, type TrailingSlashPolicy } from './types.js';
 
 export interface RouteMatch {
   pattern: string;
@@ -9,6 +9,50 @@ export interface RouteMatch {
 interface CompiledRoute {
   pattern: string;
   segments: string[];
+}
+
+export interface RouterOptions {
+  trailingSlash?: TrailingSlashPolicy;
+}
+
+export function normalizeTrailingSlashPolicy(
+  value: TrailingSlashPolicy | undefined,
+): TrailingSlashPolicy {
+  if (value === undefined) return 'strict';
+  if (value === 'strict' || value === 'redirect' || value === 'normalize') {
+    return value;
+  }
+  throw new Error(
+    'trailingSlash must be one of strict, redirect, or normalize',
+  );
+}
+
+export function stripNonRootTrailingSlashes(path: string): string {
+  const normalized = normalizePath(path);
+  if (normalized === '/') return normalized;
+  let end = normalized.length;
+  while (end > 1 && normalized.charCodeAt(end - 1) === 47) end -= 1;
+  return normalized.slice(0, end);
+}
+
+export function canonicalizePathForTrailingSlashPolicy(
+  path: string,
+  policy: TrailingSlashPolicy,
+): string {
+  const normalized = normalizePath(path);
+  return policy === 'strict'
+    ? normalized
+    : stripNonRootTrailingSlashes(normalized);
+}
+
+export function redirectPathForTrailingSlashPolicy(
+  path: string,
+  policy: TrailingSlashPolicy,
+): string | null {
+  if (policy !== 'redirect') return null;
+  const normalized = normalizePath(path);
+  const canonical = stripNonRootTrailingSlashes(normalized);
+  return canonical === normalized ? null : canonical;
 }
 
 function splitPath(path: string): string[] {
@@ -255,14 +299,35 @@ function matchPath(
 
 export class Router {
   private readonly routes: CompiledRoute[] = [];
+  private readonly trailingSlash: TrailingSlashPolicy;
+
+  constructor(options: RouterOptions = {}) {
+    this.trailingSlash = normalizeTrailingSlashPolicy(options.trailingSlash);
+  }
 
   add(pattern: string): void {
-    const normalized = normalizePath(pattern);
+    const normalized = canonicalizePathForTrailingSlashPolicy(
+      pattern,
+      this.trailingSlash,
+    );
     this.routes.push({ pattern: normalized, segments: splitPath(normalized) });
   }
 
+  redirectPath(path: string): string | null {
+    const redirectPath = redirectPathForTrailingSlashPolicy(
+      path,
+      this.trailingSlash,
+    );
+    if (redirectPath === null) return null;
+    return this.match(redirectPath) ? redirectPath : null;
+  }
+
   match(path: string): RouteMatch | null {
-    const pathSegments = splitPath(path);
+    const pathSegments = splitPath(
+      this.trailingSlash === 'normalize'
+        ? stripNonRootTrailingSlashes(path)
+        : path,
+    );
 
     let best: {
       route: CompiledRoute;

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -97,6 +97,8 @@ export interface FaceResponse {
 
 export type FaceMode = 'ssr' | 'ssg' | 'isr';
 
+export type TrailingSlashPolicy = 'strict' | 'redirect' | 'normalize';
+
 export type FaceContractWarningCode =
   | 'isr.revalidate_seconds_missing'
   | 'ssg.generate_static_params_missing';

--- a/ts/src/types.ts
+++ b/ts/src/types.ts
@@ -97,6 +97,19 @@ export interface FaceResponse {
 
 export type FaceMode = 'ssr' | 'ssg' | 'isr';
 
+export type FaceContractWarningCode =
+  | 'isr.revalidate_seconds_missing'
+  | 'ssg.generate_static_params_missing';
+
+export interface FaceContractWarningLogRecord {
+  level: 'warn';
+  event: 'facetheory.app.contract.warning';
+  warningCode: FaceContractWarningCode;
+  routePattern: string;
+  mode: FaceMode;
+  message: string;
+}
+
 export interface FaceContext {
   request: Readonly<Required<FaceRequest>>;
   params: Readonly<Record<string, string>>;

--- a/ts/test/unit/app.test.ts
+++ b/ts/test/unit/app.test.ts
@@ -8,7 +8,7 @@ import type {
   HtmlStoreWriteInput,
   HtmlStoreWriteResult,
 } from '../../src/isr.js';
-import type { FaceResourceRoute } from '../../src/types.js';
+import type { FaceModule, FaceResourceRoute } from '../../src/types.js';
 import { parseCookiesFromHeaders, parseQueryString } from '../../src/types.js';
 import { viteHydrationForEntry } from '../../src/vite.js';
 
@@ -100,6 +100,106 @@ test('FaceApp: renders HTML with title', async () => {
   const body = decodeBody(resp.body as Uint8Array);
   assert.ok(body.includes('<title>Home</title>'));
   assert.ok(body.includes('<div>hi</div>'));
+});
+
+
+test('FaceApp: validates face contracts at construction', () => {
+  assert.throws(
+    () =>
+      createFaceApp({
+        faces: [
+          {
+            route: '/',
+            mode: 'spa',
+            render: () => ({ html: '<div>unreachable</div>' }),
+          } as unknown as FaceModule,
+        ],
+      }),
+    /invalid face mode for route "\/": expected ssr, ssg, or isr/,
+  );
+
+  assert.throws(
+    () =>
+      createFaceApp({
+        faces: [
+          {
+            route: '   ',
+            mode: 'ssr',
+            render: () => ({ html: '<div>unreachable</div>' }),
+          },
+        ],
+      }),
+    /face route must be a non-empty string/,
+  );
+
+  assert.throws(
+    () =>
+      createFaceApp({
+        faces: [
+          {
+            route: '/missing-render',
+            mode: 'ssr',
+          } as unknown as FaceModule,
+        ],
+      }),
+    /face render for route "\/missing-render" must be a function/,
+  );
+});
+
+test('FaceApp: warns for soft face contract gaps at construction', () => {
+  const records: Array<Record<string, unknown>> = [];
+
+  createFaceApp({
+    faces: [
+      {
+        route: '/news/{slug}',
+        mode: 'ssg',
+        render: () => ({ html: '<div>news</div>' }),
+      },
+      {
+        route: '/preview',
+        mode: 'isr',
+        render: () => ({ html: '<div>preview</div>' }),
+      },
+      {
+        route: '/docs/{slug}',
+        mode: 'ssg',
+        generateStaticParams: async () => [{ slug: 'intro' }],
+        render: () => ({ html: '<div>docs</div>' }),
+      },
+    ],
+    observability: {
+      log: (record) => records.push(record as unknown as Record<string, unknown>),
+    },
+  });
+
+  assert.deepEqual(
+    records.map((record) => ({
+      event: record.event,
+      level: record.level,
+      warningCode: record.warningCode,
+      routePattern: record.routePattern,
+      mode: record.mode,
+    })),
+    [
+      {
+        event: 'facetheory.app.contract.warning',
+        level: 'warn',
+        warningCode: 'ssg.generate_static_params_missing',
+        routePattern: '/news/{slug}',
+        mode: 'ssg',
+      },
+      {
+        event: 'facetheory.app.contract.warning',
+        level: 'warn',
+        warningCode: 'isr.revalidate_seconds_missing',
+        routePattern: '/preview',
+        mode: 'isr',
+      },
+    ],
+  );
+  assert.match(String(records[0]?.message ?? ''), /generateStaticParams/);
+  assert.match(String(records[1]?.message ?? ''), /revalidateSeconds/);
 });
 
 test('FaceApp: propagates x-request-id and injects one when missing', async () => {

--- a/ts/test/unit/app.test.ts
+++ b/ts/test/unit/app.test.ts
@@ -202,6 +202,71 @@ test('FaceApp: warns for soft face contract gaps at construction', () => {
   assert.match(String(records[1]?.message ?? ''), /revalidateSeconds/);
 });
 
+
+test('FaceApp: strict trailing-slash policy preserves current 404 behavior', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/docs',
+        mode: 'ssr',
+        render: () => ({ html: '<main>docs</main>' }),
+      },
+    ],
+  });
+
+  const canonical = await app.handle({ method: 'GET', path: '/docs' });
+  assert.equal(canonical.status, 200);
+
+  const trailing = await app.handle({ method: 'GET', path: '/docs/' });
+  assert.equal(trailing.status, 404);
+});
+
+test('FaceApp: redirect trailing-slash policy returns a 308 canonical URL', async () => {
+  let renderCount = 0;
+  const app = createFaceApp({
+    trailingSlash: 'redirect',
+    faces: [
+      {
+        route: '/docs',
+        mode: 'ssr',
+        render: () => {
+          renderCount += 1;
+          return { html: '<main>docs</main>' };
+        },
+      },
+    ],
+  });
+
+  const trailing = await app.handle({ method: 'GET', path: '/docs/' });
+  assert.equal(trailing.status, 308);
+  assert.equal(trailing.headers.location?.[0], '/docs');
+  assert.equal(renderCount, 0);
+
+  const canonical = await app.handle({ method: 'GET', path: '/docs' });
+  assert.equal(canonical.status, 200);
+  assert.equal(renderCount, 1);
+});
+
+test('FaceApp: normalize trailing-slash policy matches both silently', async () => {
+  const app = createFaceApp({
+    trailingSlash: 'normalize',
+    faces: [
+      {
+        route: '/docs',
+        mode: 'ssr',
+        render: () => ({ html: '<main>docs</main>' }),
+      },
+    ],
+  });
+
+  const canonical = await app.handle({ method: 'GET', path: '/docs' });
+  const trailing = await app.handle({ method: 'GET', path: '/docs/' });
+
+  assert.equal(canonical.status, 200);
+  assert.equal(trailing.status, 200);
+  assert.ok(decodeBody(trailing.body as Uint8Array).includes('<main>docs</main>'));
+});
+
 test('FaceApp: propagates x-request-id and injects one when missing', async () => {
   let seen: string | null = null;
   const app = createFaceApp({

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -624,6 +624,64 @@ test('isr: default cache key partitions by auth headers and cookies without raw 
   assert.equal(serializedKeys.includes('session'), false);
 });
 
+test('isr: varyCookies allowlist scopes request variant cookie partitioning', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/account',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: async () => {
+          const seq = ++renderCount;
+          return { html: `<main>account-${seq}</main>` };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      varyCookies: ['session'],
+    },
+  });
+
+  const sessionA = await app.handle({
+    method: 'GET',
+    path: '/account',
+    headers: { cookie: ['session=COOKIE_SECRET_A; theme=light'] },
+  });
+  const sessionAThemeChanged = await app.handle({
+    method: 'GET',
+    path: '/account',
+    headers: { cookie: ['session=COOKIE_SECRET_A; theme=dark'] },
+  });
+  const sessionB = await app.handle({
+    method: 'GET',
+    path: '/account',
+    headers: { cookie: ['session=COOKIE_SECRET_B; theme=dark'] },
+  });
+
+  assert.ok(decodeBody(sessionA.body as Uint8Array).includes('account-1'));
+  assert.ok(
+    decodeBody(sessionAThemeChanged.body as Uint8Array).includes('account-1'),
+  );
+  assert.ok(decodeBody(sessionB.body as Uint8Array).includes('account-2'));
+  assert.equal(renderCount, 2);
+
+  const serializedKeys = metaStore
+    .debugSnapshot()
+    .map((record) => record.cacheKey)
+    .join('\n');
+  assert.equal(metaStore.debugSnapshot().length, 2);
+  assert.equal(serializedKeys.includes('COOKIE_SECRET_A'), false);
+  assert.equal(serializedKeys.includes('COOKIE_SECRET_B'), false);
+  assert.equal(serializedKeys.includes('session'), false);
+  assert.equal(serializedKeys.includes('theme'), false);
+});
+
 class RecordingMetaStore implements IsrMetaStore {
   private readonly inner: IsrMetaStore;
   readonly commits: CommitIsrGenerationInput[] = [];

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -375,6 +375,60 @@ test('isr: default tenant partition fails closed on tenant boundary headers', as
   );
 });
 
+test('isr: custom tenant boundary headers extend fail-closed defaults', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/tenant-custom/{slug}',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: async (ctx) => {
+          const seq = ++renderCount;
+          const tenant = ctx.request.headers['x-org-id']?.[0] ?? 'missing';
+          return { html: `<main>${tenant}-${seq}</main>` };
+        },
+      },
+    ],
+    isr: {
+      htmlStore,
+      metaStore,
+      tenantBoundaryHeaders: ['x-org-id'],
+    },
+  });
+
+  const customHeader = await app.handle({
+    method: 'GET',
+    path: '/tenant-custom/home',
+    headers: { 'x-org-id': ['TENANT_SECRET_CUSTOM'] },
+  });
+  const defaultHeader = await app.handle({
+    method: 'GET',
+    path: '/tenant-custom/home',
+    headers: { 'x-tenant-id': ['TENANT_SECRET_DEFAULT'] },
+  });
+
+  assert.equal(customHeader.status, 500);
+  assert.equal(defaultHeader.status, 500);
+  assert.equal(renderCount, 0);
+  assert.deepEqual(metaStore.debugSnapshot(), []);
+  assert.equal(
+    decodeBody(customHeader.body as Uint8Array).includes(
+      'TENANT_SECRET_CUSTOM',
+    ),
+    false,
+  );
+  assert.equal(
+    decodeBody(defaultHeader.body as Uint8Array).includes(
+      'TENANT_SECRET_DEFAULT',
+    ),
+    false,
+  );
+});
+
 for (const variant of [
   {
     label: 'null tenantKey',

--- a/ts/test/unit/router.test.ts
+++ b/ts/test/unit/router.test.ts
@@ -58,3 +58,32 @@ test('router: {name*} matches empty', () => {
   assert.equal(m?.pattern, '/{rest*}');
   assert.equal(m?.proxy, undefined);
 });
+
+
+test('router: strict trailing-slash policy preserves exact matching', () => {
+  const r = new Router();
+  r.add('/docs');
+
+  assert.equal(r.match('/docs')?.pattern, '/docs');
+  assert.equal(r.match('/docs/'), null);
+  assert.equal(r.redirectPath('/docs/'), null);
+});
+
+test('router: redirect trailing-slash policy exposes canonical redirect paths', () => {
+  const r = new Router({ trailingSlash: 'redirect' });
+  r.add('/docs');
+
+  assert.equal(r.match('/docs')?.pattern, '/docs');
+  assert.equal(r.match('/docs/'), null);
+  assert.equal(r.redirectPath('/docs/'), '/docs');
+  assert.equal(r.redirectPath('/missing/'), null);
+});
+
+test('router: normalize trailing-slash policy matches both silently', () => {
+  const r = new Router({ trailingSlash: 'normalize' });
+  r.add('/docs');
+
+  assert.equal(r.match('/docs')?.pattern, '/docs');
+  assert.equal(r.match('/docs/')?.pattern, '/docs');
+  assert.equal(r.redirectPath('/docs/'), null);
+});


### PR DESCRIPTION
## Milestone
M3 contract-guards — strengthen construction/router/ISR safety contracts without weakening existing defaults.

## Linear
- THE-2464 — Validate face mode and contract at construction
- THE-2465 — Configurable trailing-slash policy
- THE-2466 — Add a cookie allowlist to the ISR request-variant key
- THE-2467 — Make the ISR tenant-boundary guard header list configurable

## Render modes and adapters affected
- Render modes: ISR plus app/router construction paths shared by SSR/SSG/ISR.
- Adapters: core only; no React/Vue/Svelte adapter-specific behavior changed.

## Determinism impact
Preserves deterministic cache-key and fail-closed behavior. `varyCookies` is additive and absent-by-default all-cookies fail-safe remains. Custom tenant-boundary headers extend the default fail-closed list; defaults remain active.

## Backward compatibility
Additive / warning-only. Contract gap warnings from THE-2464 remain warnings until the later planned breaking escalation.

## Tasks
- [x] THE-2464 — Validate face mode and contract at construction
- [x] THE-2465 — Configurable trailing-slash policy
- [x] THE-2466 — Add a cookie allowlist to the ISR request-variant key
- [x] THE-2467 — Make the ISR tenant-boundary guard header list configurable

## Validation
- [x] `cd ts && npm run check` — PASS (lint, typecheck, unit suite; 608 tests, 607 pass, 1 skipped)
- [x] `scripts/verify-version-alignment.sh` — PASS (3.8.1)
- [x] `git log --show-signature origin/theorymcp/theorycloud/facetheory/product-strengthening-plans-2026-07-02..HEAD` — all four branch commits have good git signatures

## Cross-repo coordination
None. No TableTheory/AppTheory schema or runtime changes required.