### PR TITLE
feat(stitch): shared hosted-auth core contract

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -75,6 +75,10 @@
       "types": "./dist/stitch-shell/index.d.ts",
       "import": "./dist/stitch-shell/index.js"
     },
+    "./stitch-hosted-auth": {
+      "types": "./dist/stitch-hosted-auth/index.d.ts",
+      "import": "./dist/stitch-hosted-auth/index.js"
+    },
     "./stitch-admin": {
       "types": "./dist/stitch-admin/index.d.ts",
       "import": "./dist/stitch-admin/index.js"

--- a/ts/src/react/stitch-hosted-auth/consent.ts
+++ b/ts/src/react/stitch-hosted-auth/consent.ts
@@ -1,17 +1,15 @@
 import * as React from 'react';
 
+import {
+  authConsentItemBackground,
+  authConsentItemOpacity,
+  type ConsentItemProps as SharedConsentItemProps,
+  type ConsentListProps as SharedConsentListProps,
+} from '../../stitch-hosted-auth/index.js';
+
 const h = React.createElement;
 
-export interface ConsentItemProps {
-  /** Short label (e.g. "Read your profile"). */
-  label: React.ReactNode;
-  /** Long-form description shown under the label. */
-  description?: React.ReactNode;
-  /** Leading icon glyph. */
-  icon?: React.ReactNode;
-  /** Mark as already granted (greys out the entry). */
-  granted?: boolean;
-}
+export type ConsentItemProps = SharedConsentItemProps<React.ReactNode>;
 
 /**
  * Single scope / permission line inside an OAuth consent screen. Rendered as
@@ -29,11 +27,9 @@ export function ConsentItem(props: ConsentItemProps): React.ReactElement {
         alignItems: 'flex-start',
         gap: '12px',
         padding: '12px 16px',
-        background: granted
-          ? 'var(--stitch-color-surface-container-low, #f2f3ff)'
-          : 'var(--stitch-color-surface-container-lowest, #ffffff)',
+        background: authConsentItemBackground(granted),
         borderRadius: 'var(--stitch-radius-md, 6px)',
-        opacity: granted ? 0.7 : 1,
+        opacity: authConsentItemOpacity(granted),
       },
     },
     icon !== undefined
@@ -81,7 +77,8 @@ export function ConsentItem(props: ConsentItemProps): React.ReactElement {
   );
 }
 
-export interface ConsentListProps {
+export interface ConsentListProps
+  extends Omit<SharedConsentListProps<React.ReactNode>, 'children'> {
   children: React.ReactNode;
 }
 

--- a/ts/src/react/stitch-hosted-auth/flow.ts
+++ b/ts/src/react/stitch-hosted-auth/flow.ts
@@ -1,19 +1,17 @@
 import * as React from 'react';
 
+import {
+  resolveAuthFlowStepState,
+  type AuthFlowSectionProps as SharedAuthFlowSectionProps,
+  type AuthFlowStep as SharedAuthFlowStep,
+  type AuthFlowStepperProps as SharedAuthFlowStepperProps,
+} from '../../stitch-hosted-auth/index.js';
+
 const h = React.createElement;
 
-export interface AuthFlowStep {
-  key: string;
-  label: string;
-  /** Optional long-form description shown when this step is active. */
-  description?: React.ReactNode;
-}
+export type AuthFlowStep = SharedAuthFlowStep<React.ReactNode>;
 
-export interface AuthFlowStepperProps {
-  steps: AuthFlowStep[];
-  /** Zero-based index of the currently active step. */
-  currentIndex: number;
-}
+export type AuthFlowStepperProps = SharedAuthFlowStepperProps<AuthFlowStep>;
 
 /**
  * Compact stepper for multi-step hosted-auth flows (MFA setup, passkey
@@ -40,20 +38,12 @@ export function AuthFlowStepper(
       },
     },
     steps.map((step, index) => {
-      const isCurrent = index === currentIndex;
-      const isCompleted = index < currentIndex;
-      const dotColor =
-        isCompleted || isCurrent
-          ? 'var(--stitch-color-primary, #1f108e)'
-          : 'var(--stitch-color-surface-container-high, #e2e7ff)';
-      const labelColor = isCurrent
-        ? 'var(--stitch-color-on-surface, #131b2e)'
-        : 'var(--stitch-color-on-surface-variant, #464553)';
+      const stepState = resolveAuthFlowStepState(index, currentIndex);
       return h(
         'li',
         {
           key: step.key,
-          'aria-current': isCurrent ? 'step' : undefined,
+          'aria-current': stepState.ariaCurrent,
           style: { display: 'flex', alignItems: 'center', gap: '8px' },
         },
         h('span', {
@@ -62,7 +52,7 @@ export function AuthFlowStepper(
             width: 10,
             height: 10,
             borderRadius: '9999px',
-            background: dotColor,
+            background: stepState.dotColor,
             display: 'inline-block',
           },
         }),
@@ -73,8 +63,8 @@ export function AuthFlowStepper(
               fontSize: '12px',
               textTransform: 'uppercase',
               letterSpacing: '0.08em',
-              color: labelColor,
-              fontWeight: isCurrent ? 600 : 400,
+              color: stepState.labelColor,
+              fontWeight: stepState.labelFontWeight,
             },
           },
           step.label,
@@ -84,11 +74,8 @@ export function AuthFlowStepper(
   );
 }
 
-export interface AuthFlowSectionProps {
-  /** Optional step heading (e.g. "Step 2 of 3"). */
-  eyebrow?: React.ReactNode;
-  title?: React.ReactNode;
-  description?: React.ReactNode;
+export interface AuthFlowSectionProps
+  extends Omit<SharedAuthFlowSectionProps<React.ReactNode>, 'children'> {
   children: React.ReactNode;
 }
 
@@ -148,6 +135,10 @@ export function AuthFlowSection(
           description,
         )
       : null,
-    h('div', { style: { display: 'flex', flexDirection: 'column', gap: '12px' } }, children),
+    h(
+      'div',
+      { style: { display: 'flex', flexDirection: 'column', gap: '12px' } },
+      children,
+    ),
   );
 }

--- a/ts/src/react/stitch-hosted-auth/index.ts
+++ b/ts/src/react/stitch-hosted-auth/index.ts
@@ -29,3 +29,9 @@ export {
   type AuthStateCardProps,
   type AuthStateVariant,
 } from './states.js';
+
+export type {
+  AuthPageBackground,
+  AuthPasskeyButtonType,
+  AuthStateVariantPalette,
+} from '../../stitch-hosted-auth/index.js';

--- a/ts/src/react/stitch-hosted-auth/layout.ts
+++ b/ts/src/react/stitch-hosted-auth/layout.ts
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import { Typography } from 'antd';
 
+import {
+  resolveAuthPageBackground,
+  type AuthCardProps as SharedAuthCardProps,
+  type AuthPageLayoutProps as SharedAuthPageLayoutProps,
+} from '../../stitch-hosted-auth/index.js';
+
 const h = React.createElement;
 
