### PR TITLE
feat(core): share adapter render pipeline

### DIFF
--- a/ts/src/adapter-pipeline.ts
+++ b/ts/src/adapter-pipeline.ts
@@ -1,0 +1,178 @@
+import { prepareUIIntegrations } from './types.js';
+import type {
+  FaceContext,
+  FaceCspPolicy,
+  FaceHead,
+  FaceHeadTag,
+  FaceHydration,
+  FaceMode,
+  FaceRenderResult,
+  FaceResponseHeaders,
+  FaceStyleTag,
+  PreparedUIIntegration,
+  UIIntegration,
+} from './types.js';
+
+export interface AdapterFaceRenderOptions {
+  status?: number;
+  headers?: FaceResponseHeaders;
+  cookies?: string[];
+  head?: FaceHead;
+  headTags?: FaceHeadTag[];
+  styleTags?: FaceStyleTag[];
+  hydration?: FaceHydration;
+  csp?: FaceCspPolicy;
+}
+
+export interface AssembleFaceRenderResultInput {
+  html: FaceRenderResult['html'];
+  options?: AdapterFaceRenderOptions;
+  integrationHeadTags?: readonly FaceHeadTag[];
+  integrationStyleTags?: readonly FaceStyleTag[];
+  adapterHeadTags?: readonly FaceHeadTag[];
+  adapterStyleTags?: readonly FaceStyleTag[];
+}
+
+export interface AdapterRenderTreeOutput {
+  html: FaceRenderResult['html'];
+  headTags?: readonly FaceHeadTag[];
+  styleTags?: readonly FaceStyleTag[];
+}
+
+export type AdapterRenderTreeResult =
+  | FaceRenderResult['html']
+  | AdapterRenderTreeOutput;
+
+export interface AdapterRenderPipelineContext<
+  TTree,
+  TIntegration extends UIIntegration<TTree>,
+> {
+  ctx: FaceContext;
+  preparedIntegrations: ReadonlyArray<
+    PreparedUIIntegration<TTree, TIntegration>
+  >;
+}
+
+export interface AdapterRenderPipelineInput<
+  TTree,
+  TIntegration extends UIIntegration<TTree> = UIIntegration<TTree>,
+> {
+  ctx: FaceContext;
+  tree: TTree;
+  options?: AdapterFaceRenderOptions;
+  integrations?: ReadonlyArray<TIntegration>;
+  renderTree: (
+    tree: TTree,
+    context: AdapterRenderPipelineContext<TTree, TIntegration>,
+  ) => AdapterRenderTreeResult | Promise<AdapterRenderTreeResult>;
+  enforceStrictCsp?: (
+    out: FaceRenderResult,
+    context: AdapterRenderPipelineContext<TTree, TIntegration>,
+  ) => void | Promise<void>;
+}
+
+export function modeUsesRuntimeHydrationSidecars(mode: FaceMode): boolean {
+  return mode === 'ssr' || mode === 'isr' || mode === 'ssg';
+}
+
+export function assembleFaceRenderResult(
+  input: AssembleFaceRenderResultInput,
+): FaceRenderResult {
+  const options = input.options ?? {};
+  const headTags = [
+    ...(input.integrationHeadTags ?? []),
+    ...(options.headTags ?? []),
+    ...(input.adapterHeadTags ?? []),
+  ];
+  const styleTags = [
+    ...(input.integrationStyleTags ?? []),
+    ...(options.styleTags ?? []),
+    ...(input.adapterStyleTags ?? []),
+  ];
+
+  const out: FaceRenderResult = { html: input.html };
+  if (options.status !== undefined) out.status = options.status;
+  if (options.headers !== undefined) out.headers = options.headers;
+  if (options.cookies !== undefined) out.cookies = options.cookies;
+  if (options.head !== undefined) out.head = options.head;
+  if (headTags.length) out.headTags = headTags;
+  if (styleTags.length) out.styleTags = styleTags;
+  if (options.hydration !== undefined) out.hydration = options.hydration;
+  if (options.csp !== undefined) out.csp = options.csp;
+  return out;
+}
+
+export async function runAdapterRenderPipeline<
+  TTree,
+  TIntegration extends UIIntegration<TTree> = UIIntegration<TTree>,
+>(
+  input: AdapterRenderPipelineInput<TTree, TIntegration>,
+): Promise<FaceRenderResult> {
+  const preparedIntegrations = await prepareUIIntegrations<
+    TTree,
+    TIntegration
+  >(input.integrations ?? [], input.ctx);
+  const context: AdapterRenderPipelineContext<TTree, TIntegration> = {
+    ctx: input.ctx,
+    preparedIntegrations,
+  };
+
+  let tree = input.tree;
+  for (const { integration, state } of preparedIntegrations) {
+    if (!integration.wrapTree) continue;
+    tree = integration.wrapTree(tree, input.ctx, state);
+  }
+
+  const rendered = normalizeRenderTreeOutput(
+    await input.renderTree(tree, context),
+  );
+
+  const integrationHeadTags: FaceHeadTag[] = [];
+  const integrationStyleTags: FaceStyleTag[] = [];
+  for (const { integration, state } of preparedIntegrations) {
+    if (!integration.contribute) continue;
+    const contribution = await integration.contribute(input.ctx, state);
+    if (contribution.headTags)
+      integrationHeadTags.push(...contribution.headTags);
+    if (contribution.styleTags)
+      integrationStyleTags.push(...contribution.styleTags);
+  }
+
+  const assembleInput: AssembleFaceRenderResultInput = {
+    html: rendered.html,
+    integrationHeadTags,
+    integrationStyleTags,
+  };
+  if (input.options !== undefined) assembleInput.options = input.options;
+  if (rendered.headTags !== undefined)
+    assembleInput.adapterHeadTags = rendered.headTags;
+  if (rendered.styleTags !== undefined)
+    assembleInput.adapterStyleTags = rendered.styleTags;
+
+  let out = assembleFaceRenderResult(assembleInput);
+
+  for (const { integration, state } of preparedIntegrations) {
+    if (!integration.finalize) continue;
+    out = await integration.finalize(out, input.ctx, state);
+  }
+
+  await input.enforceStrictCsp?.(out, context);
+  return out;
+}
+
+function normalizeRenderTreeOutput(
+  rendered: AdapterRenderTreeResult,
+): AdapterRenderTreeOutput {
+  if (typeof rendered === 'string' || isAsyncIterable(rendered)) {
+    return { html: rendered };
+  }
+  return rendered;
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<Uint8Array> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Symbol.asyncIterator in value
+  );
+}

--- a/ts/src/adapters/react.ts
+++ b/ts/src/adapters/react.ts
@@ -7,7 +7,10 @@ import {
   enforceAdapterStrictCspResult,
   enforceReactStrictCspStreamingOptions,
 } from '../adapter-csp.js';
