### PR TITLE
feat(vue): add streaming SSR parity

### DIFF
--- a/docs/adapters/vue.md
+++ b/docs/adapters/vue.md
@@ -75,6 +75,8 @@ export const app = createFaceApp({
 
 For strict no-inline CSP routes (`inlineScripts:false`, `inlineStyles:false`, or `rawHead:false`), FaceTheory buffers and validates the full streamed document before returning it. That preserves the same strict-CSP nonce, sidecar, and fail-closed behavior as buffered Vue SSR.
 
+When a Vue streaming Face uses an integration with `contribute` or `finalize`, FaceTheory waits for Vue's server renderer to finish before assembling `<head>` and structured style tags. This keeps request-local styles registered by async component trees through `wrapApp` visible to `contribute`, while the response body still uses the `AsyncIterable<Uint8Array>` contract after head/style assembly is complete.
+
 ## Vite integration
 
 For Vue + Vite SSR, use `viteAssetsForEntry` and `viteHydrationForEntry` from the core `vite.ts` module to pipe the dev/build manifest into your render options. The runnable shape is `ts/examples/vite-ssr-vue/src/entry-server.ts`:
@@ -125,7 +127,7 @@ FaceTheory does not ship a Vue-specific runtime CSS-in-JS extractor. If a Vue CS
 
 1. `wrapApp(app, ctx, state)` installs the Vue plugin/provider for the request-local render.
 2. The Vue render records styles into that request-local state.
-3. `contribute(ctx, state)` returns structured `styleTags` (or external stylesheet `headTags`) for FaceTheory to serialize, nonce, order, and validate.
+3. `contribute(ctx, state)` returns structured `styleTags` (or external stylesheet `headTags`) for FaceTheory to serialize, nonce, order, and validate. In streaming mode, FaceTheory waits for async Vue render completion before calling `contribute` when an integration can contribute or finalize, so async setup/render style records are not omitted from the document head.
 
 ```typescript
 import type { App, InjectionKey } from "vue";

--- a/docs/adapters/vue.md
+++ b/docs/adapters/vue.md
@@ -17,23 +17,26 @@ npm install --save-exact \
 `createVueFace.render` returns a Vue **VNode** (or a Promise of one) — not a component definition. Use the re-exported `h` to wrap your component:
 
 ```typescript
-import { createFaceApp, createLambdaUrlStreamingHandler } from '@theory-cloud/facetheory';
-import { createVueFace, h } from '@theory-cloud/facetheory/vue';
+import {
+  createFaceApp,
+  createLambdaUrlStreamingHandler,
+} from "@theory-cloud/facetheory";
+import { createVueFace, h } from "@theory-cloud/facetheory/vue";
 
 const Home = {
   setup() {
-    return () => h('h1', 'FaceTheory + Vue (SSR)');
+    return () => h("h1", "FaceTheory + Vue (SSR)");
   },
 };
 
 export const app = createFaceApp({
   faces: [
     createVueFace({
-      route: '/',
-      mode: 'ssr',
+      route: "/",
+      mode: "ssr",
       render: () => h(Home),
       renderOptions: {
-        headTags: [{ type: 'title', text: 'Home' }],
+        headTags: [{ type: "title", text: "Home" }],
       },
     }),
   ],
@@ -42,29 +45,70 @@ export const app = createFaceApp({
 export const handler = createLambdaUrlStreamingHandler({ app });
 ```
 
+## Streaming SSR
+
+Use `createVueStreamFace` (or `renderVueStream` for lower-level adapter calls) when a Vue Face should return a streamed body. The Vue adapter uses `@vue/server-renderer`'s streaming renderer and returns the same `AsyncIterable<Uint8Array>` body contract as React streaming. FaceTheory still owns the document wrapper: `<head>` and structured style tags are emitted before the first body chunk, and mid-stream body errors are converted to FaceTheory's safe stream-error marker before the document closes.
+
+```typescript
+import { createFaceApp } from "@theory-cloud/facetheory";
+import { createVueStreamFace, h } from "@theory-cloud/facetheory/vue";
+
+const Home = {
+  setup() {
+    return () => h("main", "FaceTheory + Vue (streaming SSR)");
+  },
+};
+
+export const app = createFaceApp({
+  faces: [
+    createVueStreamFace({
+      route: "/",
+      mode: "ssr",
+      render: () => h(Home),
+      renderOptions: {
+        headTags: [{ type: "title", text: "Vue streaming" }],
+      },
+    }),
+  ],
+});
+```
+
+For strict no-inline CSP routes (`inlineScripts:false`, `inlineStyles:false`, or `rawHead:false`), FaceTheory buffers and validates the full streamed document before returning it. That preserves the same strict-CSP nonce, sidecar, and fail-closed behavior as buffered Vue SSR.
+
 ## Vite integration
 
 For Vue + Vite SSR, use `viteAssetsForEntry` and `viteHydrationForEntry` from the core `vite.ts` module to pipe the dev/build manifest into your render options. The runnable shape is `ts/examples/vite-ssr-vue/src/entry-server.ts`:
 
 ```typescript
-import { createFaceApp } from '@theory-cloud/facetheory';
-import { viteAssetsForEntry, viteHydrationForEntry } from '@theory-cloud/facetheory';
-import { createVueFace, h } from '@theory-cloud/facetheory/vue';
+import { createFaceApp } from "@theory-cloud/facetheory";
+import {
+  viteAssetsForEntry,
+  viteHydrationForEntry,
+} from "@theory-cloud/facetheory";
+import { createVueFace, h } from "@theory-cloud/facetheory/vue";
 
-import { App } from './app.js';
+import { App } from "./app.js";
 
 export function createApp(manifest) {
   return createFaceApp({
     faces: [
       createVueFace({
-        route: '/',
-        mode: 'ssr',
-        load: async () => ({ message: 'from server' }),
+        route: "/",
+        mode: "ssr",
+        load: async () => ({ message: "from server" }),
         render: (_ctx, data) =>
-          h('div', { id: 'root' }, [h(App, { message: data.message })]),
+          h("div", { id: "root" }, [h(App, { message: data.message })]),
         renderOptions: async (_ctx, data) => {
-          const { headTags } = viteAssetsForEntry(manifest, 'src/entry-client.ts', { includeAssets: true });
-          const hydration = viteHydrationForEntry(manifest, 'src/entry-client.ts', data);
+          const { headTags } = viteAssetsForEntry(
+            manifest,
+            "src/entry-client.ts",
+            { includeAssets: true },
+          );
+          const hydration = viteHydrationForEntry(
+            manifest,
+            "src/entry-client.ts",
+            data,
+          );
           return { headTags, hydration };
         },
       }),
@@ -81,6 +125,7 @@ export function createApp(manifest) {
 ## Examples in the repo
 
 - `ts/examples/vite-ssr-vue/` — Vue + Vite SSR with hydration
+- `ts/examples/vue-ssr-streaming/` — Vue streaming SSR
 
 ## Related docs
 

--- a/docs/adapters/vue.md
+++ b/docs/adapters/vue.md
@@ -117,6 +117,66 @@ export function createApp(manifest) {
 }
 ```
 
+## Style extraction position
+
+The supported Vue default is **build-time CSS through Vite**. Import component and library CSS in the client/Vite graph, then emit Vite's manifest-derived stylesheet tags with `viteAssetsForEntry(...)` so SSR, SSG, ISR, and hydration all see the same deterministic assets. This is the recommended path for Vue SFC scoped styles and application CSS.
+
+FaceTheory does not ship a Vue-specific runtime CSS-in-JS extractor. If a Vue CSS-in-JS library needs SSR setup, integrate it through the adapter integration hooks:
+
+1. `wrapApp(app, ctx, state)` installs the Vue plugin/provider for the request-local render.
+2. The Vue render records styles into that request-local state.
+3. `contribute(ctx, state)` returns structured `styleTags` (or external stylesheet `headTags`) for FaceTheory to serialize, nonce, order, and validate.
+
+```typescript
+import type { App, InjectionKey } from "vue";
+import { inject } from "vue";
+import {
+  createVueFace,
+  h,
+  type VueUIIntegration,
+} from "@theory-cloud/facetheory/vue";
+
+const registerStyleKey: InjectionKey<(cssText: string) => void> =
+  Symbol("register-style");
+
+const cssInJsIntegration: VueUIIntegration<{ styles: string[] }> = {
+  name: "example-vue-css-in-js",
+  createState: () => ({ styles: [] }),
+  wrapApp(app: App, _ctx, state) {
+    app.provide(registerStyleKey, (cssText: string) => {
+      state.styles.push(cssText);
+    });
+  },
+  contribute(_ctx, state) {
+    return {
+      styleTags: state.styles.map((cssText, index) => ({
+        cssText,
+        attrs: { id: `example-vue-css-${index}` },
+      })),
+    };
+  },
+};
+
+const StyledPanel = {
+  setup() {
+    const registerStyle = inject(registerStyleKey);
+    registerStyle?.(".panel{color:rgb(12,34,56);}");
+    return () => h("section", { class: "panel" }, "Styled by wrapApp");
+  },
+};
+
+createVueFace({
+  route: "/",
+  mode: "ssr",
+  render: () => h(StyledPanel),
+  renderOptions: {
+    integrations: [cssInJsIntegration],
+  },
+});
+```
+
+Do not inject raw `<style>` strings through component HTML or `head.html`. Use `styleTags`/structured head tags so FaceTheory can preserve deterministic head ordering and strict-CSP behavior. For strict no-inline CSP, prefer external CSS assets over inline `styleTags`.
+
 ## Sub-entry points
 
 - `@theory-cloud/facetheory/stitch-tokens` — shared Stitch token utilities used by all adapters.

--- a/ts/examples/vue-ssr-streaming/README.md
+++ b/ts/examples/vue-ssr-streaming/README.md
@@ -1,0 +1,11 @@
+# Vue Streaming SSR Example
+
+From `ts/`:
+
+```bash
+npm run example:vue:streaming:serve
+```
+
+Open `http://localhost:4176/`.
+
+This path exercises Vue streaming SSR through `FaceApp.handle()`: FaceTheory emits the document head before the streamed Vue body and preserves the same `AsyncIterable<Uint8Array>` response contract as other streaming Faces.

--- a/ts/examples/vue-ssr-streaming/handler.ts
+++ b/ts/examples/vue-ssr-streaming/handler.ts
@@ -1,0 +1,34 @@
+// Example sketch: Vue streaming SSR Face (body streamed, document wrapper handled by FaceApp).
+//
+// This is not included in `tsc` builds (examples are excluded from tsconfig).
+
+import { createFaceApp } from '../../src/app.js';
+import { createVueStreamFace, h } from '../../src/vue/index.js';
+
+const Home = {
+  setup() {
+    return () => h('h1', null, 'FaceTheory + Vue (streaming SSR)');
+  },
+};
+
+export const faceApp = createFaceApp({
+  faces: [
+    createVueStreamFace({
+      route: '/',
+      mode: 'ssr',
+      render: () => h(Home),
+      renderOptions: {
+        headTags: [{ type: 'title', text: 'Vue Streaming Home' }],
+      },
+    }),
+  ],
+});
+
+export async function handler(event: any): Promise<any> {
+  return faceApp.handle({
+    method: event?.requestContext?.http?.method ?? 'GET',
+    path: event?.rawPath ?? '/',
+    headers: {},
+    query: {},
+  });
+}

--- a/ts/examples/vue-ssr-streaming/node-server.ts
+++ b/ts/examples/vue-ssr-streaming/node-server.ts
@@ -1,0 +1,60 @@
+import http from 'node:http';
+
+import { faceApp } from './handler.js';
+
+function toNodeHeaders(
+  headers: Record<string, string[]>,
+): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  for (const [name, values] of Object.entries(headers)) {
+    if (!values.length) continue;
+    out[name] = values.length === 1 ? values[0] : values;
+  }
+  return out;
+}
+
+async function main() {
+  const server = http.createServer(async (req, res) => {
+    if (!req.url) {
+      res.writeHead(400);
+      res.end('Bad Request');
+      return;
+    }
+
+    const response = await faceApp.handle({
+      method: req.method ?? 'GET',
+      path: req.url,
+      headers: Object.fromEntries(
+        Object.entries(req.headers).map(([name, value]) => [
+          name,
+          Array.isArray(value)
+            ? value.map(String)
+            : value
+              ? [String(value)]
+              : [],
+        ]),
+      ),
+    });
+
+    res.writeHead(response.status, toNodeHeaders(response.headers));
+
+    if (response.body instanceof Uint8Array) {
+      res.end(response.body);
+      return;
+    }
+
+    for await (const chunk of response.body) {
+      res.write(chunk);
+    }
+    res.end();
+  });
+
+  const port = Number(process.env.PORT ?? 4176);
+  server.listen(port);
+  console.log(`listening on http://localhost:${port}/`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ts/package.json
+++ b/ts/package.json
@@ -212,6 +212,7 @@
     "example:ssg:serve": "tsx examples/ssg-basic/serve-static.ts",
     "example:buffered:serve": "tsx examples/react-ssr-buffered/node-server.ts",
     "example:streaming:serve": "tsx examples/react-ssr-streaming/node-server.ts",
+    "example:vue:streaming:serve": "tsx examples/vue-ssr-streaming/node-server.ts",
     "example:vite:ssr:build": "vite build --config examples/vite-ssr-react/vite.config.ts && vite build --ssr src/entry-server.tsx --config examples/vite-ssr-react/vite.config.ts",
     "example:vite:ssr:serve": "tsx examples/vite-ssr-react/node-server.ts",
     "example:vite:vue:build": "vite build --config examples/vite-ssr-vue/vite.config.ts && vite build --ssr src/entry-server.ts --config examples/vite-ssr-vue/vite.config.ts",

--- a/ts/src/vue/index.ts
+++ b/ts/src/vue/index.ts
@@ -1,5 +1,5 @@
 import { createSSRApp, h, type App, type VNode } from 'vue';
-import { renderToString } from '@vue/server-renderer';
+import { renderToSimpleStream, renderToString } from '@vue/server-renderer';
 
 import { enforceAdapterStrictCspResult } from '../adapter-csp.js';
 import {
@@ -38,12 +38,22 @@ export interface RenderVueOptions {
   integrations?: Array<VueUIIntegration>;
 }
 
+export type RenderVueStreamOptions = RenderVueOptions;
+
 export async function renderVue(
   ctx: FaceContext,
   vnode: VNode,
   options: RenderVueOptions = {},
 ): Promise<FaceRenderResult> {
   return renderVueInternal(ctx, vnode, options);
+}
+
+export async function renderVueStream(
+  ctx: FaceContext,
+  vnode: VNode,
+  options: RenderVueStreamOptions = {},
+): Promise<FaceRenderResult> {
+  return renderVueStreamInternal(ctx, vnode, options);
 }
 
 interface VueRenderValidationOptions {
@@ -63,7 +73,10 @@ async function renderVueInternal(
     integrations: options.integrations ?? [],
     renderTree: async (tree, pipelineContext) => {
       const app = createSSRApp({ render: () => tree });
-      for (const { integration, state } of pipelineContext.preparedIntegrations) {
+      for (const {
+        integration,
+        state,
+      } of pipelineContext.preparedIntegrations) {
         if (!integration.wrapApp) continue;
         await integration.wrapApp(app, ctx, state);
       }
@@ -77,6 +90,108 @@ async function renderVueInternal(
       });
     },
   });
+}
+
+async function renderVueStreamInternal(
+  ctx: FaceContext,
+  vnode: VNode,
+  options: RenderVueStreamOptions,
+  validationOptions: VueRenderValidationOptions = {},
+): Promise<FaceRenderResult> {
+  return runAdapterRenderPipeline<VNode, VueUIIntegration>({
+    ctx,
+    tree: vnode,
+    options,
+    integrations: options.integrations ?? [],
+    renderTree: async (tree, pipelineContext) => {
+      const app = createSSRApp({ render: () => tree });
+      for (const {
+        integration,
+        state,
+      } of pipelineContext.preparedIntegrations) {
+        if (!integration.wrapApp) continue;
+        await integration.wrapApp(app, ctx, state);
+      }
+      return renderVueAppToAsyncIterable(app);
+    },
+    enforceStrictCsp: (out) => {
+      enforceAdapterStrictCspResult(out, {
+        adapterName: 'Vue adapter',
+        deferHydrationValidation:
+          validationOptions.deferStrictCspHydrationValidation === true,
+      });
+    },
+  });
+}
+
+type VueStreamQueueItem =
+  | { kind: 'chunk'; chunk: Uint8Array }
+  | { kind: 'done' }
+  | { kind: 'error'; error: unknown };
+
+function renderVueAppToAsyncIterable(app: App): AsyncIterable<Uint8Array> {
+  const encoder = new TextEncoder();
+  const queue: VueStreamQueueItem[] = [];
+  let wake: (() => void) | null = null;
+  let settled = false;
+
+  const enqueue = (item: VueStreamQueueItem): void => {
+    queue.push(item);
+    wake?.();
+    wake = null;
+  };
+
+  const finish = (): void => {
+    if (settled) return;
+    settled = true;
+    enqueue({ kind: 'done' });
+  };
+
+  const fail = (error: unknown): void => {
+    if (settled) return;
+    settled = true;
+    enqueue({ kind: 'error', error });
+  };
+
+  try {
+    renderToSimpleStream(
+      app,
+      {},
+      {
+        push(chunk) {
+          if (chunk === null) {
+            finish();
+            return;
+          }
+          if (settled) return;
+          enqueue({ kind: 'chunk', chunk: encoder.encode(chunk) });
+        },
+        destroy(error) {
+          fail(error);
+        },
+      },
+    );
+  } catch (error) {
+    fail(error);
+  }
+
+  return (async function* () {
+    for (;;) {
+      while (queue.length === 0) {
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+
+      const item = queue.shift()!;
+      if (item.kind === 'chunk') {
+        yield item.chunk;
+        continue;
+      }
+      if (item.kind === 'error') throw item.error;
+      return;
+    }
+  })();
 }
 
 export interface VueFaceOptions<Data = unknown> {
@@ -105,6 +220,48 @@ export function createVueFace<Data = unknown>(
           ? await options.renderOptions(ctx, data as Data)
           : (options.renderOptions ?? {});
       return renderVueInternal(ctx, vnode, renderOptions, {
+        deferStrictCspHydrationValidation: modeUsesRuntimeHydrationSidecars(
+          options.mode,
+        ),
+      });
+    },
+  };
+
+  if (options.load) {
+    mod.load = options.load as unknown as (
+      ctx: FaceContext,
+    ) => Promise<unknown>;
+  }
+
+  return mod;
+}
+
+export interface VueStreamFaceOptions<Data = unknown> {
+  route: string;
+  mode: FaceMode;
+  load?: (ctx: FaceContext) => Promise<Data>;
+  render: (ctx: FaceContext, data: Data) => VNode | Promise<VNode>;
+  renderOptions?:
+    | RenderVueStreamOptions
+    | ((
+        ctx: FaceContext,
+        data: Data,
+      ) => RenderVueStreamOptions | Promise<RenderVueStreamOptions>);
+}
+
+export function createVueStreamFace<Data = unknown>(
+  options: VueStreamFaceOptions<Data>,
+): FaceModule {
+  const mod: FaceModule = {
+    route: options.route,
+    mode: options.mode,
+    render: async (ctx, data) => {
+      const vnode = await options.render(ctx, data as Data);
+      const renderOptions =
+        typeof options.renderOptions === 'function'
+          ? await options.renderOptions(ctx, data as Data)
+          : (options.renderOptions ?? {});
+      return renderVueStreamInternal(ctx, vnode, renderOptions, {
         deferStrictCspHydrationValidation: modeUsesRuntimeHydrationSidecars(
           options.mode,
         ),

--- a/ts/src/vue/index.ts
+++ b/ts/src/vue/index.ts
@@ -112,7 +112,20 @@ async function renderVueStreamInternal(
         if (!integration.wrapApp) continue;
         await integration.wrapApp(app, ctx, state);
       }
-      return renderVueAppToAsyncIterable(app);
+      const stream = renderVueAppToAsyncIterable(app);
+      const requiresAllReady = pipelineContext.preparedIntegrations.some(
+        ({ integration }) =>
+          typeof integration.contribute === 'function' ||
+          typeof integration.finalize === 'function',
+      );
+
+      if (requiresAllReady) {
+        await stream.completed;
+      } else {
+        void stream.completed.catch(() => undefined);
+      }
+
+      return stream.body;
     },
     enforceStrictCsp: (out) => {
       enforceAdapterStrictCspResult(out, {
@@ -129,11 +142,23 @@ type VueStreamQueueItem =
   | { kind: 'done' }
   | { kind: 'error'; error: unknown };
 
-function renderVueAppToAsyncIterable(app: App): AsyncIterable<Uint8Array> {
+interface VueAppStream {
+  body: AsyncIterable<Uint8Array>;
+  completed: Promise<void>;
+}
+
+function renderVueAppToAsyncIterable(app: App): VueAppStream {
   const encoder = new TextEncoder();
   const queue: VueStreamQueueItem[] = [];
   let wake: (() => void) | null = null;
   let settled = false;
+  let resolveCompleted: (() => void) | null = null;
+  let rejectCompleted: ((error: unknown) => void) | null = null;
+
+  const completed = new Promise<void>((resolve, reject) => {
+    resolveCompleted = resolve;
+    rejectCompleted = reject;
+  });
 
   const enqueue = (item: VueStreamQueueItem): void => {
     queue.push(item);
@@ -145,12 +170,14 @@ function renderVueAppToAsyncIterable(app: App): AsyncIterable<Uint8Array> {
     if (settled) return;
     settled = true;
     enqueue({ kind: 'done' });
+    resolveCompleted?.();
   };
 
   const fail = (error: unknown): void => {
     if (settled) return;
     settled = true;
     enqueue({ kind: 'error', error });
+    rejectCompleted?.(error);
   };
 
   try {
@@ -175,23 +202,26 @@ function renderVueAppToAsyncIterable(app: App): AsyncIterable<Uint8Array> {
     fail(error);
   }
 
-  return (async function* () {
-    for (;;) {
-      while (queue.length === 0) {
-        await new Promise<void>((resolve) => {
-          wake = resolve;
-        });
-      }
+  return {
+    body: (async function* () {
+      for (;;) {
+        while (queue.length === 0) {
+          await new Promise<void>((resolve) => {
+            wake = resolve;
+          });
+        }
 
-      const item = queue.shift()!;
-      if (item.kind === 'chunk') {
-        yield item.chunk;
-        continue;
+        const item = queue.shift()!;
+        if (item.kind === 'chunk') {
+          yield item.chunk;
+          continue;
+        }
+        if (item.kind === 'error') throw item.error;
+        return;
       }
-      if (item.kind === 'error') throw item.error;
-      return;
-    }
-  })();
+    })(),
+    completed,
+  };
 }
 
 export interface VueFaceOptions<Data = unknown> {

--- a/ts/test/unit/vue-stream.test.ts
+++ b/ts/test/unit/vue-stream.test.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createFaceApp } from '../../src/app.js';
+import {
+  createVueStreamFace,
+  h,
+  renderVueStream,
+} from '../../src/vue/index.js';
+import type { FaceBody, FaceContext } from '../../src/types.js';
+
+const baseCtx: FaceContext = {
+  request: {
+    method: 'GET',
+    path: '/',
+    query: {},
+    headers: { 'x-request-id': ['test-vue-stream'] },
+    cookies: {},
+    body: new Uint8Array(),
+    isBase64: false,
+    cspNonce: null,
+  },
+  params: {},
+  proxy: null,
+};
+
+async function collect(body: FaceBody): Promise<string> {
+  const decoder = new TextDecoder();
+  if (body instanceof Uint8Array) return decoder.decode(body);
+
+  const parts: string[] = [];
+  for await (const chunk of body) {
+    parts.push(decoder.decode(chunk, { stream: true }));
+  }
+  parts.push(decoder.decode());
+  return parts.join('');
+}
+
+function failAfterFirstChunk(
+  body: AsyncIterable<Uint8Array>,
+): AsyncIterable<Uint8Array> {
+  return (async function* () {
+    let yielded = false;
+    for await (const chunk of body) {
+      yield chunk;
+      if (!yielded) {
+        yielded = true;
+        throw new Error('vue stream failed after first chunk');
+      }
+    }
+  })();
+}
+
+test('vue adapter: streaming body renders and FaceApp wraps document', async () => {
+  const app = createFaceApp({
+    faces: [
+      createVueStreamFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => h('main', null, 'Hello Vue (stream)'),
+        renderOptions: {
+          headTags: [{ type: 'title', text: 'Vue Stream' }],
+        },
+      }),
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.ok(!(resp.body instanceof Uint8Array));
+
+  const iterator = resp.body[Symbol.asyncIterator]();
+  const firstChunk = await iterator.next();
+  assert.equal(firstChunk.done, false);
+  const first = new TextDecoder().decode(firstChunk.value);
+  assert.ok(first.startsWith('<!doctype html>'));
+  assert.ok(first.includes('<title>Vue Stream</title>'));
+  assert.ok(!first.includes('Hello Vue (stream)'));
+
+  const remainder = await collect({
+    async *[Symbol.asyncIterator]() {
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) return;
+        yield next.value;
+      }
+    },
+  });
+  const html = `${first}${remainder}`;
+  assert.ok(html.includes('<main>Hello Vue (stream)</main>'));
+});
+
+test('vue adapter: renderVueStream returns the AsyncIterable body contract', async () => {
+  const out = await renderVueStream(
+    baseCtx,
+    h('main', null, 'Direct Vue stream'),
+  );
+
+  assert.notEqual(typeof out.html, 'string');
+  const html = await collect(out.html as FaceBody);
+  assert.ok(html.includes('<main>Direct Vue stream</main>'));
+});
+
+test('vue adapter: strict CSP streaming buffers safe output', async () => {
+  const app = createFaceApp({
+    faces: [
+      createVueStreamFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => h('main', null, 'Strict Vue stream'),
+        renderOptions: {
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          hydration: {
+            type: 'external',
+            data: { stream: true },
+            dataUrl: '/_facetheory/data/vue-stream.json',
+            bootstrapModule: '/assets/vue-stream-entry.js',
+          },
+        },
+      }),
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.ok(resp.body instanceof Uint8Array);
+
+  const html = await collect(resp.body);
+  assert.ok(html.includes('Strict Vue stream'));
+  assert.ok(html.includes('id="__FACETHEORY_DATA_URL__"'));
+  assert.ok(!html.includes('id="__FACETHEORY_DATA__"'));
+});
+
+test('vue adapter: streaming body error emits marker and closes document', async () => {
+  const app = createFaceApp({
+    faces: [
+      createVueStreamFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => h('main', null, 'Vue stream before failure'),
+        renderOptions: {
+          integrations: [
+            {
+              name: 'vue-stream-failure-test',
+              finalize: (out) => {
+                assert.notEqual(typeof out.html, 'string');
+                return {
+                  ...out,
+                  html: failAfterFirstChunk(
+                    out.html as AsyncIterable<Uint8Array>,
+                  ),
+                };
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  const resp = await app.handle({ method: 'GET', path: '/' });
+  assert.ok(!(resp.body instanceof Uint8Array));
+
+  const html = await collect(resp.body);
+  assert.ok(html.includes('Vue stream before failure'));
+  assert.ok(html.includes('data-facetheory-stream-error="true"'));
+  assert.ok(html.endsWith('</body></html>'));
+});

--- a/ts/test/unit/vue-stream.test.ts
+++ b/ts/test/unit/vue-stream.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { inject, type InjectionKey } from 'vue';
+
+import { assertDocumentTagNonces } from '../helpers/csp.js';
+
 import { createFaceApp } from '../../src/app.js';
 import {
   createVueStreamFace,
@@ -98,6 +102,88 @@ test('vue adapter: renderVueStream returns the AsyncIterable body contract', asy
   assert.notEqual(typeof out.html, 'string');
   const html = await collect(out.html as FaceBody);
   assert.ok(html.includes('<main>Direct Vue stream</main>'));
+});
+
+test('vue adapter: streaming waits for async wrapApp style contribution before head assembly', async () => {
+  const registerStyleKey: InjectionKey<(cssText: string) => void> = Symbol(
+    'facetheory-vue-stream-wrap-style',
+  );
+
+  const AsyncStyledByWrapApp = {
+    async setup() {
+      const registerStyle = inject(registerStyleKey);
+      assert.ok(registerStyle, 'expected wrapApp style provider');
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      registerStyle('.async-wrap-app-style{color:rgb(22,44,66);}');
+      return () =>
+        h('main', { class: 'async-wrap-app-style' }, 'Async WrapApp CSS');
+    },
+  };
+
+  const app = createFaceApp({
+    faces: [
+      createVueStreamFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => h(AsyncStyledByWrapApp),
+        renderOptions: {
+          integrations: [
+            {
+              name: 'stream-wrap-app-style-provider',
+              createState: () => ({ styles: [] as string[] }),
+              wrapApp: (vueApp, _ctx, state) => {
+                vueApp.provide(registerStyleKey, (cssText: string) => {
+                  (state as { styles: string[] }).styles.push(cssText);
+                });
+              },
+              contribute: (_ctx, state) => ({
+                styleTags: (state as { styles: string[] }).styles.map(
+                  (cssText, index) => ({
+                    cssText,
+                    attrs: { id: `async-wrap-app-style-${String(index)}` },
+                  }),
+                ),
+              }),
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  const nonce = 'nonce-vue-stream-wrap-style';
+  const resp = await app.handle({ method: 'GET', path: '/', cspNonce: nonce });
+  assert.ok(!(resp.body instanceof Uint8Array));
+
+  const iterator = resp.body[Symbol.asyncIterator]();
+  const firstChunk = await iterator.next();
+  assert.equal(firstChunk.done, false);
+  const first = new TextDecoder().decode(firstChunk.value);
+  assert.ok(first.includes('id="async-wrap-app-style-0"'), first);
+  assert.ok(
+    first.includes('.async-wrap-app-style{color:rgb(22,44,66);}'),
+    first,
+  );
+  assert.ok(!first.includes('Async WrapApp CSS'));
+
+  const remainder = await collect({
+    async *[Symbol.asyncIterator]() {
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) return;
+        yield next.value;
+      }
+    },
+  });
+  const html = `${first}${remainder}`;
+  const styleIndex = html.indexOf('id="async-wrap-app-style-0"');
+  const bodyIndex = html.indexOf(
+    '<main class="async-wrap-app-style">Async WrapApp CSS</main>',
+  );
+  assert.ok(styleIndex >= 0, html);
+  assert.ok(bodyIndex >= 0, html);
+  assert.ok(styleIndex < bodyIndex);
+  assertDocumentTagNonces(html, nonce, 1, 0);
 });
 
 test('vue adapter: strict CSP streaming buffers safe output', async () => {

--- a/ts/test/unit/vue.test.ts
+++ b/ts/test/unit/vue.test.ts
@@ -5,6 +5,8 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { inject, type InjectionKey } from 'vue';
+
 import { assertDocumentTagNonces } from '../helpers/csp.js';
 
 import { createFaceApp } from '../../src/app.js';
@@ -207,6 +209,66 @@ test('vue adapter: integration hooks provide deterministic head/style ordering a
   assert.ok(secondBody.includes('/integration-a-2.css'));
   assert.ok(secondBody.includes('/integration-b-2.css'));
   assert.ok(secondBody.includes('id="style-int-2"'));
+});
+
+test('vue adapter: wrapApp can provide deterministic style contribution', async () => {
+  const registerStyleKey: InjectionKey<(cssText: string) => void> = Symbol(
+    'facetheory-vue-wrap-style',
+  );
+
+  const StyledByWrapApp = {
+    setup() {
+      const registerStyle = inject(registerStyleKey);
+      assert.ok(registerStyle, 'expected wrapApp style provider');
+      registerStyle('.wrap-app-style{color:rgb(12,34,56);}');
+      return () => h('main', { class: 'wrap-app-style' }, 'WrapApp CSS');
+    },
+  };
+
+  const app = createFaceApp({
+    faces: [
+      createVueFace({
+        route: '/',
+        mode: 'ssr',
+        render: () => h(StyledByWrapApp),
+        renderOptions: {
+          integrations: [
+            {
+              name: 'wrap-app-style-provider',
+              createState: () => ({ styles: [] as string[] }),
+              wrapApp: (vueApp, _ctx, state) => {
+                vueApp.provide(registerStyleKey, (cssText: string) => {
+                  (state as { styles: string[] }).styles.push(cssText);
+                });
+              },
+              contribute: (_ctx, state) => ({
+                styleTags: (state as { styles: string[] }).styles.map(
+                  (cssText, index) => ({
+                    cssText,
+                    attrs: { id: `wrap-app-style-${String(index)}` },
+                  }),
+                ),
+              }),
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  const nonce = 'nonce-vue-wrap-style';
+  const resp = await app.handle({ method: 'GET', path: '/', cspNonce: nonce });
+  const body = new TextDecoder().decode(resp.body as Uint8Array);
+
+  const styleIndex = body.indexOf('id="wrap-app-style-0"');
+  const bodyIndex = body.indexOf(
+    '<main class="wrap-app-style">WrapApp CSS</main>',
+  );
+  assert.ok(styleIndex >= 0, body);
+  assert.ok(bodyIndex >= 0, body);
+  assert.ok(styleIndex < bodyIndex);
+  assert.ok(body.includes('.wrap-app-style{color:rgb(12,34,56);}'));
+  assertDocumentTagNonces(body, nonce, 1, 0);
 });
 
 test('vue adapter: strict CSP emits external hydration without inline data', async () => {


### PR DESCRIPTION
## Milestone
M7 vue-parity — Vue streaming SSR and documented Vue style-extraction position.

## Linear
References THE-2477 and THE-2478.

## Render modes and adapters affected
- Vue adapter: SSR and ISR streaming render path.
- Vue docs/tests: SSR, SSG, and ISR style-extraction guidance.

## Determinism impact
- Adds Vue streaming through the existing `AsyncIterable<Uint8Array>` response contract.
- Preserves FaceTheory head-before-body document wrapping.
- Strict no-inline CSP streaming buffers and validates before returning bytes.
- Mid-stream body errors keep the document shape with FaceTheory's safe stream-error marker.
- `wrapApp` style contributions are characterized through structured `styleTags`, preserving nonce and ordering behavior.
- Vue streaming waits for render completion before `contribute`/`finalize` integrations so async component-tree style records are available before head/style assembly.

## Backward compatibility
Additive for 3.x. Existing `renderVue` / `createVueFace` behavior is unchanged.

## Tasks
- [x] THE-2477 / FT strengthen #17 — Add Vue streaming SSR.
- [x] THE-2478 / FT strengthen #18 — Document Vue style-extraction position and lock it with a test.

## Validation
- Baseline before editing: `cd ts && npm run check` — pass.
- Initial targeted: `cd ts && node --import tsx --test --test-concurrency=1 test/unit/vue-stream.test.ts test/unit/vue.test.ts` — pass (13 tests).
- Initial full: `cd ts && npm run check` — pass (629 tests, 628 pass / 1 skipped; unit discovery found 56 files).
- Smoke: `cd ts && PORT=4276 npm run example:vue:streaming:serve` plus `curl http://127.0.0.1:4276/` — pass; response included `<title>Vue Streaming Home</title>` and `<h1>FaceTheory + Vue (streaming SSR)</h1>`.
- Rework targeted: `cd ts && node --import tsx --test --test-concurrency=1 test/unit/vue-stream.test.ts test/unit/vue.test.ts` — pass (14 tests; expected stream-error marker test logs the synthetic body error).
- Rework full: `cd ts && npm run check` — pass (630 tests, 629 pass / 1 skipped; unit discovery found 56 files).
- `scripts/verify-version-alignment.sh` — pass (3.8.1).
- `git diff --check theorymcp/theorycloud/facetheory/product-strengthening-plans-2026-07-02..HEAD` and `git diff --check` — pass.

## Cross-repo coordination
None. No cloud, deployment, account, DNS, secret, live receipt, or TheoryCloud control-plane behavior changed.