-export interface AuthPageLayoutProps {
-  /** Brand mark rendered in the top-left (e.g. logo). */
-  brand?: React.ReactNode;
-  /** Background treatment. `gradient` applies the Stitch signature indigo gradient. */
-  background?: 'surface' | 'gradient';
-  /** Right-rail slot for legal / locale / help links rendered at the bottom. */
-  footer?: React.ReactNode;
+export interface AuthPageLayoutProps
+  extends Omit<SharedAuthPageLayoutProps<React.ReactNode>, 'children'> {
   children: React.ReactNode;
 }
 
@@ -23,15 +24,9 @@ export function AuthPageLayout(
 ): React.ReactElement {
   const { brand, background = 'surface', footer, children } = props;
 
-  const bgStyle: React.CSSProperties =
-    background === 'gradient'
-      ? {
-          background:
-            'linear-gradient(135deg, var(--stitch-color-primary, #1f108e) 0%, var(--stitch-color-primary-container, #3730a3) 100%)',
-        }
-      : {
-          background: 'var(--stitch-color-surface, #faf8ff)',
-        };
+  const bgStyle: React.CSSProperties = {
+    background: resolveAuthPageBackground(background),
+  };
 
   return h(
     'div',
@@ -86,13 +81,8 @@ export function AuthPageLayout(
   );
 }
 
-export interface AuthCardProps {
-  title: React.ReactNode;
-  description?: React.ReactNode;
-  /** Right-aligned secondary action slot inside the header (e.g. "Sign up"). */
-  headerAction?: React.ReactNode;
-  /** Footer slot rendered below the body (e.g. "Trouble signing in?"). */
-  footer?: React.ReactNode;
+export interface AuthCardProps
+  extends Omit<SharedAuthCardProps<React.ReactNode>, 'children'> {
   children: React.ReactNode;
 }
 

--- a/ts/src/react/stitch-hosted-auth/otp.ts
+++ b/ts/src/react/stitch-hosted-auth/otp.ts
@@ -1,21 +1,14 @@
 import * as React from 'react';
 import { Input } from 'antd';
 
+import {
+  authOtpInputClassName,
+  type OTPInputProps,
+} from '../../stitch-hosted-auth/index.js';
+
 const h = React.createElement;
 
-export interface OTPInputProps {
-  /** Number of characters to accept. Default 6. */
-  length?: number;
-  value?: string;
-  onChange?: (value: string) => void;
-  /** Fires when the last digit is entered (useful for auto-submit flows). */
-  onComplete?: (value: string) => void;
-  disabled?: boolean;
-  /** Visually marks the input invalid. Pairs with a caller-supplied error message. */
-  invalid?: boolean;
-  /** Autofocus the first character box on mount. Default `true`. */
-  autoFocus?: boolean;
-}
+export type { OTPInputProps } from '../../stitch-hosted-auth/index.js';
 
 /**
  * One-time-password input. Wraps AntD's `Input.OTP` with Stitch styling —
@@ -34,12 +27,7 @@ export function OTPInput(props: OTPInputProps): React.ReactElement {
     autoFocus = true,
   } = props;
 
-  const className = [
-    'facetheory-stitch-otp-input',
-    invalid ? 'facetheory-stitch-otp-input-invalid' : null,
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const className = authOtpInputClassName(invalid);
 
   const otpProps: React.ComponentProps<typeof Input.OTP> = {
     length,

--- a/ts/src/react/stitch-hosted-auth/passkey.ts
+++ b/ts/src/react/stitch-hosted-auth/passkey.ts
@@ -2,17 +2,19 @@ import * as React from 'react';
 import { Button } from 'antd';
 import type { ButtonProps } from 'antd';
 
+import {
+  AUTH_SIGNATURE_GRADIENT_BACKGROUND,
+  type PasskeyCTAProps as SharedPasskeyCTAProps,
+} from '../../stitch-hosted-auth/index.js';
+
 const h = React.createElement;
 
-export interface PasskeyCTAProps {
+export interface PasskeyCTAProps
+  extends Omit<
+    SharedPasskeyCTAProps<React.ReactNode, ButtonProps['onClick']>,
+    'children'
+  > {
   children: React.ReactNode;
-  loading?: boolean;
-  disabled?: boolean;
-  onClick?: ButtonProps['onClick'];
-  /** Leading icon (e.g. a passkey glyph). */
-  icon?: React.ReactNode;
-  /** HTML button type. Default `button` so it does not submit forms. */
-  type?: 'button' | 'submit';
 }
 
 /**
@@ -31,8 +33,7 @@ export function PasskeyCTA(props: PasskeyCTAProps): React.ReactElement {
     htmlType: type,
     className: 'facetheory-stitch-passkey-cta',
     style: {
-      background:
-        'linear-gradient(135deg, var(--stitch-color-primary, #1f108e) 0%, var(--stitch-color-primary-container, #3730a3) 100%)',
+      background: AUTH_SIGNATURE_GRADIENT_BACKGROUND,
       border: 'none',
       borderRadius: '9999px',
       height: 48,

--- a/ts/src/react/stitch-hosted-auth/states.ts
+++ b/ts/src/react/stitch-hosted-auth/states.ts
@@ -1,47 +1,17 @@
 import * as React from 'react';
 
+import {
+  authStateClassName,
+  authStateRole,
+  authStateVariantPalette,
+  type AuthStateCardProps as SharedAuthStateCardProps,
+} from '../../stitch-hosted-auth/index.js';
+
 const h = React.createElement;
 
-export type AuthStateVariant = 'info' | 'success' | 'warning' | 'error';
+export type { AuthStateVariant } from '../../stitch-hosted-auth/index.js';
 
-export interface AuthStateCardProps {
-  variant?: AuthStateVariant;
-  title: React.ReactNode;
-  description?: React.ReactNode;
-  /** Leading icon glyph. */
-  icon?: React.ReactNode;
-  /** Actions rendered below the description (e.g. "Try again", "Contact support"). */
-  actions?: React.ReactNode;
-}
-
-interface VariantPalette {
-  accent: string;
-  surface: string;
-  text: string;
-}
-
-const VARIANT_PALETTE: Record<AuthStateVariant, VariantPalette> = {
-  info: {
-    accent: 'var(--stitch-color-primary, #1f108e)',
-    surface: 'var(--stitch-color-surface-container-lowest, #ffffff)',
-    text: 'var(--stitch-color-on-surface, #131b2e)',
-  },
-  success: {
-    accent: 'var(--stitch-color-tertiary, #00332e)',
-    surface: 'var(--stitch-color-surface-container-lowest, #ffffff)',
-    text: 'var(--stitch-color-on-surface, #131b2e)',
-  },
-  warning: {
-    accent: 'var(--stitch-color-error, #ba1a1a)',
-    surface: 'var(--stitch-color-surface-container-lowest, #ffffff)',
-    text: 'var(--stitch-color-on-surface, #131b2e)',
-  },
-  error: {
-    accent: 'var(--stitch-color-error, #ba1a1a)',
-    surface: 'var(--stitch-color-error-container, #ffdad6)',
-    text: 'var(--stitch-color-on-error-container, #93000a)',
-  },
-};
+export type AuthStateCardProps = SharedAuthStateCardProps<React.ReactNode>;
 
 /**
  * Terminal-state hosted-auth card. Covers the `Account Locked`, `Error`,
@@ -51,13 +21,13 @@ const VARIANT_PALETTE: Record<AuthStateVariant, VariantPalette> = {
  */
 export function AuthStateCard(props: AuthStateCardProps): React.ReactElement {
   const { variant = 'info', title, description, icon, actions } = props;
-  const palette = VARIANT_PALETTE[variant];
+  const palette = authStateVariantPalette(variant);
 
   return h(
     'div',
     {
-      className: `facetheory-stitch-auth-state facetheory-stitch-auth-state-${variant}`,
-      role: variant === 'error' || variant === 'warning' ? 'alert' : undefined,
+      className: authStateClassName(variant),
+      role: authStateRole(variant),
       style: {
         width: '100%',
         maxWidth: 440,

--- a/ts/src/stitch-hosted-auth/index.ts
+++ b/ts/src/stitch-hosted-auth/index.ts
@@ -1,0 +1,245 @@
+/**
+ * Shared hosted-auth Stitch contract consumed by the React, Vue, and Svelte
+ * adapters. Framework-specific node, slot, and event payload types stay in
+ * the adapters; deterministic variant, class, and token decisions live here
+ * so the hosted-auth surface cannot drift across adapters.
+ */
+
+export type AuthPageBackground = 'surface' | 'gradient';
+
+export type AuthPasskeyButtonType = 'button' | 'submit';
+
+export type AuthStateVariant = 'info' | 'success' | 'warning' | 'error';
+
+export interface AuthPageLayoutProps<TNode = unknown> {
+  /** Brand mark rendered in the top-left (e.g. logo). */
+  brand?: TNode;
+  /** Background treatment. `gradient` applies the Stitch signature indigo gradient. */
+  background?: AuthPageBackground;
+  /** Right-rail slot for legal / locale / help links rendered at the bottom. */
+  footer?: TNode;
+  children?: TNode;
+}
+
+export interface AuthCardProps<TNode = unknown> {
+  title: TNode;
+  description?: TNode;
+  /** Right-aligned secondary action slot inside the header (e.g. "Sign up"). */
+  headerAction?: TNode;
+  /** Footer slot rendered below the body (e.g. "Trouble signing in?"). */
+  footer?: TNode;
+  children?: TNode;
+}
+
+export interface AuthFlowStep<TDescription = unknown> {
+  key: string;
+  label: string;
+  /** Optional long-form description shown when this step is active. */
+  description?: TDescription;
+}
+
+export interface AuthFlowStepperProps<
+  TStep extends AuthFlowStep = AuthFlowStep,
+> {
+  steps: TStep[];
+  /** Zero-based index of the currently active step. */
+  currentIndex: number;
+}
+
+export interface AuthFlowSectionProps<TNode = unknown> {
+  /** Optional step heading (e.g. "Step 2 of 3"). */
+  eyebrow?: TNode;
+  title?: TNode;
+  description?: TNode;
+  children?: TNode;
+}
+
+export interface PasskeyCTAProps<TNode = unknown, TClick = unknown> {
+  children?: TNode;
+  loading?: boolean;
+  disabled?: boolean;
+  onClick?: TClick;
+  /** Leading icon (e.g. a passkey glyph). */
+  icon?: TNode;
+  /** HTML button type. Default `button` so it does not submit forms. */
+  type?: AuthPasskeyButtonType;
+}
+
+export interface OTPInputProps {
+  /** Number of characters to accept. Default 6. */
+  length?: number;
+  value?: string;
+  onChange?: (value: string) => void;
+  /** Fires when the last digit is entered (useful for auto-submit flows). */
+  onComplete?: (value: string) => void;
+  disabled?: boolean;
+  /** Visually marks the input invalid. Pairs with a caller-supplied error message. */
+  invalid?: boolean;
+  /** Autofocus the first character box on mount. Default `true`. */
+  autoFocus?: boolean;
+}
+
+export interface ConsentItemProps<TNode = unknown> {
+  /** Short label (e.g. "Read your profile"). */
+  label: TNode;
+  /** Long-form description shown under the label. */
+  description?: TNode;
+  /** Leading icon glyph. */
+  icon?: TNode;
+  /** Mark as already granted (greys out the entry). */
+  granted?: boolean;
+}
+
+export interface ConsentListProps<TNode = unknown> {
+  children?: TNode;
+}
+
+export interface AuthStateCardProps<TNode = unknown> {
+  variant?: AuthStateVariant;
+  title: TNode;
+  description?: TNode;
+  /** Leading icon glyph. */
+  icon?: TNode;
+  /** Actions rendered below the description (e.g. "Try again", "Contact support"). */
+  actions?: TNode;
+}
+
+export interface AuthStateVariantPalette {
+  accent: string;
+  surface: string;
+  text: string;
+}
+
+export interface AuthFlowStepState {
+  isCurrent: boolean;
+  isCompleted: boolean;
+  dotColor: string;
+  labelColor: string;
+  labelFontWeight: 400 | 600;
+  ariaCurrent: 'step' | undefined;
+}
+
+export const AUTH_SIGNATURE_GRADIENT_BACKGROUND =
+  'linear-gradient(135deg, var(--stitch-color-primary, #1f108e) 0%, var(--stitch-color-primary-container, #3730a3) 100%)';
+
+export const AUTH_PAGE_SURFACE_BACKGROUND =
+  'var(--stitch-color-surface, #faf8ff)';
+
+export const AUTH_PRIMARY_COLOR = 'var(--stitch-color-primary, #1f108e)';
+
+export const AUTH_INACTIVE_STEP_COLOR =
+  'var(--stitch-color-surface-container-high, #e2e7ff)';
+
+export const AUTH_ON_SURFACE_COLOR =
+  'var(--stitch-color-on-surface, #131b2e)';
+
+export const AUTH_ON_SURFACE_VARIANT_COLOR =
+  'var(--stitch-color-on-surface-variant, #464553)';
+
+export const AUTH_SURFACE_CONTAINER_LOW_BACKGROUND =
+  'var(--stitch-color-surface-container-low, #f2f3ff)';
+
+export const AUTH_SURFACE_CONTAINER_LOWEST_BACKGROUND =
+  'var(--stitch-color-surface-container-lowest, #ffffff)';
+
+export const AUTH_STATE_VARIANT_PALETTE = {
+  info: {
+    accent: AUTH_PRIMARY_COLOR,
+    surface: AUTH_SURFACE_CONTAINER_LOWEST_BACKGROUND,
+    text: AUTH_ON_SURFACE_COLOR,
+  },
+  success: {
+    accent: 'var(--stitch-color-tertiary, #00332e)',
+    surface: AUTH_SURFACE_CONTAINER_LOWEST_BACKGROUND,
+    text: AUTH_ON_SURFACE_COLOR,
+  },
+  warning: {
+    accent: 'var(--stitch-color-error, #ba1a1a)',
+    surface: AUTH_SURFACE_CONTAINER_LOWEST_BACKGROUND,
+    text: AUTH_ON_SURFACE_COLOR,
+  },
+  error: {
+    accent: 'var(--stitch-color-error, #ba1a1a)',
+    surface: 'var(--stitch-color-error-container, #ffdad6)',
+    text: 'var(--stitch-color-on-error-container, #93000a)',
+  },
+} as const satisfies Record<AuthStateVariant, AuthStateVariantPalette>;
+
+export function resolveAuthPageBackground(
+  background: AuthPageBackground = 'surface',
+): string {
+  return background === 'gradient'
+    ? AUTH_SIGNATURE_GRADIENT_BACKGROUND
+    : AUTH_PAGE_SURFACE_BACKGROUND;
+}
+
+export function resolveAuthFlowStepState(
+  index: number,
+  currentIndex: number,
+): AuthFlowStepState {
+  const isCurrent = index === currentIndex;
+  const isCompleted = index < currentIndex;
+
+  return {
+    isCurrent,
+    isCompleted,
+    dotColor:
+      isCompleted || isCurrent ? AUTH_PRIMARY_COLOR : AUTH_INACTIVE_STEP_COLOR,
+    labelColor: isCurrent
+      ? AUTH_ON_SURFACE_COLOR
+      : AUTH_ON_SURFACE_VARIANT_COLOR,
+    labelFontWeight: isCurrent ? 600 : 400,
+    ariaCurrent: isCurrent ? 'step' : undefined,
+  };
+}
+
+export function authConsentItemBackground(
+  granted: boolean | undefined,
+): string {
+  return granted
+    ? AUTH_SURFACE_CONTAINER_LOW_BACKGROUND
+    : AUTH_SURFACE_CONTAINER_LOWEST_BACKGROUND;
+}
+
+export function authConsentItemOpacity(granted: boolean | undefined): number {
+  return granted ? 0.7 : 1;
+}
+
+export function authStateVariantPalette(
+  variant: AuthStateVariant,
+): AuthStateVariantPalette {
+  return AUTH_STATE_VARIANT_PALETTE[variant];
+}
+
+export function authStateRole(
+  variant: AuthStateVariant,
+): 'alert' | undefined {
+  return variant === 'error' || variant === 'warning' ? 'alert' : undefined;
+}
+
+export function authStateClassName(variant: AuthStateVariant): string {
+  return `facetheory-stitch-auth-state facetheory-stitch-auth-state-${variant}`;
+}
+
+export function authOtpInputClassName(invalid: boolean | undefined): string {
+  return invalid
+    ? 'facetheory-stitch-otp-input facetheory-stitch-otp-input-invalid'
+    : 'facetheory-stitch-otp-input';
+}
+
+export function splitAuthOtpValue(value: string, length: number): string[] {
+  const chars = value.slice(0, length).split('');
+  while (chars.length < length) chars.push('');
+  return chars;
+}
+
+export function updateAuthOtpValueAtIndex(
+  value: string,
+  length: number,
+  index: number,
+  nextChar: string,
+): string {
+  const chars = splitAuthOtpValue(value, length);
+  chars[index] = nextChar.slice(-1);
+  return chars.join('').slice(0, length).trimEnd();
+}

--- a/ts/src/svelte/stitch-hosted-auth/AuthFlowStepper.svelte
+++ b/ts/src/svelte/stitch-hosted-auth/AuthFlowStepper.svelte
@@ -1,12 +1,25 @@
 <script lang="ts">
-  export interface AuthFlowStep {
-    key: string;
-    label: string;
-    description?: unknown;
-  }
+  import { resolveAuthFlowStepState } from '../../stitch-hosted-auth/index.js';
+  import type { AuthFlowStep } from '../../stitch-hosted-auth/index.js';
 
   export let steps: AuthFlowStep[] = [];
   export let currentIndex: number;
+
+  function stepAriaCurrent(index: number): 'step' | undefined {
+    return resolveAuthFlowStepState(index, currentIndex).ariaCurrent;
+  }
+
+  function stepDotColor(index: number): string {
+    return resolveAuthFlowStepState(index, currentIndex).dotColor;
+  }
+
+  function stepLabelColor(index: number): string {
+    return resolveAuthFlowStepState(index, currentIndex).labelColor;
+  }
+
+  function stepLabelWeight(index: number): 400 | 600 {
+    return resolveAuthFlowStepState(index, currentIndex).labelFontWeight;
+  }
 </script>
 
 <ol
@@ -15,23 +28,15 @@
 >
   {#each steps as step, index (step.key)}
     <li
-      aria-current={index === currentIndex ? 'step' : undefined}
+      aria-current={stepAriaCurrent(index)}
       style="display:flex;align-items:center;gap:8px;"
     >
       <span
         aria-hidden="true"
-        style={`width:10px;height:10px;border-radius:9999px;display:inline-block;background:${
-          index < currentIndex || index === currentIndex
-            ? 'var(--stitch-color-primary, #1f108e)'
-            : 'var(--stitch-color-surface-container-high, #e2e7ff)'
-        };`}
+        style={`width:10px;height:10px;border-radius:9999px;display:inline-block;background:${stepDotColor(index)};`}
       />
       <span
-        style={`font-size:12px;text-transform:uppercase;letter-spacing:0.08em;color:${
-          index === currentIndex
-            ? 'var(--stitch-color-on-surface, #131b2e)'
-            : 'var(--stitch-color-on-surface-variant, #464553)'
-        };font-weight:${index === currentIndex ? 600 : 400};`}
+        style={`font-size:12px;text-transform:uppercase;letter-spacing:0.08em;color:${stepLabelColor(index)};font-weight:${stepLabelWeight(index)};`}
       >
         {step.label}
       </span>

--- a/ts/src/svelte/stitch-hosted-auth/AuthPageLayout.svelte
+++ b/ts/src/svelte/stitch-hosted-auth/AuthPageLayout.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  export let background: 'surface' | 'gradient' = 'surface';
+  import { resolveAuthPageBackground } from '../../stitch-hosted-auth/index.js';
+  import type { AuthPageBackground } from '../../stitch-hosted-auth/index.js';
 
-  $: backgroundStyle =
-    background === 'gradient'
-      ? 'linear-gradient(135deg, var(--stitch-color-primary, #1f108e) 0%, var(--stitch-color-primary-container, #3730a3) 100%)'
-      : 'var(--stitch-color-surface, #faf8ff)';
+  export let background: AuthPageBackground = 'surface';
+
+  $: backgroundStyle = resolveAuthPageBackground(background);
 </script>
 
 <div

--- a/ts/src/svelte/stitch-hosted-auth/AuthStateCard.svelte
+++ b/ts/src/svelte/stitch-hosted-auth/AuthStateCard.svelte
@@ -1,42 +1,21 @@
 <script lang="ts">
-  export type AuthStateVariant = 'info' | 'success' | 'warning' | 'error';
+  import {
+    authStateClassName,
+    authStateRole,
+    authStateVariantPalette,
+  } from '../../stitch-hosted-auth/index.js';
+  import type { AuthStateVariant } from '../../stitch-hosted-auth/index.js';
 
   export let variant: AuthStateVariant = 'info';
   export let title: unknown;
   export let description: unknown = undefined;
 
-  const variantPalette: Record<
-    AuthStateVariant,
-    { accent: string; surface: string; text: string }
-  > = {
-    info: {
-      accent: 'var(--stitch-color-primary, #1f108e)',
-      surface: 'var(--stitch-color-surface-container-lowest, #ffffff)',
-      text: 'var(--stitch-color-on-surface, #131b2e)',
-    },
-    success: {
-      accent: 'var(--stitch-color-tertiary, #00332e)',
-      surface: 'var(--stitch-color-surface-container-lowest, #ffffff)',
-      text: 'var(--stitch-color-on-surface, #131b2e)',
-    },
-    warning: {
-      accent: 'var(--stitch-color-error, #ba1a1a)',
-      surface: 'var(--stitch-color-surface-container-lowest, #ffffff)',
-      text: 'var(--stitch-color-on-surface, #131b2e)',
-    },
-    error: {
-      accent: 'var(--stitch-color-error, #ba1a1a)',
-      surface: 'var(--stitch-color-error-container, #ffdad6)',
-      text: 'var(--stitch-color-on-error-container, #93000a)',
-    },
-  };
-
-  $: palette = variantPalette[variant];
+  $: palette = authStateVariantPalette(variant);
 </script>
 
 <div
-  class={`facetheory-stitch-auth-state facetheory-stitch-auth-state-${variant}`}
-  role={variant === 'error' || variant === 'warning' ? 'alert' : undefined}
+  class={authStateClassName(variant)}
+  role={authStateRole(variant)}
   style={`width:100%;max-width:440px;background:${palette.surface};color:${palette.text};border-radius:var(--stitch-radius-xl, 16px);padding:40px;display:flex;flex-direction:column;gap:16px;align-items:center;text-align:center;box-shadow:0 24px 48px -12px rgba(19, 27, 46, 0.04);`}
 >
   <div

--- a/ts/src/svelte/stitch-hosted-auth/ConsentItem.svelte
+++ b/ts/src/svelte/stitch-hosted-auth/ConsentItem.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+  import {
+    authConsentItemBackground,
+    authConsentItemOpacity,
+  } from '../../stitch-hosted-auth/index.js';
+
   export let label: unknown;
   export let description: unknown = undefined;
   export let granted = false;
@@ -6,11 +11,7 @@
 
 <li
   class="facetheory-stitch-consent-item"
-  style={`display:flex;align-items:flex-start;gap:12px;padding:12px 16px;background:${
-    granted
-      ? 'var(--stitch-color-surface-container-low, #f2f3ff)'
-      : 'var(--stitch-color-surface-container-lowest, #ffffff)'
-  };border-radius:var(--stitch-radius-md, 6px);opacity:${granted ? 0.7 : 1};`}
+  style={`display:flex;align-items:flex-start;gap:12px;padding:12px 16px;background:${authConsentItemBackground(granted)};border-radius:var(--stitch-radius-md, 6px);opacity:${authConsentItemOpacity(granted)};`}
 >
   <span
     aria-hidden="true"

--- a/ts/src/svelte/stitch-hosted-auth/OTPInput.svelte
+++ b/ts/src/svelte/stitch-hosted-auth/OTPInput.svelte
@@ -1,4 +1,10 @@
 <script lang="ts">
+  import {
+    authOtpInputClassName,
+    splitAuthOtpValue,
+    updateAuthOtpValueAtIndex,
+  } from '../../stitch-hosted-auth/index.js';
+
   export let length = 6;
   export let value: string | undefined = undefined;
   export let onChange: ((value: string) => void) | undefined = undefined;
@@ -11,16 +17,13 @@
 
   $: currentValue = value ?? internalValue;
 
-  function splitValue(raw: string): string[] {
-    const chars = raw.slice(0, length).split('');
-    while (chars.length < length) chars.push('');
-    return chars;
-  }
-
   function updateIndex(index: number, nextChar: string): void {
-    const chars = splitValue(currentValue);
-    chars[index] = nextChar.slice(-1);
-    const nextValue = chars.join('').slice(0, length).trimEnd();
+    const nextValue = updateAuthOtpValueAtIndex(
+      currentValue,
+      length,
+      index,
+      nextChar,
+    );
     internalValue = nextValue;
     onChange?.(nextValue);
     if (nextValue.length === length) onComplete?.(nextValue);
@@ -28,11 +31,10 @@
 </script>
 
 <div
-  class:facetheory-stitch-otp-input={true}
-  class:facetheory-stitch-otp-input-invalid={invalid}
+  class={authOtpInputClassName(invalid)}
   style="display:flex;gap:8px;"
 >
-  {#each splitValue(currentValue) as char, index (index)}
+  {#each splitAuthOtpValue(currentValue, length) as char, index (index)}
     <input
       value={char}
       maxlength="1"

--- a/ts/src/svelte/stitch-hosted-auth/PasskeyCTA.svelte
+++ b/ts/src/svelte/stitch-hosted-auth/PasskeyCTA.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+  import { AUTH_SIGNATURE_GRADIENT_BACKGROUND } from '../../stitch-hosted-auth/index.js';
+  import type { AuthPasskeyButtonType } from '../../stitch-hosted-auth/index.js';
+
   export let loading = false;
   export let disabled = false;
   export let onClick: ((event: MouseEvent) => void) | undefined = undefined;
-  export let type: 'button' | 'submit' = 'button';
+  export let type: AuthPasskeyButtonType = 'button';
 </script>
 
 <button
@@ -11,7 +14,7 @@
   disabled={disabled || loading}
   aria-busy={loading ? 'true' : undefined}
   on:click={onClick}
-  style="width:100%;display:inline-flex;align-items:center;justify-content:center;gap:10px;background:linear-gradient(135deg, var(--stitch-color-primary, #1f108e) 0%, var(--stitch-color-primary-container, #3730a3) 100%);border:none;border-radius:9999px;height:48px;font-weight:600;font-size:15px;color:#ffffff;cursor:pointer;"
+  style={`width:100%;display:inline-flex;align-items:center;justify-content:center;gap:10px;background:${AUTH_SIGNATURE_GRADIENT_BACKGROUND};border:none;border-radius:9999px;height:48px;font-weight:600;font-size:15px;color:#ffffff;cursor:pointer;`}
 >
   <slot name="icon" />
   {#if loading}

--- a/ts/src/svelte/stitch-hosted-auth/index.d.ts
+++ b/ts/src/svelte/stitch-hosted-auth/index.d.ts
@@ -1,70 +1,65 @@
 import type { Component } from 'svelte';
+import type {
+  AuthCardProps as SharedAuthCardProps,
+  AuthFlowSectionProps as SharedAuthFlowSectionProps,
+  AuthFlowStepperProps as SharedAuthFlowStepperProps,
+  AuthPageLayoutProps as SharedAuthPageLayoutProps,
+  AuthStateCardProps as SharedAuthStateCardProps,
+  ConsentItemProps as SharedConsentItemProps,
+  PasskeyCTAProps as SharedPasskeyCTAProps,
+} from '../../stitch-hosted-auth/index.js';
 
-export interface AuthPageLayoutProps {
-  background?: 'surface' | 'gradient';
-}
+export type {
+  AuthFlowStep,
+  AuthPageBackground,
+  AuthPasskeyButtonType,
+  AuthStateVariant,
+  ConsentListProps,
+  OTPInputProps,
+} from '../../stitch-hosted-auth/index.js';
 
-export interface AuthCardProps {
-  title: unknown;
-  description?: unknown;
-}
+export type AuthPageLayoutProps = Pick<
+  SharedAuthPageLayoutProps,
+  'background'
+>;
 
-export interface AuthFlowStep {
-  key: string;
-  label: string;
-  description?: unknown;
-}
+export type AuthCardProps = Pick<
+  SharedAuthCardProps,
+  'title' | 'description'
+>;
 
-export interface AuthFlowStepperProps {
-  steps: AuthFlowStep[];
-  currentIndex: number;
-}
+export type AuthFlowStepperProps = SharedAuthFlowStepperProps;
 
-export interface AuthFlowSectionProps {
-  eyebrow?: unknown;
-  title?: unknown;
-  description?: unknown;
-}
+export type AuthFlowSectionProps = Pick<
+  SharedAuthFlowSectionProps,
+  'eyebrow' | 'title' | 'description'
+>;
 
-export interface PasskeyCTAProps {
-  loading?: boolean;
-  disabled?: boolean;
-  onClick?: (event: MouseEvent) => void;
-  type?: 'button' | 'submit';
-}
+export type PasskeyCTAProps = Pick<
+  SharedPasskeyCTAProps<unknown, (event: MouseEvent) => void>,
+  'loading' | 'disabled' | 'onClick' | 'type'
+>;
 
-export interface OTPInputProps {
-  length?: number;
-  value?: string;
-  onChange?: (value: string) => void;
-  onComplete?: (value: string) => void;
-  disabled?: boolean;
-  invalid?: boolean;
-  autoFocus?: boolean;
-}
+export type ConsentItemProps = Pick<
+  SharedConsentItemProps,
+  'label' | 'description' | 'granted'
+>;
 
-export interface ConsentItemProps {
-  label: unknown;
-  description?: unknown;
-  granted?: boolean;
-}
-
-export type ConsentListProps = Record<string, never>;
-
-export type AuthStateVariant = 'info' | 'success' | 'warning' | 'error';
-
-export interface AuthStateCardProps {
-  variant?: AuthStateVariant;
-  title: unknown;
-  description?: unknown;
-}
+export type AuthStateCardProps = Pick<
+  SharedAuthStateCardProps,
+  'variant' | 'title' | 'description'
+>;
 
 export declare const AuthPageLayout: Component<AuthPageLayoutProps>;
 export declare const AuthCard: Component<AuthCardProps>;
 export declare const AuthFlowStepper: Component<AuthFlowStepperProps>;
 export declare const AuthFlowSection: Component<AuthFlowSectionProps>;
 export declare const PasskeyCTA: Component<PasskeyCTAProps>;
-export declare const OTPInput: Component<OTPInputProps>;
+export declare const OTPInput: Component<
+  import('../../stitch-hosted-auth/index.js').OTPInputProps
+>;
 export declare const ConsentItem: Component<ConsentItemProps>;
-export declare const ConsentList: Component<ConsentListProps>;
+export declare const ConsentList: Component<
+  import('../../stitch-hosted-auth/index.js').ConsentListProps
+>;
 export declare const AuthStateCard: Component<AuthStateCardProps>;

--- a/ts/src/svelte/stitch-hosted-auth/index.ts
+++ b/ts/src/svelte/stitch-hosted-auth/index.ts
@@ -11,3 +11,19 @@ export { default as ConsentItem } from './ConsentItem.svelte';
 export { default as ConsentList } from './ConsentList.svelte';
 
 export { default as AuthStateCard } from './AuthStateCard.svelte';
+
+export type {
+  AuthCardProps,
+  AuthFlowSectionProps,
+  AuthFlowStep,
+  AuthFlowStepperProps,
+  AuthPageBackground,
+  AuthPageLayoutProps,
+  AuthPasskeyButtonType,
+  AuthStateCardProps,
+  AuthStateVariant,
+  ConsentItemProps,
+  ConsentListProps,
+  OTPInputProps,
+  PasskeyCTAProps,
+} from '../../stitch-hosted-auth/index.js';

--- a/ts/src/vue/stitch-hosted-auth/consent.ts
+++ b/ts/src/vue/stitch-hosted-auth/consent.ts
@@ -1,6 +1,11 @@
 import { defineComponent, h } from 'vue';
 
 import {
+  authConsentItemBackground,
+  authConsentItemOpacity,
+} from '../../stitch-hosted-auth/index.js';
+
+import {
   renderDefaultSlot,
   renderPropContent,
   vnodeChildProp,
@@ -25,11 +30,9 @@ export const ConsentItem = defineComponent({
             alignItems: 'flex-start',
             gap: '12px',
             padding: '12px 16px',
-            background: props.granted
-              ? 'var(--stitch-color-surface-container-low, #f2f3ff)'
-              : 'var(--stitch-color-surface-container-lowest, #ffffff)',
+            background: authConsentItemBackground(props.granted),
             borderRadius: 'var(--stitch-radius-md, 6px)',
-            opacity: props.granted ? 0.7 : 1,
+            opacity: authConsentItemOpacity(props.granted),
           },
         },
         [

--- a/ts/src/vue/stitch-hosted-auth/flow.ts
+++ b/ts/src/vue/stitch-hosted-auth/flow.ts
@@ -1,17 +1,16 @@
 import { defineComponent, h } from 'vue';
 import type { PropType } from 'vue';
 
+import { resolveAuthFlowStepState } from '../../stitch-hosted-auth/index.js';
+import type { AuthFlowStep } from '../../stitch-hosted-auth/index.js';
+
 import {
   renderDefaultSlot,
   renderPropContent,
   vnodeChildProp,
 } from '../stitch-common.js';
 
-export interface AuthFlowStep {
-  key: string;
-  label: string;
-  description?: unknown;
-}
+export type { AuthFlowStep } from '../../stitch-hosted-auth/index.js';
 
 export const AuthFlowStepper = defineComponent({
   name: 'FaceTheoryVueAuthFlowStepper',
@@ -41,21 +40,16 @@ export const AuthFlowStepper = defineComponent({
           },
         },
         props.steps.map((step, index) => {
-          const isCurrent = index === props.currentIndex;
-          const isCompleted = index < props.currentIndex;
-          const dotColor =
-            isCompleted || isCurrent
-              ? 'var(--stitch-color-primary, #1f108e)'
-              : 'var(--stitch-color-surface-container-high, #e2e7ff)';
-          const labelColor = isCurrent
-            ? 'var(--stitch-color-on-surface, #131b2e)'
-            : 'var(--stitch-color-on-surface-variant, #464553)';
+          const stepState = resolveAuthFlowStepState(
+            index,
+            props.currentIndex,
+          );
 
           return h(
             'li',
             {
               key: step.key,
-              'aria-current': isCurrent ? 'step' : undefined,
+              'aria-current': stepState.ariaCurrent,
               style: { display: 'flex', alignItems: 'center', gap: '8px' },
             },
             [
@@ -65,7 +59,7 @@ export const AuthFlowStepper = defineComponent({
                   width: '10px',
                   height: '10px',
                   borderRadius: '9999px',
-                  background: dotColor,
+                  background: stepState.dotColor,
                   display: 'inline-block',
                 },
               }),
@@ -76,8 +70,8 @@ export const AuthFlowStepper = defineComponent({
                     fontSize: '12px',
                     textTransform: 'uppercase',
                     letterSpacing: '0.08em',
-                    color: labelColor,
-                    fontWeight: isCurrent ? 600 : 400,
+                    color: stepState.labelColor,
+                    fontWeight: stepState.labelFontWeight,
                   },
                 },
                 step.label,

--- a/ts/src/vue/stitch-hosted-auth/index.ts
+++ b/ts/src/vue/stitch-hosted-auth/index.ts
@@ -1,6 +1,6 @@
 export { AuthPageLayout, AuthCard } from './layout.js';
 
-export { AuthFlowStepper, AuthFlowSection, type AuthFlowStep } from './flow.js';
+export { AuthFlowStepper, AuthFlowSection } from './flow.js';
 
 export { PasskeyCTA } from './passkey.js';
 
@@ -8,4 +8,20 @@ export { OTPInput } from './otp.js';
 
 export { ConsentItem, ConsentList } from './consent.js';
 
-export { AuthStateCard, type AuthStateVariant } from './states.js';
+export { AuthStateCard } from './states.js';
+
+export type {
+  AuthCardProps,
+  AuthFlowSectionProps,
+  AuthFlowStep,
+  AuthFlowStepperProps,
+  AuthPageBackground,
+  AuthPageLayoutProps,
+  AuthPasskeyButtonType,
+  AuthStateCardProps,
+  AuthStateVariant,
+  ConsentItemProps,
+  ConsentListProps,
+  OTPInputProps,
+  PasskeyCTAProps,
+} from '../../stitch-hosted-auth/index.js';

--- a/ts/src/vue/stitch-hosted-auth/layout.ts
+++ b/ts/src/vue/stitch-hosted-auth/layout.ts
@@ -1,5 +1,8 @@
 import { defineComponent, h } from 'vue';
 
+import { resolveAuthPageBackground } from '../../stitch-hosted-auth/index.js';
+import type { AuthPageBackground } from '../../stitch-hosted-auth/index.js';
+
 import {
   renderDefaultSlot,
   renderPropContent,
@@ -11,22 +14,16 @@ export const AuthPageLayout = defineComponent({
   props: {
     brand: vnodeChildProp,
     background: {
-      type: String as () => 'surface' | 'gradient',
+      type: String as () => AuthPageBackground,
       default: 'surface',
     },
     footer: vnodeChildProp,
   },
   setup(props, { slots }) {
     return () => {
-      const backgroundStyle =
-        props.background === 'gradient'
-          ? {
-              background:
-                'linear-gradient(135deg, var(--stitch-color-primary, #1f108e) 0%, var(--stitch-color-primary-container, #3730a3) 100%)',
-            }
-          : {
-              background: 'var(--stitch-color-surface, #faf8ff)',
-            };
+      const backgroundStyle = {
+        background: resolveAuthPageBackground(props.background),
+      };
 
       return h(
         'div',

--- a/ts/src/vue/stitch-hosted-auth/otp.ts
+++ b/ts/src/vue/stitch-hosted-auth/otp.ts
@@ -1,11 +1,12 @@
 import { computed, defineComponent, h, ref } from 'vue';
 import type { PropType } from 'vue';
 
-function splitOtp(value: string, length: number): string[] {
-  const chars = value.slice(0, length).split('');
-  while (chars.length < length) chars.push('');
-  return chars;
-}
+import {
+  authOtpInputClassName,
+  splitAuthOtpValue,
+  updateAuthOtpValueAtIndex,
+} from '../../stitch-hosted-auth/index.js';
+import type { OTPInputProps } from '../../stitch-hosted-auth/index.js';
 
 export const OTPInput = defineComponent({
   name: 'FaceTheoryVueOTPInput',
@@ -13,11 +14,11 @@ export const OTPInput = defineComponent({
     length: { type: Number, default: 6 },
     value: { type: String, required: false },
     onChange: {
-      type: Function as PropType<((value: string) => void) | undefined>,
+      type: Function as PropType<OTPInputProps['onChange']>,
       required: false,
     },
     onComplete: {
-      type: Function as PropType<((value: string) => void) | undefined>,
+      type: Function as PropType<OTPInputProps['onComplete']>,
       required: false,
     },
     disabled: { type: Boolean, default: false },
@@ -29,9 +30,12 @@ export const OTPInput = defineComponent({
     const renderedValue = computed(() => props.value ?? internalValue.value);
 
     function updateIndex(index: number, nextChar: string): void {
-      const chars = splitOtp(renderedValue.value, props.length);
-      chars[index] = nextChar.slice(-1);
-      const nextValue = chars.join('').slice(0, props.length).trimEnd();
+      const nextValue = updateAuthOtpValueAtIndex(
+        renderedValue.value,
+        props.length,
+        index,
+        nextChar,
+      );
       internalValue.value = nextValue;
       props.onChange?.(nextValue);
       if (nextValue.length === props.length) props.onComplete?.(nextValue);
@@ -41,18 +45,13 @@ export const OTPInput = defineComponent({
       h(
         'div',
         {
-          class: [
-            'facetheory-stitch-otp-input',
-            props.invalid ? 'facetheory-stitch-otp-input-invalid' : null,
-          ]
-            .filter(Boolean)
-            .join(' '),
+          class: authOtpInputClassName(props.invalid),
           style: {
             display: 'flex',
             gap: '8px',
           },
         },
-        splitOtp(renderedValue.value, props.length).map((char, index) =>
+        splitAuthOtpValue(renderedValue.value, props.length).map((char, index) =>
           h('input', {
             key: index,
             value: char,

--- a/ts/src/vue/stitch-hosted-auth/passkey.ts
+++ b/ts/src/vue/stitch-hosted-auth/passkey.ts
@@ -1,6 +1,9 @@
 import { defineComponent, h } from 'vue';
 import type { PropType } from 'vue';
 
+import { AUTH_SIGNATURE_GRADIENT_BACKGROUND } from '../../stitch-hosted-auth/index.js';
+import type { AuthPasskeyButtonType } from '../../stitch-hosted-auth/index.js';
+
 import {
   renderDefaultSlot,
   renderPropContent,
@@ -18,7 +21,7 @@ export const PasskeyCTA = defineComponent({
     },
     icon: vnodeChildProp,
     type: {
-      type: String as () => 'button' | 'submit',
+      type: String as () => AuthPasskeyButtonType,
       default: 'button',
     },
   },
@@ -38,8 +41,7 @@ export const PasskeyCTA = defineComponent({
             alignItems: 'center',
             justifyContent: 'center',
             gap: '10px',
-            background:
-              'linear-gradient(135deg, var(--stitch-color-primary, #1f108e) 0%, var(--stitch-color-primary-container, #3730a3) 100%)',
+            background: AUTH_SIGNATURE_GRADIENT_BACKGROUND,
             border: 'none',
             borderRadius: '9999px',
             height: '48px',

--- a/ts/src/vue/stitch-hosted-auth/states.ts
+++ b/ts/src/vue/stitch-hosted-auth/states.ts
@@ -1,37 +1,15 @@
 import { defineComponent, h } from 'vue';
 
+import {
+  authStateClassName,
+  authStateRole,
+  authStateVariantPalette,
+} from '../../stitch-hosted-auth/index.js';
+import type { AuthStateVariant } from '../../stitch-hosted-auth/index.js';
+
 import { renderPropContent, vnodeChildProp } from '../stitch-common.js';
 
-export type AuthStateVariant = 'info' | 'success' | 'warning' | 'error';
-
-interface VariantPalette {
-  accent: string;
-  surface: string;
-  text: string;
-}
-
-const variantPalette: Record<AuthStateVariant, VariantPalette> = {
-  info: {
-    accent: 'var(--stitch-color-primary, #1f108e)',
-    surface: 'var(--stitch-color-surface-container-lowest, #ffffff)',
-    text: 'var(--stitch-color-on-surface, #131b2e)',
-  },
-  success: {
-    accent: 'var(--stitch-color-tertiary, #00332e)',
-    surface: 'var(--stitch-color-surface-container-lowest, #ffffff)',
-    text: 'var(--stitch-color-on-surface, #131b2e)',
-  },
-  warning: {
-    accent: 'var(--stitch-color-error, #ba1a1a)',
-    surface: 'var(--stitch-color-surface-container-lowest, #ffffff)',
-    text: 'var(--stitch-color-on-surface, #131b2e)',
-  },
-  error: {
-    accent: 'var(--stitch-color-error, #ba1a1a)',
-    surface: 'var(--stitch-color-error-container, #ffdad6)',
-    text: 'var(--stitch-color-on-error-container, #93000a)',
-  },
-};
+export type { AuthStateVariant } from '../../stitch-hosted-auth/index.js';
 
 export const AuthStateCard = defineComponent({
   name: 'FaceTheoryVueAuthStateCard',
@@ -47,16 +25,13 @@ export const AuthStateCard = defineComponent({
   },
   setup(props) {
     return () => {
-      const palette = variantPalette[props.variant];
+      const palette = authStateVariantPalette(props.variant);
 
       return h(
         'div',
         {
-          class: `facetheory-stitch-auth-state facetheory-stitch-auth-state-${props.variant}`,
-          role:
-            props.variant === 'error' || props.variant === 'warning'
-              ? 'alert'
-              : undefined,
+          class: authStateClassName(props.variant),
+          role: authStateRole(props.variant),
           style: {
             width: '100%',
             maxWidth: '440px',

--- a/ts/test/unit/stitch-hosted-auth.test.ts
+++ b/ts/test/unit/stitch-hosted-auth.test.ts
@@ -3,6 +3,28 @@ import test from 'node:test';
 
 import * as React from 'react';
 
+import {
+  AUTH_INACTIVE_STEP_COLOR,
+  AUTH_ON_SURFACE_COLOR,
+  AUTH_ON_SURFACE_VARIANT_COLOR,
+  AUTH_PAGE_SURFACE_BACKGROUND,
+  AUTH_PRIMARY_COLOR,
+  AUTH_SIGNATURE_GRADIENT_BACKGROUND,
+  AUTH_SURFACE_CONTAINER_LOW_BACKGROUND,
+  AUTH_SURFACE_CONTAINER_LOWEST_BACKGROUND,
+  authConsentItemBackground,
+  authConsentItemOpacity,
+  authOtpInputClassName,
+  authStateClassName,
+  authStateRole,
+  authStateVariantPalette,
+  resolveAuthFlowStepState,
+  resolveAuthPageBackground,
+  splitAuthOtpValue,
+  updateAuthOtpValueAtIndex,
+  type AuthFlowStep,
+} from '../../src/stitch-hosted-auth/index.js';
+
 import { createFaceApp } from '../../src/app.js';
 import { createReactFace } from '../../src/adapters/react.js';
 import { createAntdIntegration } from '../../src/react/antd.js';
@@ -19,6 +41,68 @@ import {
 } from '../../src/react/stitch-hosted-auth/index.js';
 
 const h = React.createElement;
+
+
+test('stitch-hosted-auth shared core contract resolves deterministic values', () => {
+  const step = {
+    key: 'verify',
+    label: 'Verify',
+    description: 'Confirm the one-time code',
+  } satisfies AuthFlowStep<string>;
+
+  assert.deepEqual(step, {
+    key: 'verify',
+    label: 'Verify',
+    description: 'Confirm the one-time code',
+  });
+  assert.equal(resolveAuthPageBackground('surface'), AUTH_PAGE_SURFACE_BACKGROUND);
+  assert.equal(
+    resolveAuthPageBackground('gradient'),
+    AUTH_SIGNATURE_GRADIENT_BACKGROUND,
+  );
+  assert.deepEqual(resolveAuthFlowStepState(1, 1), {
+    isCurrent: true,
+    isCompleted: false,
+    dotColor: AUTH_PRIMARY_COLOR,
+    labelColor: AUTH_ON_SURFACE_COLOR,
+    labelFontWeight: 600,
+    ariaCurrent: 'step',
+  });
+  assert.deepEqual(resolveAuthFlowStepState(2, 1), {
+    isCurrent: false,
+    isCompleted: false,
+    dotColor: AUTH_INACTIVE_STEP_COLOR,
+    labelColor: AUTH_ON_SURFACE_VARIANT_COLOR,
+    labelFontWeight: 400,
+    ariaCurrent: undefined,
+  });
+  assert.equal(
+    authConsentItemBackground(true),
+    AUTH_SURFACE_CONTAINER_LOW_BACKGROUND,
+  );
+  assert.equal(
+    authConsentItemBackground(false),
+    AUTH_SURFACE_CONTAINER_LOWEST_BACKGROUND,
+  );
+  assert.equal(authConsentItemOpacity(true), 0.7);
+  assert.equal(authConsentItemOpacity(false), 1);
+  assert.equal(authStateRole('warning'), 'alert');
+  assert.equal(authStateRole('success'), undefined);
+  assert.equal(
+    authStateClassName('error'),
+    'facetheory-stitch-auth-state facetheory-stitch-auth-state-error',
+  );
+  assert.equal(
+    authStateVariantPalette('error').surface,
+    'var(--stitch-color-error-container, #ffdad6)',
+  );
+  assert.equal(
+    authOtpInputClassName(true),
+    'facetheory-stitch-otp-input facetheory-stitch-otp-input-invalid',
+  );
+  assert.deepEqual(splitAuthOtpValue('12', 4), ['1', '2', '', '']);
+  assert.equal(updateAuthOtpValueAtIndex('12', 4, 2, '9'), '129');
+});
 
 async function renderSSR(element: React.ReactElement): Promise<string> {
   const app = createFaceApp({


### PR DESCRIPTION
## Milestone
M8 stitch-hosted-auth-core — add the shared `stitch-hosted-auth` core contract for THE-2479.

## Linear
Refs THE-2479
https://linear.app/theorycloud/issue/THE-2479/ft-strengthen-19-add-a-shared-stitch-hosted-auth-core-contract

## Render modes and adapters affected
- Render modes: none (component contract consolidation only)
- Adapters: React, Vue, Svelte hosted-auth surfaces consume the shared core contract

## Determinism impact
Preserves rendered output. Shared helpers centralize deterministic tokens/classes/variant/OTP decisions without moving framework rendering internals into core.

## Backward compatibility
Additive; no intentional 3.x consumer break.

## Changes
- Add `ts/src/stitch-hosted-auth/index.ts` shared hosted-auth types/helpers.
- Add the `./stitch-hosted-auth` package subpath export.
- Refactor React/Vue/Svelte hosted-auth adapters to consume shared core types/logic.
- Extend hosted-auth unit coverage for the shared core contract.

## Validation
- `cd ts && node --import tsx --test --test-concurrency=1 test/unit/stitch-hosted-auth.test.ts test/unit/vue-stitch-hosted-auth.test.ts` — passed (14 tests)
- `cd ts && npm run check` — passed (631 tests, 630 pass, 1 skipped)
- `git diff --check origin/theorymcp/theorycloud/facetheory/product-strengthening-plans-2026-07-02..HEAD` — passed
- `git log --show-signature origin/theorymcp/theorycloud/facetheory/product-strengthening-plans-2026-07-02..HEAD` — good git signature verified for c0936dc

## Cross-repo coordination
Autheory notification remains a release follow-up through Factory/user before release; no outbound consultation/email was sent from this implementation session.