-import { prepareUIIntegrations } from '../types.js';
+import {
+  modeUsesRuntimeHydrationSidecars,
+  runAdapterRenderPipeline,
+} from '../adapter-pipeline.js';
 import type {
   FaceContext,
   FaceCspPolicy,
@@ -84,62 +87,23 @@ async function renderReactInternal(
   options: RenderReactOptions,
   validationOptions: ReactRenderValidationOptions = {},
 ): Promise<FaceRenderResult> {
-  const integrations = await prepareUIIntegrations<
+  return runAdapterRenderPipeline<
     React.ReactElement,
     UIIntegration<React.ReactElement>
-  >(options.integrations ?? [], ctx);
-
-  let tree: React.ReactElement = React.createElement(
-    React.Fragment,
-    null,
-    node,
-  );
-
-  for (const { integration, state } of integrations) {
-    if (integration.wrapTree) {
-      tree = integration.wrapTree(tree, ctx, state);
-    }
-  }
-
-  const integrationHeadTags: FaceHeadTag[] = [];
-  const integrationStyleTags: FaceStyleTag[] = [];
-
-  for (const { integration, state } of integrations) {
-    if (!integration.contribute) continue;
-    const contribution = await integration.contribute(ctx, state);
-    if (contribution.headTags)
-      integrationHeadTags.push(...contribution.headTags);
-    if (contribution.styleTags)
-      integrationStyleTags.push(...contribution.styleTags);
-  }
-
-  const html = ReactDOMServer.renderToString(tree);
-  const headTags = [...integrationHeadTags, ...(options.headTags ?? [])];
-  const styleTags = [...integrationStyleTags, ...(options.styleTags ?? [])];
-
-  let out: FaceRenderResult = { html };
-  if (options.status !== undefined) out.status = options.status;
-  if (options.headers !== undefined) out.headers = options.headers;
-  if (options.cookies !== undefined) out.cookies = options.cookies;
-  if (options.head !== undefined) out.head = options.head;
-  if (headTags.length) out.headTags = headTags;
-  if (styleTags.length) out.styleTags = styleTags;
-  if (options.hydration !== undefined) out.hydration = options.hydration;
-  if (options.csp !== undefined) out.csp = options.csp;
-
-  for (const { integration, state } of integrations) {
-    if (integration.finalize) {
-      out = await integration.finalize(out, ctx, state);
-    }
-  }
-
-  enforceAdapterStrictCspResult(out, {
-    adapterName: 'React adapter',
-    deferHydrationValidation:
-      validationOptions.deferStrictCspHydrationValidation === true,
+  >({
+    ctx,
+    tree: React.createElement(React.Fragment, null, node),
+    options,
+    integrations: options.integrations ?? [],
+    renderTree: (tree) => ReactDOMServer.renderToString(tree),
+    enforceStrictCsp: (out) => {
+      enforceAdapterStrictCspResult(out, {
+        adapterName: 'React adapter',
+        deferHydrationValidation:
+          validationOptions.deferStrictCspHydrationValidation === true,
+      });
+    },
   });
-
-  return out;
 }
 
 export async function renderReactStream(
@@ -156,185 +120,144 @@ async function renderReactStreamInternal(
   options: RenderReactStreamOptions,
   validationOptions: ReactRenderValidationOptions = {},
 ): Promise<FaceRenderResult> {
-  const integrations = await prepareUIIntegrations<
+  return runAdapterRenderPipeline<
     React.ReactElement,
     UIIntegration<React.ReactElement>
-  >(options.integrations ?? [], ctx);
-
-  let tree: React.ReactElement = React.createElement(
-    React.Fragment,
-    null,
-    node,
-  );
-
-  for (const { integration, state } of integrations) {
-    if (integration.wrapTree) {
-      tree = integration.wrapTree(tree, ctx, state);
-    }
-  }
-
-  const integrationHeadTags: FaceHeadTag[] = [];
-  const integrationStyleTags: FaceStyleTag[] = [];
-
-  for (const { integration, state } of integrations) {
-    if (!integration.contribute) continue;
-    const contribution = await integration.contribute(ctx, state);
-    if (contribution.headTags)
-      integrationHeadTags.push(...contribution.headTags);
-    if (contribution.styleTags)
-      integrationStyleTags.push(...contribution.styleTags);
-  }
-
-  const headTags = [...integrationHeadTags, ...(options.headTags ?? [])];
-  const styleTags = [...integrationStyleTags, ...(options.styleTags ?? [])];
-
-  const stream = new PassThrough();
-  const abortDelayMs = options.abortDelayMs ?? 5000;
-  const styleStrategy = options.styleStrategy ?? 'all-ready';
-  enforceReactStrictCspStreamingOptions({
-    adapterName: 'React adapter',
-    policy: options.csp,
-    styleStrategy,
-    hasFinalizeInlineStyleIntegration: integrations.some(
-      ({ integration }) => typeof integration.finalize === 'function',
-    ),
-  });
-  const startedAt = Date.now();
-  const requestId =
-    String(ctx.request.headers['x-request-id']?.[0] ?? '').trim() || null;
-
-  let didPipe = false;
-  let shellSettled = false;
-  let allReadySettled = false;
-
-  let resolveShell: (() => void) | null = null;
-  let rejectShell: ((err: unknown) => void) | null = null;
-  let resolveAllReady: (() => void) | null = null;
-  let rejectAllReady: ((err: unknown) => void) | null = null;
-
-  const shellReady = new Promise<void>((resolve, reject) => {
-    resolveShell = resolve;
-    rejectShell = reject;
-  });
-  const allReady = new Promise<void>((resolve, reject) => {
-    resolveAllReady = resolve;
-    rejectAllReady = reject;
-  });
-
-  if (styleStrategy === 'shell') {
-    void allReady.catch(() => undefined);
-  }
-
-  const settleShellReady = (): void => {
-    if (shellSettled) return;
-    shellSettled = true;
-    resolveShell?.();
-  };
-
-  const settleAllReady = (): void => {
-    if (allReadySettled) return;
-    allReadySettled = true;
-    resolveAllReady?.();
-  };
-
-  const rejectReadiness = (err: unknown): void => {
-    if (!shellSettled) {
-      shellSettled = true;
-      rejectShell?.(err);
-    }
-    if (!allReadySettled) {
-      allReadySettled = true;
-      rejectAllReady?.(err);
-    }
-  };
-
-  const pipeOnce = (pipe: (dest: NodeJS.WritableStream) => void): void => {
-    if (didPipe) return;
-    didPipe = true;
-    pipe(stream);
-  };
-
-  const { pipe, abort } = ReactDOMServer.renderToPipeableStream(tree, {
-    ...(ctx.request.cspNonce ? { nonce: ctx.request.cspNonce } : {}),
-    onShellReady: () => {
-      settleShellReady();
-      options.onReadiness?.({
-        phase: 'shell',
+  >({
+    ctx,
+    tree: React.createElement(React.Fragment, null, node),
+    options,
+    integrations: options.integrations ?? [],
+    renderTree: async (tree, pipelineContext) => {
+      const stream = new PassThrough();
+      const abortDelayMs = options.abortDelayMs ?? 5000;
+      const styleStrategy = options.styleStrategy ?? 'all-ready';
+      enforceReactStrictCspStreamingOptions({
+        adapterName: 'React adapter',
+        policy: options.csp,
         styleStrategy,
-        requestId,
-        ms: Math.max(0, Date.now() - startedAt),
+        hasFinalizeInlineStyleIntegration:
+          pipelineContext.preparedIntegrations.some(
+            ({ integration }) => typeof integration.finalize === 'function',
+          ),
       });
+      const startedAt = Date.now();
+      const requestId =
+        String(ctx.request.headers['x-request-id']?.[0] ?? '').trim() || null;
+
+      let didPipe = false;
+      let shellSettled = false;
+      let allReadySettled = false;
+
+      let resolveShell: (() => void) | null = null;
+      let rejectShell: ((err: unknown) => void) | null = null;
+      let resolveAllReady: (() => void) | null = null;
+      let rejectAllReady: ((err: unknown) => void) | null = null;
+
+      const shellReady = new Promise<void>((resolve, reject) => {
+        resolveShell = resolve;
+        rejectShell = reject;
+      });
+      const allReady = new Promise<void>((resolve, reject) => {
+        resolveAllReady = resolve;
+        rejectAllReady = reject;
+      });
+
       if (styleStrategy === 'shell') {
-        pipeOnce(pipe);
+        void allReady.catch(() => undefined);
       }
-    },
-    onAllReady: () => {
-      settleAllReady();
-      options.onReadiness?.({
-        phase: 'all-ready',
-        styleStrategy,
-        requestId,
-        ms: Math.max(0, Date.now() - startedAt),
+
+      const settleShellReady = (): void => {
+        if (shellSettled) return;
+        shellSettled = true;
+        resolveShell?.();
+      };
+
+      const settleAllReady = (): void => {
+        if (allReadySettled) return;
+        allReadySettled = true;
+        resolveAllReady?.();
+      };
+
+      const rejectReadiness = (err: unknown): void => {
+        if (!shellSettled) {
+          shellSettled = true;
+          rejectShell?.(err);
+        }
+        if (!allReadySettled) {
+          allReadySettled = true;
+          rejectAllReady?.(err);
+        }
+      };
+
+      const pipeOnce = (pipe: (dest: NodeJS.WritableStream) => void): void => {
+        if (didPipe) return;
+        didPipe = true;
+        pipe(stream);
+      };
+
+      const { pipe, abort } = ReactDOMServer.renderToPipeableStream(tree, {
+        ...(ctx.request.cspNonce ? { nonce: ctx.request.cspNonce } : {}),
+        onShellReady: () => {
+          settleShellReady();
+          options.onReadiness?.({
+            phase: 'shell',
+            styleStrategy,
+            requestId,
+            ms: Math.max(0, Date.now() - startedAt),
+          });
+          if (styleStrategy === 'shell') {
+            pipeOnce(pipe);
+          }
+        },
+        onAllReady: () => {
+          settleAllReady();
+          options.onReadiness?.({
+            phase: 'all-ready',
+            styleStrategy,
+            requestId,
+            ms: Math.max(0, Date.now() - startedAt),
+          });
+          if (styleStrategy === 'all-ready') {
+            pipeOnce(pipe);
+          }
+        },
+        onShellError: (err) => {
+          rejectReadiness(err);
+          stream.destroy(err as Error);
+        },
+        onError: (err) => {
+          // Preserve React's default error reporting; surface the error if the stream is consumed.
+          if (!stream.destroyed) {
+            stream.destroy(err as Error);
+          }
+          rejectReadiness(err);
+        },
       });
+
+      const abortTimer = setTimeout(() => abort(), abortDelayMs);
+      abortTimer.unref?.();
+      stream.on('close', () => clearTimeout(abortTimer));
+      stream.on('end', () => clearTimeout(abortTimer));
+      stream.on('error', () => clearTimeout(abortTimer));
+
+      // Ensure integrations can extract critical styles before FaceApp emits <head>.
       if (styleStrategy === 'all-ready') {
-        pipeOnce(pipe);
+        await allReady;
+      } else {
+        await shellReady;
       }
+
+      return stream as unknown as AsyncIterable<Uint8Array>;
     },
-    onShellError: (err) => {
-      rejectReadiness(err);
-      stream.destroy(err as Error);
-    },
-    onError: (err) => {
-      // Preserve React's default error reporting; surface the error if the stream is consumed.
-      if (!stream.destroyed) {
-        stream.destroy(err as Error);
-      }
-      rejectReadiness(err);
+    enforceStrictCsp: (out) => {
+      enforceAdapterStrictCspResult(out, {
+        adapterName: 'React adapter',
+        deferHydrationValidation:
+          validationOptions.deferStrictCspHydrationValidation === true,
+      });
     },
   });
-
-  const abortTimer = setTimeout(() => abort(), abortDelayMs);
-  abortTimer.unref?.();
-  stream.on('close', () => clearTimeout(abortTimer));
-  stream.on('end', () => clearTimeout(abortTimer));
-  stream.on('error', () => clearTimeout(abortTimer));
-
-  // Ensure integrations can extract critical styles before FaceApp emits <head>.
-  if (styleStrategy === 'all-ready') {
-    await allReady;
-  } else {
-    await shellReady;
-  }
-
-  let out: FaceRenderResult = {
-    html: stream as unknown as AsyncIterable<Uint8Array>,
-  };
-  if (options.status !== undefined) out.status = options.status;
-  if (options.headers !== undefined) out.headers = options.headers;
-  if (options.cookies !== undefined) out.cookies = options.cookies;
-  if (options.head !== undefined) out.head = options.head;
-  if (headTags.length) out.headTags = headTags;
-  if (styleTags.length) out.styleTags = styleTags;
-  if (options.hydration !== undefined) out.hydration = options.hydration;
-  if (options.csp !== undefined) out.csp = options.csp;
-
-  for (const { integration, state } of integrations) {
-    if (integration.finalize) {
-      out = await integration.finalize(out, ctx, state);
-    }
-  }
-
-  enforceAdapterStrictCspResult(out, {
-    adapterName: 'React adapter',
-    deferHydrationValidation:
-      validationOptions.deferStrictCspHydrationValidation === true,
-  });
-
-  return out;
-}
-
-function modeUsesRuntimeHydrationSidecars(mode: FaceMode): boolean {
-  return mode === 'ssr' || mode === 'isr' || mode === 'ssg';
 }
 
 export interface ReactFaceOptions<Data = unknown> {

--- a/ts/src/control-plane.ts
+++ b/ts/src/control-plane.ts
@@ -1,10 +1,7 @@
 import { utf8 } from './bytes.js';
 import { createFaceApp, type FaceApp, type FaceAppOptions } from './app.js';
-import {
-  DEFAULT_NAVIGATION_PENDING_INDICATOR_ID,
-  NAVIGATION_PENDING_ATTRIBUTE,
-  NAVIGATION_PENDING_INDICATOR_ATTRIBUTE,
-} from './navigation-pending.js';
+import { escapeHTML } from './html.js';
+import { NAVIGATION_PENDING_BOOTSTRAP_SOURCE } from './navigation-pending.js';
 import {
   RESPONSIVE_PRIMITIVES_CSS,
   RESPONSIVE_PRIMITIVES_CLASS_PREFIX,
@@ -497,12 +494,12 @@ function renderDefaultControlPlaneShell(
 
 function renderSectionFrame(section: ControlPlaneSectionRenderInfo): string {
   const title = section.title
-    ? `<h2 class="facetheory-control-plane-section__title">${escapeHtml(section.title)}</h2>`
+    ? `<h2 class="facetheory-control-plane-section__title">${escapeHTML(section.title)}</h2>`
     : '';
   const srcAttr = section.src
-    ? ` data-facetheory-section-src="${escapeHtml(section.src)}"`
+    ? ` data-facetheory-section-src="${escapeHTML(section.src)}"`
     : '';
-  return `<section class="facetheory-control-plane-section" data-facetheory-control-section="${escapeHtml(section.id)}" data-state="loading"${srcAttr}>${title}<div class="facetheory-control-plane-section__body">${section.loadingHtml}</div></section>`;
+  return `<section class="facetheory-control-plane-section" data-facetheory-control-section="${escapeHTML(section.id)}" data-state="loading"${srcAttr}>${title}<div class="facetheory-control-plane-section__body">${section.loadingHtml}</div></section>`;
 }
 
 async function* streamControlPlaneSections(
@@ -526,7 +523,7 @@ async function* streamControlPlaneSections(
       observability,
     );
     yield utf8(
-      `<section class="facetheory-control-plane-section facetheory-control-plane-section--streamed" data-facetheory-control-streamed-section="${escapeHtml(section.id)}" data-state="success"><div class="facetheory-control-plane-section__body">${html}</div></section>`,
+      `<section class="facetheory-control-plane-section facetheory-control-plane-section--streamed" data-facetheory-control-streamed-section="${escapeHTML(section.id)}" data-state="success"><div class="facetheory-control-plane-section__body">${html}</div></section>`,
     );
   }
 }
@@ -659,7 +656,7 @@ function deniedControlPlaneResult(
     },
     head: { title },
     headTags: [controlPlaneStylesheetHeadTag()],
-    html: `<main data-facetheory-control-plane-gate="denied"><h1>${escapeHtml(title)}</h1><p>${escapeHtml(message)}</p></main>`,
+    html: `<main data-facetheory-control-plane-gate="denied"><h1>${escapeHTML(title)}</h1><p>${escapeHTML(message)}</p></main>`,
   };
   if (gate.cookies !== undefined) result.cookies = gate.cookies;
   if (cspMode === 'strict') {
@@ -710,14 +707,14 @@ function sectionEndpointForRequest(endpoint: string, ctx: FaceContext): string {
 
 function defaultSectionLoadingHtml(section: ControlPlaneDataSection): string {
   const label = section.title ? `${section.title} loading` : 'Loading';
-  return `<div class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-async-boundary" data-state="loading"><div class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-loading-state" role="status" aria-live="polite" aria-busy="true"><div class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-loading-state__content"><span class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-spinner ${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-spinner--sm ${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-spinner--primary" role="status" aria-label="${escapeHtml(label)}"><svg class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-spinner__glyph" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg><span class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-visually-hidden">${escapeHtml(label)}</span></span><p class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-loading-state__message">Loading…</p></div></div></div>`;
+  return `<div class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-async-boundary" data-state="loading"><div class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-loading-state" role="status" aria-live="polite" aria-busy="true"><div class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-loading-state__content"><span class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-spinner ${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-spinner--sm ${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-spinner--primary" role="status" aria-label="${escapeHTML(label)}"><svg class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-spinner__glyph" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg><span class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-visually-hidden">${escapeHTML(label)}</span></span><p class="${RESPONSIVE_PRIMITIVES_CLASS_PREFIX}-loading-state__message">Loading…</p></div></div></div>`;
 }
 
 function defaultSectionErrorHtml<Data>(
   section: ControlPlaneDataSection<Data>,
 ): string {
   const title = section.title ?? section.id;
-  return `<div class="facetheory-control-plane-section__error" role="alert">${escapeHtml(title)} failed to load.</div>`;
+  return `<div class="facetheory-control-plane-section__error" role="alert">${escapeHTML(title)} failed to load.</div>`;
 }
 
 function slugForRoute(route: string, index: number): string {
@@ -763,14 +760,6 @@ function sortHeaderValues(
   return sorted;
 }
 
-function escapeHtml(value: string): string {
-  return String(value)
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
 
 export const CONTROL_PLANE_STYLESHEET = `${RESPONSIVE_PRIMITIVES_CSS}
 .facetheory-control-plane-section {
@@ -822,15 +811,7 @@ export const CONTROL_PLANE_STYLESHEET = `${RESPONSIVE_PRIMITIVES_CSS}
 }
 `;
 
-export const CONTROL_PLANE_BOOTSTRAP_MODULE = `const NAV_ATTR=${JSON.stringify(NAVIGATION_PENDING_ATTRIBUTE)};
-const INDICATOR_ATTR=${JSON.stringify(NAVIGATION_PENDING_INDICATOR_ATTRIBUTE)};
-const DEFAULT_INDICATOR_ID=${JSON.stringify(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID)};
-function sameOriginUrl(href){try{const url=new URL(href,window.location.href);return url.origin===window.location.origin?url:null;}catch{return null;}}
-function acceptedAnchor(event){if(event.defaultPrevented||event.button!==0||event.metaKey||event.altKey||event.ctrlKey||event.shiftKey)return null;const target=event.target instanceof Element?event.target.closest('a[href]'):null;if(!(target instanceof HTMLAnchorElement))return null;if(target.target&&target.target.toLowerCase()!=='_self')return null;if(target.hasAttribute('download')||target.hasAttribute('data-facetheory-reload'))return null;const rel=(target.getAttribute('rel')||'').toLowerCase().split(/\\s+/);if(rel.includes('external'))return null;const url=sameOriginUrl(target.href);if(!url||url.href===window.location.href)return null;return target;}
-function isIndicator(el){return el instanceof HTMLElement&&el.getAttribute(INDICATOR_ATTR)==='true';}
-function indicatorElement(id){const existing=document.getElementById(id);if(isIndicator(existing))return existing;if(!existing){const el=document.createElement('div');el.id=id;return el;}for(let i=1;i<1000;i+=1){const candidate=id+'-'+String(i);const next=document.getElementById(candidate);if(isIndicator(next))return next;if(!next){const el=document.createElement('div');el.id=candidate;console.warn('FaceTheory navigation pending indicator id "'+id+'" already belongs to a non-indicator element; using "'+candidate+'" instead.');return el;}}throw new Error('FaceTheory navigation pending could not allocate indicator id');}
-function showPending(source,targets){for(const target of targets){target.setAttribute(NAV_ATTR,source);target.setAttribute('aria-busy','true');target.classList.add('facetheory-navigation-pending-control');}const el=indicatorElement(DEFAULT_INDICATOR_ID);el.textContent='Loading…';el.setAttribute('role','status');el.setAttribute('aria-live','polite');el.setAttribute('aria-atomic','true');el.setAttribute(NAV_ATTR,source);el.setAttribute(INDICATOR_ATTR,'true');el.classList.add('facetheory-navigation-pending-pill');if(!el.parentNode)(document.body||document.documentElement).appendChild(el);}
-function startNavigationPending(){document.addEventListener('click',event=>{const anchor=acceptedAnchor(event);if(anchor)showPending('link',[anchor]);});document.addEventListener('submit',event=>{const form=event.target instanceof HTMLFormElement?event.target:null;if(!form)return;const targets=[form];if(event.submitter instanceof HTMLElement)targets.push(event.submitter);showPending('form',targets);},true);}
+export const CONTROL_PLANE_BOOTSTRAP_MODULE = `${NAVIGATION_PENDING_BOOTSTRAP_SOURCE}
 async function fillSection(section){const src=section.getAttribute('data-facetheory-section-src');if(!src)return;try{const response=await fetch(src,{credentials:'same-origin',headers:{accept:'text/html'}});if(!response.ok)throw new Error('HTTP '+String(response.status));const html=await response.text();const body=section.querySelector('.facetheory-control-plane-section__body')||section;body.innerHTML=html;section.setAttribute('data-state','success');}catch(error){section.setAttribute('data-state','error');const body=section.querySelector('.facetheory-control-plane-section__body')||section;body.innerHTML='<div class="facetheory-control-plane-section__error" role="alert">Section failed to load.</div>';console.error('FaceTheory control-plane section fill failed',error);}}
 function startClientFill(){for(const section of document.querySelectorAll('[data-facetheory-control-section][data-facetheory-section-src]'))void fillSection(section);}
 export function startControlPlane(){startNavigationPending();startClientFill();}

--- a/ts/src/dom-guards.ts
+++ b/ts/src/dom-guards.ts
@@ -1,0 +1,30 @@
+export function isElement(value: unknown): value is Element {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { tagName?: unknown }).tagName === 'string' &&
+    typeof (value as { setAttribute?: unknown }).setAttribute === 'function' &&
+    typeof (value as { classList?: unknown }).classList === 'object'
+  );
+}
+
+export function isHTMLElement(value: unknown): value is HTMLElement {
+  return (
+    isElement(value) &&
+    typeof (value as { hasAttribute?: unknown }).hasAttribute === 'function'
+  );
+}
+
+export function isElementWithTag(
+  value: unknown,
+  tagName: string,
+): value is Element {
+  return isElement(value) && value.tagName.toLowerCase() === tagName;
+}
+
+export function isHTMLElementWithTag(
+  value: unknown,
+  tagName: string,
+): value is HTMLElement {
+  return isHTMLElement(value) && value.tagName.toLowerCase() === tagName;
+}

--- a/ts/src/head.ts
+++ b/ts/src/head.ts
@@ -1,4 +1,4 @@
-import { escapeHTML, safeJson } from './html.js';
+import { escapeHTML, renderAttributes, safeJson } from './html.js';
 import type {
   FaceAttributes,
   FaceCspPolicy,
@@ -200,25 +200,6 @@ function validateStrictHeadTags(
         break;
     }
   }
-}
-
-function renderAttributes(attrs: FaceAttributes | undefined): string {
-  if (!attrs) return '';
-  const keys = Object.keys(attrs).sort();
-  let out = '';
-
-  for (const key of keys) {
-    const value = attrs[key];
-    if (value === undefined || value === null || value === false) continue;
-    const name = escapeHTML(key);
-    if (value === true) {
-      out += ` ${name}`;
-      continue;
-    }
-    out += ` ${name}="${escapeHTML(String(value))}"`;
-  }
-
-  return out;
 }
 
 function isCharsetMeta(tag: FaceHeadTag): boolean {

--- a/ts/src/html.ts
+++ b/ts/src/html.ts
@@ -10,7 +10,11 @@ export function escapeHTML(value: string): string {
 }
 
 export function safeJson(value: unknown): string {
-  return JSON.stringify(value)
+  return escapeJsonForHtml(JSON.stringify(value));
+}
+
+export function escapeJsonForHtml(serialized: string): string {
+  return serialized
     .replaceAll('<', '\\u003c')
     .replaceAll('>', '\\u003e')
     .replaceAll('&', '\\u0026')
@@ -26,7 +30,7 @@ export interface HTMLDocumentParts {
   body: string;
 }
 
-function renderAttributes(attrs: FaceAttributes | undefined): string {
+export function renderAttributes(attrs: FaceAttributes | undefined): string {
   if (!attrs) return '';
 
   const keys = Object.keys(attrs).sort();

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,4 +1,5 @@
 export * from './app.js';
+export * from './adapter-pipeline.js';
 export * from './bytes.js';
 export * from './control-plane.js';
 export * from './control-plane-guardrails.js';

--- a/ts/src/navigation-pending.ts
+++ b/ts/src/navigation-pending.ts
@@ -2,6 +2,7 @@ import {
   classifyFaceNavigationAnchorClick,
   FACE_NAVIGATION_CLASSIFIER_SOURCE,
 } from './spa.js';
+import { isElement, isElementWithTag } from './dom-guards.js';
 import type { ClassifyFaceNavigationAnchorClickOptions } from './spa.js';
 
 export const NAVIGATION_PENDING_CLASSIFIER_SOURCE =
@@ -15,6 +16,16 @@ export const NAVIGATION_PENDING_INDICATOR_ATTRIBUTE =
 export const DEFAULT_NAVIGATION_PENDING_INDICATOR_ID =
   'facetheory-navigation-pending';
 export const DEFAULT_NAVIGATION_PENDING_TEXT = 'Loading…';
+
+export const NAVIGATION_PENDING_BOOTSTRAP_SOURCE = `const NAV_ATTR=${JSON.stringify(NAVIGATION_PENDING_ATTRIBUTE)};
+const INDICATOR_ATTR=${JSON.stringify(NAVIGATION_PENDING_INDICATOR_ATTRIBUTE)};
+const DEFAULT_INDICATOR_ID=${JSON.stringify(DEFAULT_NAVIGATION_PENDING_INDICATOR_ID)};
+function sameOriginUrl(href){try{const url=new URL(href,window.location.href);return url.origin===window.location.origin?url:null;}catch{return null;}}
+function acceptedAnchor(event){if(event.defaultPrevented||event.button!==0||event.metaKey||event.altKey||event.ctrlKey||event.shiftKey)return null;const target=event.target instanceof Element?event.target.closest('a[href]'):null;if(!(target instanceof HTMLAnchorElement))return null;if(target.target&&target.target.toLowerCase()!=='_self')return null;if(target.hasAttribute('download')||target.hasAttribute('data-facetheory-reload'))return null;const rel=(target.getAttribute('rel')||'').toLowerCase().split(/\\s+/);if(rel.includes('external'))return null;const url=sameOriginUrl(target.href);if(!url||url.href===window.location.href)return null;return target;}
+function isIndicator(el){return el instanceof HTMLElement&&el.getAttribute(INDICATOR_ATTR)==='true';}
+function indicatorElement(id){const existing=document.getElementById(id);if(isIndicator(existing))return existing;if(!existing){const el=document.createElement('div');el.id=id;return el;}for(let i=1;i<1000;i+=1){const candidate=id+'-'+String(i);const next=document.getElementById(candidate);if(isIndicator(next))return next;if(!next){const el=document.createElement('div');el.id=candidate;console.warn('FaceTheory navigation pending indicator id "'+id+'" already belongs to a non-indicator element; using "'+candidate+'" instead.');return el;}}throw new Error('FaceTheory navigation pending could not allocate indicator id');}
+function showPending(source,targets){for(const target of targets){target.setAttribute(NAV_ATTR,source);target.setAttribute('aria-busy','true');target.classList.add('facetheory-navigation-pending-control');}const el=indicatorElement(DEFAULT_INDICATOR_ID);el.textContent='Loading…';el.setAttribute('role','status');el.setAttribute('aria-live','polite');el.setAttribute('aria-atomic','true');el.setAttribute(NAV_ATTR,source);el.setAttribute(INDICATOR_ATTR,'true');el.classList.add('facetheory-navigation-pending-pill');if(!el.parentNode)(document.body||document.documentElement).appendChild(el);}
+function startNavigationPending(){document.addEventListener('click',event=>{const anchor=acceptedAnchor(event);if(anchor)showPending('link',[anchor]);});document.addEventListener('submit',event=>{const form=event.target instanceof HTMLFormElement?event.target:null;if(!form)return;const targets=[form];if(event.submitter instanceof HTMLElement)targets.push(event.submitter);showPending('form',targets);},true);}`;
 
 export interface NavigationPendingClassNames {
   form?: string;
@@ -406,21 +417,4 @@ function readSubmitForm(event: SubmitEvent): HTMLFormElement | null {
 
 function readSubmitter(event: SubmitEvent): HTMLElement | null {
   return isElement(event.submitter) ? (event.submitter as HTMLElement) : null;
-}
-
-function isElement(value: EventTarget | null): value is Element {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { tagName?: unknown }).tagName === 'string' &&
-    typeof (value as { setAttribute?: unknown }).setAttribute === 'function' &&
-    typeof (value as { classList?: unknown }).classList === 'object'
-  );
-}
-
-function isElementWithTag(
-  value: EventTarget | null,
-  tagName: string,
-): value is Element {
-  return isElement(value) && value.tagName.toLowerCase() === tagName;
 }

--- a/ts/src/oac-form.ts
+++ b/ts/src/oac-form.ts
@@ -9,6 +9,7 @@ import {
   type FaceNavigationSnapshot,
   type FaceNavigationBootstrapModule,
 } from './spa.js';
+import { isHTMLElement, isHTMLElementWithTag } from './dom-guards.js';
 
 export const AWS_OAC_CONTENT_SHA256_HEADER = 'x-amz-content-sha256';
 export const AWS_OAC_FORM_MARKER_ATTRIBUTE = 'data-facetheory-oac-form';
@@ -691,7 +692,7 @@ function resolveFetch(
 
 function readSubmitForm(event: SubmitEvent): HTMLFormElement | null {
   const target = event.target;
-  if (isHtmlFormElement(target)) return target;
+  if (isHTMLElementWithTag(target, 'form')) return target as HTMLFormElement;
   return null;
 }
 
@@ -768,19 +769,6 @@ function passesConstraintValidation(
   if (typeof form.reportValidity === 'function') return form.reportValidity();
   if (typeof form.checkValidity === 'function') return form.checkValidity();
   return true;
-}
-
-function isHtmlFormElement(value: unknown): value is HTMLFormElement {
-  return isHTMLElement(value) && value.tagName.toLowerCase() === 'form';
-}
-
-function isHTMLElement(value: unknown): value is HTMLElement {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { tagName?: unknown }).tagName === 'string' &&
-    typeof (value as { hasAttribute?: unknown }).hasAttribute === 'function'
-  );
 }
 
 function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {

--- a/ts/src/resource.ts
+++ b/ts/src/resource.ts
@@ -1,4 +1,5 @@
 import { utf8 } from './bytes.js';
+import { escapeJsonForHtml } from './html.js';
 import type {
   FaceResponse,
   FaceResponseHeaders,
@@ -251,10 +252,5 @@ function safeResourceJson(value: unknown): string {
 
   // Mirrors html.safeJson so resource responses are safe beside HTML delivery
   // contexts such as hydration sidecars and script-adjacent fetch payloads.
-  return serialized
-    .replaceAll('<', '\\u003c')
-    .replaceAll('>', '\\u003e')
-    .replaceAll('&', '\\u0026')
-    .replaceAll('\u2028', '\\u2028')
-    .replaceAll('\u2029', '\\u2029');
+  return escapeJsonForHtml(serialized);
 }

--- a/ts/src/ssr-hydration.ts
+++ b/ts/src/ssr-hydration.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
 import { utf8 } from './bytes.js';
+import { escapeJsonForHtml } from './html.js';
 import type { HtmlStore } from './isr.js';
 import { trimOuterSlashes, trimTrailingSlashes } from './types.js';
 
@@ -169,12 +170,7 @@ export function serializeSsrHydrationSidecarJson(data: unknown): string {
     );
   }
 
-  return serialized
-    .replaceAll('<', '\\u003c')
-    .replaceAll('>', '\\u003e')
-    .replaceAll('&', '\\u0026')
-    .replaceAll('\u2028', '\\u2028')
-    .replaceAll('\u2029', '\\u2029');
+  return escapeJsonForHtml(serialized);
 }
 
 export function buildSsrHydrationSidecarDataUrl(

--- a/ts/src/svelte/index.ts
+++ b/ts/src/svelte/index.ts
@@ -1,5 +1,8 @@
 import { enforceAdapterStrictCspResult } from '../adapter-csp.js';
-import { prepareUIIntegrations } from '../types.js';
+import {
+  modeUsesRuntimeHydrationSidecars,
+  runAdapterRenderPipeline,
+} from '../adapter-pipeline.js';
 import type {
   FaceContext,
   FaceCspPolicy,
@@ -67,96 +70,46 @@ async function renderSvelteInternal<Props extends Record<string, unknown>>(
   options: RenderSvelteOptions,
   validationOptions: SvelteRenderValidationOptions = {},
 ): Promise<FaceRenderResult> {
-  const integrations = await prepareUIIntegrations<
+  return runAdapterRenderPipeline<
     SvelteRenderInput<Props>,
     SvelteUIIntegration<Props>
-  >((options.integrations ?? []) as Array<SvelteUIIntegration<Props>>, ctx);
+  >({
+    ctx,
+    tree: input,
+    options,
+    integrations: (options.integrations ?? []) as Array<
+      SvelteUIIntegration<Props>
+    >,
+    renderTree: async (currentInput) => {
+      const rendered = await renderSvelteInput(currentInput);
+      const headTags: FaceHeadTag[] = [];
+      const styleTags: FaceStyleTag[] = [];
 
-  let currentInput: SvelteRenderInput<Props> = input;
-  for (const { integration, state } of integrations) {
-    if (!integration.wrapTree) continue;
-    currentInput = integration.wrapTree(currentInput, ctx, state);
-  }
+      if (rendered.head) {
+        headTags.push({ type: 'raw', html: rendered.head });
+      }
+      const cssText = rendered.css?.code ?? currentInput.cssText;
+      if (cssText) {
+        styleTags.push({
+          cssText,
+          attrs: { 'data-svelte': 'true' },
+        });
+      }
 
-  const integrationHeadTags: FaceHeadTag[] = [];
-  const integrationStyleTags: FaceStyleTag[] = [];
-  for (const { integration, state } of integrations) {
-    if (!integration.contribute) continue;
-    const contribution = await integration.contribute(ctx, state);
-    if (contribution.headTags)
-      integrationHeadTags.push(...contribution.headTags);
-    if (contribution.styleTags)
-      integrationStyleTags.push(...contribution.styleTags);
-  }
-
-  let rendered: SvelteSSRRenderResult;
-
-  const maybeLegacy = currentInput.component as Partial<
-    SvelteLegacySSRComponent<Props>
-  >;
-  if (typeof maybeLegacy.render === 'function') {
-    try {
-      rendered = maybeLegacy.render(currentInput.props);
-    } catch (err) {
-      if (!isSvelte5DeprecatedRenderError(err)) throw err;
-      rendered = await renderWithSvelteServer(
-        currentInput.component,
-        currentInput.props,
-      );
-    }
-  } else {
-    rendered = await renderWithSvelteServer(
-      currentInput.component,
-      currentInput.props,
-    );
-  }
-
-  const headTags: FaceHeadTag[] = [
-    ...integrationHeadTags,
-    ...(options.headTags ?? []),
-  ];
-  const styleTags: FaceStyleTag[] = [
-    ...integrationStyleTags,
-    ...(options.styleTags ?? []),
-  ];
-
-  if (rendered.head) {
-    headTags.push({ type: 'raw', html: rendered.head });
-  }
-  const cssText = rendered.css?.code ?? currentInput.cssText;
-  if (cssText) {
-    styleTags.push({
-      cssText,
-      attrs: { 'data-svelte': 'true' },
-    });
-  }
-
-  let out: FaceRenderResult = { html: rendered.html };
-  if (options.status !== undefined) out.status = options.status;
-  if (options.headers !== undefined) out.headers = options.headers;
-  if (options.cookies !== undefined) out.cookies = options.cookies;
-  if (options.head !== undefined) out.head = options.head;
-  if (headTags.length) out.headTags = headTags;
-  if (styleTags.length) out.styleTags = styleTags;
-  if (options.hydration !== undefined) out.hydration = options.hydration;
-  if (options.csp !== undefined) out.csp = options.csp;
-
-  for (const { integration, state } of integrations) {
-    if (!integration.finalize) continue;
-    out = await integration.finalize(out, ctx, state);
-  }
-
-  enforceAdapterStrictCspResult(out, {
-    adapterName: 'Svelte adapter',
-    deferHydrationValidation:
-      validationOptions.deferStrictCspHydrationValidation === true,
+      return {
+        html: rendered.html,
+        headTags,
+        styleTags,
+      };
+    },
+    enforceStrictCsp: (out) => {
+      enforceAdapterStrictCspResult(out, {
+        adapterName: 'Svelte adapter',
+        deferHydrationValidation:
+          validationOptions.deferStrictCspHydrationValidation === true,
+      });
+    },
   });
-
-  return out;
-}
-
-function modeUsesRuntimeHydrationSidecars(mode: FaceMode): boolean {
-  return mode === 'ssr' || mode === 'isr' || mode === 'ssg';
 }
 
 function isSvelte5DeprecatedRenderError(err: unknown): boolean {
@@ -164,6 +117,24 @@ function isSvelte5DeprecatedRenderError(err: unknown): boolean {
   return err.message.includes(
     'Component.render(...) is no longer valid in Svelte 5',
   );
+}
+
+async function renderSvelteInput<Props extends Record<string, unknown>>(
+  input: SvelteRenderInput<Props>,
+): Promise<SvelteSSRRenderResult> {
+  const maybeLegacy = input.component as Partial<
+    SvelteLegacySSRComponent<Props>
+  >;
+  if (typeof maybeLegacy.render === 'function') {
+    try {
+      return maybeLegacy.render(input.props);
+    } catch (err) {
+      if (!isSvelte5DeprecatedRenderError(err)) throw err;
+      return renderWithSvelteServer(input.component, input.props);
+    }
+  }
+
+  return renderWithSvelteServer(input.component, input.props);
 }
 
 async function renderWithSvelteServer<Props extends Record<string, unknown>>(

--- a/ts/src/vue/index.ts
+++ b/ts/src/vue/index.ts
@@ -2,7 +2,10 @@ import { createSSRApp, h, type App, type VNode } from 'vue';
 import { renderToString } from '@vue/server-renderer';
 
 import { enforceAdapterStrictCspResult } from '../adapter-csp.js';
-import { prepareUIIntegrations } from '../types.js';
+import {
+  modeUsesRuntimeHydrationSidecars,
+  runAdapterRenderPipeline,
+} from '../adapter-pipeline.js';
 import type {
   FaceContext,
   FaceCspPolicy,
@@ -53,65 +56,27 @@ async function renderVueInternal(
   options: RenderVueOptions,
   validationOptions: VueRenderValidationOptions = {},
 ): Promise<FaceRenderResult> {
-  const integrations = await prepareUIIntegrations<VNode, VueUIIntegration>(
-    options.integrations ?? [],
+  return runAdapterRenderPipeline<VNode, VueUIIntegration>({
     ctx,
-  );
-
-  let tree = vnode;
-  for (const { integration, state } of integrations) {
-    if (!integration.wrapTree) continue;
-    tree = integration.wrapTree(tree, ctx, state);
-  }
-
-  const app = createSSRApp({ render: () => tree });
-  for (const { integration, state } of integrations) {
-    if (!integration.wrapApp) continue;
-    await integration.wrapApp(app, ctx, state);
-  }
-
-  const integrationHeadTags: FaceHeadTag[] = [];
-  const integrationStyleTags: FaceStyleTag[] = [];
-  for (const { integration, state } of integrations) {
-    if (!integration.contribute) continue;
-    const contribution = await integration.contribute(ctx, state);
-    if (contribution.headTags)
-      integrationHeadTags.push(...contribution.headTags);
-    if (contribution.styleTags)
-      integrationStyleTags.push(...contribution.styleTags);
-  }
-
-  const html = await renderToString(app);
-
-  const headTags = [...integrationHeadTags, ...(options.headTags ?? [])];
-  const styleTags = [...integrationStyleTags, ...(options.styleTags ?? [])];
-
-  let out: FaceRenderResult = { html };
-  if (options.status !== undefined) out.status = options.status;
-  if (options.headers !== undefined) out.headers = options.headers;
-  if (options.cookies !== undefined) out.cookies = options.cookies;
-  if (options.head !== undefined) out.head = options.head;
-  if (headTags.length) out.headTags = headTags;
-  if (styleTags.length) out.styleTags = styleTags;
-  if (options.hydration !== undefined) out.hydration = options.hydration;
-  if (options.csp !== undefined) out.csp = options.csp;
-
-  for (const { integration, state } of integrations) {
-    if (!integration.finalize) continue;
-    out = await integration.finalize(out, ctx, state);
-  }
-
-  enforceAdapterStrictCspResult(out, {
-    adapterName: 'Vue adapter',
-    deferHydrationValidation:
-      validationOptions.deferStrictCspHydrationValidation === true,
+    tree: vnode,
+    options,
+    integrations: options.integrations ?? [],
+    renderTree: async (tree, pipelineContext) => {
+      const app = createSSRApp({ render: () => tree });
+      for (const { integration, state } of pipelineContext.preparedIntegrations) {
+        if (!integration.wrapApp) continue;
+        await integration.wrapApp(app, ctx, state);
+      }
+      return renderToString(app);
+    },
+    enforceStrictCsp: (out) => {
+      enforceAdapterStrictCspResult(out, {
+        adapterName: 'Vue adapter',
+        deferHydrationValidation:
+          validationOptions.deferStrictCspHydrationValidation === true,
+      });
+    },
   });
-
-  return out;
-}
-
-function modeUsesRuntimeHydrationSidecars(mode: FaceMode): boolean {
-  return mode === 'ssr' || mode === 'isr' || mode === 'ssg';
 }
 
 export interface VueFaceOptions<Data = unknown> {

--- a/ts/test/unit/adapter-pipeline.test.ts
+++ b/ts/test/unit/adapter-pipeline.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  assembleFaceRenderResult,
+  modeUsesRuntimeHydrationSidecars,
+  runAdapterRenderPipeline,
+} from '../../src/adapter-pipeline.js';
+import type { FaceContext, UIIntegration } from '../../src/types.js';
+
+const ctx: FaceContext = {
+  params: {},
+  proxy: null,
+  request: {
+    body: new Uint8Array(),
+    cookies: {},
+    cspNonce: null,
+    headers: {},
+    isBase64: false,
+    method: 'GET',
+    path: '/',
+    query: {},
+  },
+};
+
+test('adapter pipeline: modeUsesRuntimeHydrationSidecars preserves current modes', () => {
+  assert.equal(modeUsesRuntimeHydrationSidecars('ssr'), true);
+  assert.equal(modeUsesRuntimeHydrationSidecars('ssg'), true);
+  assert.equal(modeUsesRuntimeHydrationSidecars('isr'), true);
+});
+
+test('adapter pipeline: assembleFaceRenderResult preserves deterministic tag order', () => {
+  const out = assembleFaceRenderResult({
+    html: '<main>ok</main>',
+    integrationHeadTags: [{ type: 'meta', attrs: { name: 'integration' } }],
+    integrationStyleTags: [{ cssText: '.integration{}' }],
+    options: {
+      status: 202,
+      headers: { 'x-test': 'yes' },
+      cookies: ['a=b'],
+      head: { title: 'Pipeline' },
+      headTags: [{ type: 'meta', attrs: { name: 'options' } }],
+      styleTags: [{ cssText: '.options{}' }],
+      hydration: { data: { ok: true }, bootstrapModule: '/assets/app.js' },
+      csp: { inlineScripts: false },
+    },
+    adapterHeadTags: [{ type: 'meta', attrs: { name: 'adapter' } }],
+    adapterStyleTags: [{ cssText: '.adapter{}' }],
+  });
+
+  assert.equal(out.status, 202);
+  assert.deepEqual(out.headers, { 'x-test': 'yes' });
+  assert.deepEqual(out.cookies, ['a=b']);
+  assert.deepEqual(
+    out.headTags?.map((tag) => tag.type === 'meta' && tag.attrs.name),
+    ['integration', 'options', 'adapter'],
+  );
+  assert.deepEqual(
+    out.styleTags?.map((tag) => tag.cssText),
+    ['.integration{}', '.options{}', '.adapter{}'],
+  );
+});
+
+test('adapter pipeline: runs prepare, wrap, render, contribute, finalize, enforce in order', async () => {
+  const events: string[] = [];
+  const integration: UIIntegration<string> = {
+    name: 'ordering',
+    createState: () => {
+      events.push('prepare');
+      return { suffix: '!' };
+    },
+    wrapTree: (tree, _ctx, state) => {
+      const suffix = (state as { suffix: string }).suffix;
+      events.push(`wrap:${suffix}`);
+      return `${tree}${suffix}`;
+    },
+    contribute: (_ctx, state) => {
+      const suffix = (state as { suffix: string }).suffix;
+      events.push(`contribute:${suffix}`);
+      return {
+        headTags: [{ type: 'meta', attrs: { name: 'contribute' } }],
+        styleTags: [{ cssText: '.contribute{}' }],
+      };
+    },
+    finalize: (out, _ctx, state) => {
+      const suffix = (state as { suffix: string }).suffix;
+      events.push(`finalize:${suffix}`);
+      return {
+        ...out,
+        headTags: [
+          ...(out.headTags ?? []),
+          { type: 'meta', attrs: { name: 'finalize' } },
+        ],
+      };
+    },
+  };
+
+  const out = await runAdapterRenderPipeline({
+    ctx,
+    tree: 'tree',
+    integrations: [integration],
+    options: {
+      headTags: [{ type: 'meta', attrs: { name: 'options' } }],
+      styleTags: [{ cssText: '.options{}' }],
+    },
+    renderTree: (tree, context) => {
+      events.push(
+        `render:${tree}:${String(context.preparedIntegrations.length)}`,
+      );
+      return {
+        html: `<main>${tree}</main>`,
+        headTags: [{ type: 'meta', attrs: { name: 'adapter' } }],
+        styleTags: [{ cssText: '.adapter{}' }],
+      };
+    },
+    enforceStrictCsp: (result) => {
+      events.push(`enforce:${String(result.headTags?.length ?? 0)}`);
+    },
+  });
+
+  assert.deepEqual(events, [
+    'prepare',
+    'wrap:!',
+    'render:tree!:1',
+    'contribute:!',
+    'finalize:!',
+    'enforce:4',
+  ]);
+  assert.equal(out.html, '<main>tree!</main>');
+  assert.deepEqual(
+    out.headTags?.map((tag) => tag.type === 'meta' && tag.attrs.name),
+    ['contribute', 'options', 'adapter', 'finalize'],
+  );
+});

--- a/ts/test/unit/html.test.ts
+++ b/ts/test/unit/html.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { escapeHTML, renderHTMLDocument, safeJson } from '../../src/html.js';
+import {
+  escapeHTML,
+  renderAttributes,
+  renderHTMLDocument,
+  safeJson,
+} from '../../src/html.js';
 import {
   buildStrictCspHeader,
   validateStrictCspDocument,
@@ -15,6 +20,18 @@ test('safeJson escapes HTML-significant characters', () => {
   const s = safeJson({ a: '<script>&</script>' });
   assert.ok(!s.includes('<script>'));
   assert.ok(s.includes('\\u003c'));
+});
+
+test('renderAttributes sorts, escapes, and omits falsey attrs', () => {
+  assert.equal(
+    renderAttributes({
+      disabled: true,
+      'data-label': 'a&b<c>d"e',
+      hidden: false,
+      title: null,
+    }),
+    ' data-label="a&amp;b&lt;c&gt;d&quot;e" disabled',
+  );
 });
 
 test('renderHTMLDocument emits doctype', () => {


### PR DESCRIPTION
## Summary

Ship M5 `shared-render-pipeline` for the FaceTheory Product Strengthening Program 2026-07. This keeps the adapter behavior byte-identical while moving shared render assembly into a core additive pipeline.

## Milestone scope

- THE-2470: consolidate escaping, attribute rendering, and DOM guard helpers.
- THE-2471: add core adapter pipeline primitives (`modeUsesRuntimeHydrationSidecars`, `assembleFaceRenderResult`, `runAdapterRenderPipeline`).
- THE-2472: route React buffered and streaming rendering through the shared pipeline.
- THE-2473: route Vue rendering through the shared pipeline; no observable output divergence found in existing tests.
- THE-2474: route Svelte rendering through the shared pipeline.

## Determinism / compatibility

- No intentional 3.x consumer break.
- Preserves head/style/hydration ordering through the shared `prepare -> wrap -> renderTree -> contribute -> assemble/finalize -> strict-CSP` sequence.
- No AppTheory, TableTheory, Autheory, cloud, release, or deployment changes.

## Validation

- `cd ts && npm run check` — pass.
- `cd ts && npm run example:streaming:serve` — bounded curl smoke pass.
- `cd ts && npm run example:vite:react:build` / `serve` — scripts are unavailable in `package.json`; used React Vite equivalents `example:vite:ssr:build` and bounded `example:vite:ssr:serve`, both pass.
- `cd ts && npm run example:vite:vue:build` and bounded `example:vite:vue:serve` — pass.
- `cd ts && npm run example:vite:svelte:build` and bounded `example:vite:svelte:serve` — pass; build emits existing Svelte a11y/self-closing warnings.
- `scripts/verify-version-alignment.sh` — pass.
- `git diff --check` — pass.

Closes THE-2470
Closes THE-2471
Closes THE-2472
Closes THE-2473
Closes THE-2474
