### PR TITLE
feat: consumer testing and telemetry surface

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -63,8 +63,13 @@ FaceTheory `createFaceApp({ observability: ... })` supports:
   - `event: "facetheory.request.completed"`
   - `requestId`, `routePattern`, `mode`, `status`, `durationMs`, `renderMs`, `isrState`, `isStream`, `errorClass`
 - `observability.metric(record)`:
-  - `facetheory.request` counter (tags include `route_pattern`, `mode`, `status`, `isr_state`, `error_class`)
+  - `facetheory.request` counter (tags include `route_pattern`, `mode`, `status`, `isr_state`, `error_class`, and `cold_start`; the first request handled by a FaceApp instance reports `cold_start: "1"`, later requests report `"0"`)
   - `facetheory.render_ms` timing for requests that actually rendered
+  - `facetheory.isr.cache` counter for ISR responses (tags include `state: hit|miss|stale|wait-hit|stale-metadata-error`, `route_pattern`, and `status`)
+  - `facetheory.isr.regeneration_ms` timing for ISR regeneration attempts, distinct from Face render timing and tagged with `outcome`
+  - `facetheory.isr.lease_contention` counter when an ISR request observes another active regeneration lease
+  - `facetheory.stream_error` counter when a non-strict streaming body fails after bytes have started
+- `observability.log(record)` also receives `event: "facetheory.stream_error"` when a non-strict streaming response emits the bounded `<template data-facetheory-stream-error="true">` marker after a body failure. This log is emitted in addition to the historical `console.error` and the response bytes remain unchanged by telemetry hooks.
 - `observability.onError(err, ctx)`:
   - Receives the original thrown value when FaceTheory converts an internal failure into a deterministic response, fallback fragment, sidecar miss, or degraded ISR state.
   - The hook is for telemetry only; rendered error HTML remains bounded and does not include the thrown message or stack.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -30,6 +30,10 @@ This document describes production hardening guidance for FaceTheory apps and th
   - Emit structured, parseable JSON logs (one record per request minimum).
   - Emit minimal metrics (request count, render duration; ISR state counts; React shell/all-ready readiness timing if streaming).
 
+- Client hydration failure beacons:
+  - Wire `reportHydrationFailure({ endpoint })` from `@theory-cloud/facetheory/client` into framework hydrate error hooks only when the application has a same-origin collection route.
+  - The helper is opt-in and does nothing unless the consumer calls the returned reporter.
+
 ## Observability
 
 ### Request ID conventions
@@ -41,6 +45,7 @@ This document describes production hardening guidance for FaceTheory apps and th
   FaceTheory request as `x-request-id` to keep correlation consistent across both runtimes.
 
 AWS example (`infra/apptheory-ssg-isr-site/`) additionally:
+
 - Sets `x-request-id` in a CloudFront viewer-request function (defaulting to the CloudFront request ID).
 - Echoes `x-request-id` back to the viewer for S3 and SSR responses via a viewer-response function.
 
@@ -53,6 +58,7 @@ AWS example (`infra/apptheory-ssg-isr-site/`) additionally:
 ### Structured logs and minimal metrics
 
 FaceTheory `createFaceApp({ observability: ... })` supports:
+
 - `observability.log(record)`:
   - `event: "facetheory.request.completed"`
   - `requestId`, `routePattern`, `mode`, `status`, `durationMs`, `renderMs`, `isrState`, `isStream`, `errorClass`
@@ -64,7 +70,34 @@ FaceTheory `createFaceApp({ observability: ... })` supports:
   - The hook is for telemetry only; rendered error HTML remains bounded and does not include the thrown message or stack.
   - `ctx.phase` names the failure surface (`render`, `stream-preflight`, `resource`, `ssr-hydration-sidecar`, `control-plane-section`, or `isr-metadata`), and `ctx.errorClass` matches the request metric tag.
 
+### Client hydration failure beacons
+
+FaceTheory does not install browser telemetry globally. Consumers that want client-side hydration visibility can opt in from their bootstrap module:
+
+```ts
+import { reportHydrationFailure } from "@theory-cloud/facetheory/client";
+
+const onRecoverableError = reportHydrationFailure({
+  endpoint: "/ops/hydration-failure",
+  framework: "react",
+  tags: { surface: "checkout" },
+});
+
+hydrateRoot(root, app, { onRecoverableError });
+```
+
+Operational contract:
+
+- `endpoint` must resolve to the same origin as the active document. Cross-origin endpoints throw before wiring.
+- The reporter first uses `navigator.sendBeacon(endpoint, payload)` and falls back to a `POST` with `credentials: "same-origin"`, `keepalive: true`, and `redirect: "error"` when `sendBeacon` is unavailable or returns `false`.
+- The JSON payload has `event: "facetheory.hydration_failure"`, `framework`, `message`, `errorClass`, `path`, optional React-style `componentStack`/`digest`, and caller-supplied string tags.
+- The helper is intentionally opt-in: importing `@theory-cloud/facetheory/client` or rendering a Face does not add listeners, patch console methods, or send network traffic.
+- The collection route is host-owned. Treat payloads as diagnostic telemetry, not as proof of root cause; correlate them with server `x-request-id`/route metrics and hydration-equivalence tests before changing render code.
+
+For React, wire the returned reporter to `hydrateRoot(..., { onRecoverableError })`. For Vue or Svelte, call the returned reporter from the framework error hook only for hydration/mount failures you intend to count.
+
 React streaming readiness (React adapter):
+
 - `renderReactStream(..., { onReadiness })` emits readiness timing for:
   - `phase: "shell"` (React `onShellReady`)
   - `phase: "all-ready"` (React `onAllReady`)
@@ -74,15 +107,18 @@ React streaming readiness (React adapter):
 ### CSP nonce conventions (SSR only)
 
 FaceTheory supports CSP nonces via `FaceRequest.cspNonce`:
+
 - `renderFaceHead(...)` applies `nonce="..."` to inline `<script>`/`<style>` tags (including hydration data scripts).
 - React streaming passes the nonce to React’s streaming renderer.
 
 Important constraint:
+
 - A per-request nonce must not be baked into cached HTML (SSG/ISR). If an ISR/SSG HTML document contains a nonce,
   your CSP header must match the cached nonce value for every request, which is not compatible with per-request nonces.
   For cached HTML, prefer a hash-based CSP or avoid inline scripts/styles entirely.
 
 Helper:
+
 - `createCspNonce()` is available at `ts/src/security.ts`.
 
 ### Strict no-inline CSP operations
@@ -109,6 +145,7 @@ pair:
   CSP-protected HTML should become a real browser navigation instead of a document-write or SPA DOM replacement.
 
 Evidence boundary:
+
 - A local strict-CSP test or example build proves repository behavior only.
 - A successful RC validation must name the exact FaceTheory GitHub Release tarball installed by the consuming app.
 - Do not record "AWS deployment verified", "Simulacrum verified", or "customer deployed" unless that system supplied
@@ -117,6 +154,7 @@ Evidence boundary:
 ### Response headers policy guidance
 
 Recommended baseline (CDN layer preferred):
+
 - `strict-transport-security` (HSTS)
 - `x-content-type-options: nosniff`
 - `x-frame-options: DENY`
@@ -124,6 +162,7 @@ Recommended baseline (CDN layer preferred):
 - `permissions-policy` (disable features you don’t need)
 
 The SSG/ISR example stack provisions these via `cloudfront.ResponseHeadersPolicy`:
+
 - `infra/apptheory-ssg-isr-site/src/stack.ts`
 
 ### Tenant partitioning guidance
@@ -147,11 +186,13 @@ The SSG/ISR example stack provisions these via `cloudfront.ResponseHeadersPolicy
 ### Deploy / rollback (SSR + assets)
 
 Recommended approach:
+
 1. Deploy assets to S3 (hashed assets `immutable`; manifests and HTML short-lived).
 2. Deploy SSR Lambda (versioned + alias in real deployments).
 3. Invalidate CloudFront only when you deploy non-hashed, cacheable keys.
 
 Rollback:
+
 1. Roll back the SSR Lambda alias to the previous version.
 2. Roll back assets by switching the assets prefix (preferred) or redeploying the previous assets set.
 3. Invalidate CloudFront for any non-hashed keys that may be cached.
@@ -159,9 +200,11 @@ Rollback:
 ### SSG cache invalidation strategy
 
 Prefer versioned prefixes for HTML/data outputs:
+
 - Example: deploy under `ssg/<build-id>/...` and switch CloudFront behavior/origin path.
 
 If using stable keys:
+
 - Invalidate HTML keys (`/*` or targeted paths) on deploy.
 - Do not invalidate immutable hashed assets.
 
@@ -198,6 +241,7 @@ Use this checklist before promoting strict-CSP changes from release candidate to
    - `main` is back-merged to `staging` after stable release per the normal release flow
 
 Rollback:
+
 - pin consumers to the previous FaceTheory release tarball, or remove the strict-CSP opt-in on affected routes.
 - do not weaken OAC, expose direct Lambda Function URLs, or remove CSP headers as the framework rollback path.
 
@@ -222,10 +266,12 @@ The workflow guardrails are intentionally fail-closed:
 ### ISR lock contention diagnostics
 
 Symptoms:
+
 - Elevated `x-facetheory-isr: stale` or `x-facetheory-isr: wait-hit`.
 - Any `x-facetheory-isr: stale-metadata-error` response, which indicates a metadata-store read or lease failure was degraded to stale HTML using a last-known pointer.
 
 Checks:
+
 - CloudWatch logs for request patterns and render durations (`renderMs`).
 - `observability.onError` events with `ctx.phase === "isr-metadata"`; inspect `ctx.errorClass` and the associated `x-request-id` before treating the stale response as healthy.
 - DynamoDB table hot partitions (if tenant+route concentrates traffic).
@@ -233,6 +279,7 @@ Checks:
   - If regeneration routinely exceeds the lease, you will see contention and repeated stale serving.
 
 Mitigations (FaceTheory ISR options):
+
 - Increase `leaseDurationMs`.
 - Increase `regenerationWaitTimeoutMs` or switch `lockContentionPolicy` to `serve-stale`.
 - Ensure the regeneration path does not block on external dependencies without timeouts.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -202,6 +202,17 @@ Rollback:
 2. Roll back assets by switching the assets prefix (preferred) or redeploying the previous assets set.
 3. Invalidate CloudFront for any non-hashed keys that may be cached.
 
+### ISR on-demand invalidation and orphaned HTML objects
+
+`IsrMetaStore.invalidate(cacheKey)` invalidates the metadata pointer, not the stored HTML object. That is deliberate: FaceTheory's ISR state authority is the metadata record and regeneration lease. Deleting an S3 object independently of the metadata/lease flow can turn a still-fresh pointer into a cache read failure.
+
+Operational guidance:
+
+- Local/in-memory invalidation deletes the metadata record; the next request regenerates and writes a new HTML pointer.
+- The TableTheory adapter throws `IsrInvalidateUnsupportedError` until TableTheory provides a coordinated invalidation/delete operation for the FaceTheory ISR metadata model. Do not patch around it with raw DynamoDB writes from FaceTheory.
+- For S3-backed HTML stores, configure lifecycle expiration for the ISR HTML prefix (and strict-CSP ISR hydration sidecar suffixes) so metadata-invalidated or superseded objects age out automatically. Choose the lifecycle window longer than your maximum rollback/debugging window and longer than any CloudFront/S3 cache horizon for the same keys.
+- If you need emergency removal of sensitive HTML, coordinate both sides: invalidate or remove the metadata pointer through the supported meta-store path, remove or deny the S3 object, and invalidate CloudFront for affected paths.
+
 ### SSG cache invalidation strategy
 
 Prefer versioned prefixes for HTML/data outputs:

--- a/docs/modes/isr.md
+++ b/docs/modes/isr.md
@@ -7,17 +7,25 @@ Blocking ISR is FaceTheory's incremental static regeneration model. Requests ser
 ## Declaring an ISR Face
 
 ```typescript
-import { createFaceApp, type FaceModule } from '@theory-cloud/facetheory';
+import { createFaceApp, type FaceModule } from "@theory-cloud/facetheory";
 
 const faces: FaceModule[] = [
   {
-    route: '/news/{slug}',
-    mode: 'isr',
+    route: "/news/{slug}",
+    mode: "isr",
     revalidateSeconds: 30,
-    load: async (ctx) => ({ slug: ctx.params.slug, latest: await fetchLatest(ctx.params.slug) }),
+    load: async (ctx) => ({
+      slug: ctx.params.slug,
+      latest: await fetchLatest(ctx.params.slug),
+    }),
     render: (_ctx, data) => {
-      const { slug, latest } = data as { slug: string; latest: { title: string; body: string } };
-      return { html: `<article><h1>${latest.title}</h1><p>${latest.body}</p></article>` };
+      const { slug, latest } = data as {
+        slug: string;
+        latest: { title: string; body: string };
+      };
+      return {
+        html: `<article><h1>${latest.title}</h1><p>${latest.body}</p></article>`,
+      };
     },
   },
 ];
@@ -30,7 +38,11 @@ const faces: FaceModule[] = [
 Configure the ISR runtime when constructing the app:
 
 ```typescript
-import { createFaceApp, InMemoryHtmlStore, InMemoryIsrMetaStore } from '@theory-cloud/facetheory';
+import {
+  createFaceApp,
+  InMemoryHtmlStore,
+  InMemoryIsrMetaStore,
+} from "@theory-cloud/facetheory";
 
 const htmlStore = new InMemoryHtmlStore();
 const metaStore = new InMemoryIsrMetaStore();
@@ -74,12 +86,33 @@ export const app = createFaceApp({
   isr: {
     htmlStore,
     metaStore,
-    varyCookies: ['session'],
+    varyCookies: ["session"],
   },
 });
 ```
 
 With `varyCookies`, only listed cookies partition the default cache key; absent `varyCookies` keeps the all-cookies default.
+
+## On-demand invalidation
+
+`IsrMetaStore.invalidate(cacheKey)` is the FaceTheory-side invalidation primitive. The in-memory store deletes the metadata record for the cache key, so the next request cannot find a fresh pointer and performs a normal blocking regeneration. The HTML object that used to be referenced is not deleted by metadata invalidation; in production it becomes an orphan until object lifecycle cleanup removes it.
+
+Use the same cache-key function the app uses for ISR requests. For the default key, call `defaultIsrCacheKey(...)` with the route pattern, params, query, tenant, and request variant dimensions that affect the Face output.
+
+```typescript
+import { defaultIsrCacheKey } from "@theory-cloud/facetheory";
+
+const cacheKey = defaultIsrCacheKey({
+  tenant: "default",
+  routePattern: "/news/{slug}",
+  params: { slug: "launch" },
+  query: {},
+});
+
+await metaStore.invalidate(cacheKey);
+```
+
+The TableTheory adapter currently throws `IsrInvalidateUnsupportedError` for `invalidate(cacheKey)`. This is intentional: FaceTheory must not hand-roll a DynamoDB delete/update beside TableTheory's lease and lifecycle semantics. TableTheory needs a first-class ISR invalidation/delete operation before production TableTheory-backed invalidation can be enabled.
 
 ## What ISR guarantees
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -38,6 +38,72 @@ Expected result:
 - Type checking completes with no errors.
 - The unit suite passes.
 
+## Test Your Faces With `@theory-cloud/facetheory/testing`
+
+Consumer apps can unit-test a Face without constructing Lambda Function URL events or copying repository-only harnesses. The testing subpath is Node test tooling and is intentionally separate from the browser client helper surface:
+
+```ts
+import {
+  assertHydrationEquivalent,
+  buildFaceRequest,
+  renderFace,
+} from "@theory-cloud/facetheory/testing";
+
+const request = buildFaceRequest({
+  url: "https://checkout.example.test/checkout?cart=cart_test",
+  headers: { cookie: "session=test-session" },
+  cspNonce: "nonce-test",
+});
+
+const rendered = await renderFace(checkoutFace, { request });
+
+assert.equal(rendered.status, 200);
+assert.match(rendered.html, /Checkout/);
+
+await assertHydrationEquivalent({
+  html: rendered.html,
+  selector: "#root",
+  hydrate: async ({ document }) => {
+    // Wire the same framework hydrate call your client bootstrap uses.
+    // React example: hydrateRoot(document.getElementById("root")!, <App />)
+  },
+});
+```
+
+`buildFaceRequest()` returns a deterministic `FaceRequest` with a stable `x-request-id` and parses URL query strings for you. `renderFace()` accepts a `FaceModule`, an array of Faces, or an app-like object with `handle(request)` and returns the collected response body as `html`/`text` so tests can assert against complete documents.
+
+`assertHydrationEquivalent()` uses a jsdom-backed browser harness, installs browser globals for the duration of the assertion, captures `console.error`/`console.warn`, fails on framework hydration-mismatch messages, and compares the selected DOM subtree before and after the consumer-provided hydrate callback. It fails closed on unexpected `fetch()` by default; pass a fixture fetcher when a strict-CSP route intentionally loads external hydration data:
+
+```ts
+import {
+  assertHydrationEquivalent,
+  createStrictCspFixtureFetch,
+} from "@theory-cloud/facetheory/testing";
+
+const { fetcher } = createStrictCspFixtureFetch({
+  "/_facetheory/data/page.json": { cartId: "cart_test" },
+});
+
+await assertHydrationEquivalent({
+  html,
+  selector: "#root",
+  fetcher,
+  hydrate: async (ctx) => {
+    // Load external hydration data, then call the framework hydrate primitive.
+  },
+});
+```
+
+Strict-CSP test helpers are also exported for application suites that need the same no-inline assertions FaceTheory uses internally:
+
+```ts
+import { assertStrictCspDocument } from "@theory-cloud/facetheory/testing";
+
+await assertStrictCspDocument(rendered.html);
+```
+
+The DOM helpers dynamically load `jsdom`. Keep `jsdom` in the consuming test workspace's dev dependencies; it is not part of FaceTheory's browser/runtime contract.
+
 ## Focused Verification Paths
 
 Run these targeted flows when a change touches one delivery mode or adapter more than the rest of the runtime.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,18 +8,19 @@ Use this guide for recurring setup, build, and runtime failures that already hav
 
 ## Quick Diagnosis
 
-| Symptom                                                               | Likely cause                                                                                  | Where to look                                                       |
-| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `npm ci` or scripts fail early                                        | Node.js is below the required baseline                                                        | `ts/package.json` (`engines.node: >=24`)                            |
-| `npm run ssg` exits with usage errors                                 | Missing or invalid CLI flags                                                                  | `docs/api-reference.md` and `ts/src/ssg-cli.ts`                     |
-| SSG build fails during page generation                                | Network access was attempted without opting in                                                | `buildSsgSite()` and SSG fetch guard behavior                       |
-| SSG build fails with dot-segment output errors                        | `generateStaticParams()` returned `.` / `..` path segments                                    | `ts/src/ssg.ts` path validation and route params                    |
-| ISR route returns a deterministic 500 when tenant headers are present | Known tenant boundary headers reached ISR without an explicit tenant/cache partition          | `docs/migration-guide.md` and `ts/src/isr.ts` tenant guard behavior |
-| ISR object keys look duplicated                                       | `S3HtmlStore.keyPrefix` and `htmlPointerPrefix` repeat the same prefix                        | `docs/core-patterns.md` and `docs/cdk/aws-deployment.md`            |
-| React streaming misses late styles                                    | `styleStrategy: shell` was used where `all-ready` was needed                                  | `docs/core-patterns.md`                                             |
-| Strict-CSP route fails before returning HTML                          | The route emitted inline hydration, inline styles/scripts, raw head, or unsafe body attrs     | `FaceRenderResult.csp` and `docs/core-patterns.md`                  |
-| Browser receives 404 or HTML for an SSR hydration sidecar             | `/_facetheory/ssr-data/...` was not routed to the same FaceApp/Lambda handler as the SSR page | `ssrHydrationSidecars` and Lambda URL routing                       |
-| Form POST behind AppTheorySsrSite OAC returns 403 before Lambda       | Native browser form cannot provide `x-amz-content-sha256` for the Lambda URL OAC signing path | `startAwsOacFormTransport()` and `docs/core-patterns.md`            |
+| Symptom                                                               | Likely cause                                                                                  | Where to look                                                            |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `npm ci` or scripts fail early                                        | Node.js is below the required baseline                                                        | `ts/package.json` (`engines.node: >=24`)                                 |
+| `npm run ssg` exits with usage errors                                 | Missing or invalid CLI flags                                                                  | `docs/api-reference.md` and `ts/src/ssg-cli.ts`                          |
+| SSG build fails during page generation                                | Network access was attempted without opting in                                                | `buildSsgSite()` and SSG fetch guard behavior                            |
+| SSG build fails with dot-segment output errors                        | `generateStaticParams()` returned `.` / `..` path segments                                    | `ts/src/ssg.ts` path validation and route params                         |
+| ISR route returns a deterministic 500 when tenant headers are present | Known tenant boundary headers reached ISR without an explicit tenant/cache partition          | `docs/migration-guide.md` and `ts/src/isr.ts` tenant guard behavior      |
+| ISR object keys look duplicated                                       | `S3HtmlStore.keyPrefix` and `htmlPointerPrefix` repeat the same prefix                        | `docs/core-patterns.md` and `docs/cdk/aws-deployment.md`                 |
+| React streaming misses late styles                                    | `styleStrategy: shell` was used where `all-ready` was needed                                  | `docs/core-patterns.md`                                                  |
+| Strict-CSP route fails before returning HTML                          | The route emitted inline hydration, inline styles/scripts, raw head, or unsafe body attrs     | `FaceRenderResult.csp` and `docs/core-patterns.md`                       |
+| Browser receives 404 or HTML for an SSR hydration sidecar             | `/_facetheory/ssr-data/...` was not routed to the same FaceApp/Lambda handler as the SSR page | `ssrHydrationSidecars` and Lambda URL routing                            |
+| Browser logs hydration mismatch warnings after SSR                    | Client hydrate output differs from server HTML or hydration data was refetched/recomputed     | `@theory-cloud/facetheory/testing` and the affected adapter hydrate path |
+| Form POST behind AppTheorySsrSite OAC returns 403 before Lambda       | Native browser form cannot provide `x-amz-content-sha256` for the Lambda URL OAC signing path | `startAwsOacFormTransport()` and `docs/core-patterns.md`                 |
 
 ## Issue: Node.js Version Mismatch
 
@@ -48,6 +49,49 @@ Verification:
 
 - `npm run typecheck` passes
 - `npm test` passes
+
+## Issue: Browser Logs Hydration Mismatch Warnings
+
+Symptoms:
+
+- React reports hydration failed, Vue remounts over server DOM, or Svelte claim/hydration warnings appear in the browser console
+- server-rendered HTML looks correct before hydration but changes during the first client boot
+- style tags, head tags, IDs, dates, random values, or fetched data differ between server and client
+
+Cause:
+
+- the Face rendered non-deterministic output, or the client bootstrap hydrated with data that was not the exact data used during the server render
+- common sources are `Date.now()`, `new Date()`, `Math.random()`, generated IDs, direct `window`/`document` reads during render, locale/time-zone formatting, direct head-tag emission, missing style extraction, or a client-side refetch during hydration
+
+Solution:
+
+- move head tags through FaceTheory's head primitive and framework style extraction path
+- serialize server-loaded data into FaceTheory hydration data or strict external sidecars and load it before hydrate
+- keep browser-only reads inside client-only effects/hooks rather than render functions
+- add a consumer test with `@theory-cloud/facetheory/testing`:
+
+```ts
+import {
+  assertHydrationEquivalent,
+  renderFace,
+} from "@theory-cloud/facetheory/testing";
+
+const rendered = await renderFace(face, { path: "/checkout" });
+
+await assertHydrationEquivalent({
+  html: rendered.html,
+  selector: "#root",
+  hydrate: async ({ document }) => {
+    // call the same hydrate primitive used by the app's client bootstrap
+  },
+});
+```
+
+Verification:
+
+- the hydration-equivalence test passes without console mismatch messages
+- repeated SSR renders for the same request produce byte-identical HTML for deterministic inputs
+- strict-CSP routes fetch same-origin external hydration JSON before hydrate and do not recompute server-only data on the client
 
 ## Issue: SSR Hydration Sidecar URL Returns 404 or HTML
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -59,6 +59,10 @@
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.js"
     },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
+    },
     "./aws-s3": {
       "types": "./dist/aws-s3/index.d.ts",
       "import": "./dist/aws-s3/index.js"

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -16,11 +16,13 @@ import {
   type IsrRuntime,
 } from './isr.js';
 import {
+  errorClassFor,
   logLevelForStatus,
   reportFaceError,
   type FaceErrorPhase,
   type FaceObservabilityHooks,
   type FaceRequestCompletedLogRecord,
+  type FaceStreamErrorLogRecord,
 } from './ops.js';
 import {
   buildStrictCspHeader,
@@ -76,13 +78,16 @@ export interface FaceAppOptions {
 
 export type FaceAppLogRecord =
   | FaceRequestCompletedLogRecord
+  | FaceStreamErrorLogRecord
   | (FaceContractWarningLogRecord &
       Partial<Omit<FaceRequestCompletedLogRecord, 'event'>>);
 
 export type FaceAppLogHook = (record: FaceAppLogRecord) => void;
 
-export interface FaceAppObservabilityHooks
-  extends Omit<FaceObservabilityHooks, 'log'> {
+export interface FaceAppObservabilityHooks extends Omit<
+  FaceObservabilityHooks,
+  'log'
+> {
   /**
    * Structured request completion records and construction-time contract
    * warnings. Contract warnings remain warnings until the planned v4 contract
@@ -188,6 +193,7 @@ export class FaceApp {
   private readonly observability: FaceAppObservabilityHooks | null;
   private readonly strictCspMaxStreamingBodyBytes: number;
   private readonly trailingSlash: TrailingSlashPolicy;
+  private coldStartPending = true;
 
   constructor(options: FaceAppOptions) {
     this.trailingSlash = normalizeTrailingSlashPolicy(options.trailingSlash);
@@ -285,6 +291,7 @@ export class FaceApp {
 
     const normalizedReq = normalizeRequest(request);
     const requestId = normalizedReq.headers[REQUEST_ID_HEADER]?.[0] ?? '';
+    const coldStart = this.consumeColdStartMarker();
 
     let routePattern = '';
     let mode: FaceMode | 'none' = 'none';
@@ -307,6 +314,7 @@ export class FaceApp {
           routePattern: trailingSlashRedirectPath,
           mode,
           renderMs,
+          coldStart,
         },
       );
     }
@@ -329,6 +337,7 @@ export class FaceApp {
           routePattern,
           mode,
           renderMs,
+          coldStart,
         },
       );
     }
@@ -363,6 +372,7 @@ export class FaceApp {
           routePattern,
           mode,
           renderMs,
+          coldStart,
           error: observedError,
         },
       );
@@ -384,6 +394,7 @@ export class FaceApp {
           routePattern,
           mode,
           renderMs,
+          coldStart,
         },
       );
     }
@@ -414,6 +425,14 @@ export class FaceApp {
             preparedOut,
             normalizedReq,
             this.strictCspMaxStreamingBodyBytes,
+            {
+              hooks,
+              method: normalizedReq.method,
+              mode,
+              path: normalizedReq.path,
+              requestId,
+              routePattern,
+            },
           );
         } finally {
           renderMs = Math.max(0, now() - renderStartedAt);
@@ -443,6 +462,7 @@ export class FaceApp {
             routePattern,
             mode,
             renderMs,
+            coldStart,
           },
         );
       }
@@ -459,6 +479,7 @@ export class FaceApp {
           routePattern,
           mode,
           renderMs,
+          coldStart,
         },
       );
     } catch (err) {
@@ -478,10 +499,17 @@ export class FaceApp {
           routePattern,
           mode,
           renderMs,
+          coldStart,
           error: observedError,
         },
       );
     }
+  }
+
+  private consumeColdStartMarker(): boolean {
+    const coldStart = this.coldStartPending;
+    this.coldStartPending = false;
+    return coldStart;
   }
 }
 
@@ -557,7 +585,9 @@ function faceContractWarnings(
 function routePatternHasParams(routePattern: string): boolean {
   return routePattern.split('/').some((segment) => {
     const trimmed = segment.trim();
-    return trimmed.startsWith('{') && trimmed.endsWith('}') && trimmed.length > 2;
+    return (
+      trimmed.startsWith('{') && trimmed.endsWith('}') && trimmed.length > 2
+    );
   });
 }
 
@@ -694,6 +724,7 @@ function finishResponse(
     routePattern: string;
     mode: FaceMode | 'none';
     renderMs: number | null;
+    coldStart?: boolean;
     error?: ObservedFaceError | null;
   },
 ): FaceResponse {
@@ -755,8 +786,22 @@ function finishResponse(
       isr_state: isrState ?? '',
       is_stream: isStream ? '1' : '0',
       error_class: errorClass ?? '',
+      cold_start: context.coldStart ? '1' : '0',
     },
   });
+
+  if (context.mode === 'isr' && isrState !== null) {
+    hooks?.metric?.({
+      name: 'facetheory.isr.cache',
+      value: 1,
+      tags: {
+        method: req.method,
+        route_pattern: context.routePattern || req.path,
+        state: isrState,
+        status: String(out.status),
+      },
+    });
+  }
 
   if (context.renderMs !== null) {
     hooks?.metric?.({
@@ -925,10 +970,20 @@ function isExternalHydration(
   return hydration.type === 'external';
 }
 
+interface StreamErrorTelemetryContext {
+  hooks: FaceObservabilityHooks | null;
+  requestId: string;
+  method: string;
+  path: string;
+  routePattern: string;
+  mode: FaceMode | 'none';
+}
+
 async function toHTTPResponse(
   out: FaceRenderResult,
   req: Readonly<Required<FaceRequest>>,
   strictCspMaxStreamingBodyBytes: number,
+  streamTelemetry?: StreamErrorTelemetryContext,
 ): Promise<FaceResponse> {
   const status = out.status ?? 200;
   const headers = toHeaders(out.headers, out.cookies);
@@ -984,9 +1039,42 @@ async function toHTTPResponse(
     ...documentParts,
     head,
     body: await preflightStream(out.html),
+    ...(streamTelemetry
+      ? {
+          onStreamError: (err: unknown) =>
+            reportStreamError(streamTelemetry, err),
+        }
+      : {}),
   });
 
   return { status, headers, cookies, body, isBase64: false };
+}
+
+function reportStreamError(
+  context: StreamErrorTelemetryContext,
+  err: unknown,
+): void {
+  const errorClass = errorClassFor(err);
+  context.hooks?.log?.({
+    level: 'error',
+    event: 'facetheory.stream_error',
+    requestId: context.requestId,
+    method: context.method,
+    path: context.path,
+    routePattern: context.routePattern,
+    mode: context.mode,
+    errorClass,
+  });
+  context.hooks?.metric?.({
+    name: 'facetheory.stream_error',
+    value: 1,
+    tags: {
+      method: context.method,
+      route_pattern: context.routePattern || context.path,
+      mode: String(context.mode),
+      error_class: errorClass,
+    },
+  });
 }
 
 function applyStrictCspResponseHeader(
@@ -1061,7 +1149,10 @@ async function preflightStream(
   })();
 }
 
-function withQueryString(path: string, query: Record<string, string[]>): string {
+function withQueryString(
+  path: string,
+  query: Record<string, string[]>,
+): string {
   const params = new URLSearchParams();
   for (const [key, values] of Object.entries(query)) {
     for (const value of values) {

--- a/ts/src/client/index.ts
+++ b/ts/src/client/index.ts
@@ -6,7 +6,9 @@ export interface ReadFaceHydrationDataOptions {
   document?: Document;
 }
 
-export type ReadFaceHydrationDataInput = Document | ReadFaceHydrationDataOptions;
+export type ReadFaceHydrationDataInput =
+  | Document
+  | ReadFaceHydrationDataOptions;
 
 export interface ResolveFaceHydrationUrlOptions {
   allowedOrigin?: string | URL;
@@ -14,13 +16,39 @@ export interface ResolveFaceHydrationUrlOptions {
   document?: Document;
 }
 
-export interface FetchExternalFaceHydrationDataOptions
-  extends ResolveFaceHydrationUrlOptions {
+export interface FetchExternalFaceHydrationDataOptions extends ResolveFaceHydrationUrlOptions {
   fetcher?: typeof fetch;
   requestInit?: RequestInit;
 }
 
-export type LoadFaceHydrationDataOptions = FetchExternalFaceHydrationDataOptions;
+export type LoadFaceHydrationDataOptions =
+  FetchExternalFaceHydrationDataOptions;
+
+export interface ReportHydrationFailureOptions extends ResolveFaceHydrationUrlOptions {
+  endpoint: string | URL;
+  framework?: string;
+  route?: string;
+  tags?: Record<string, string | number | boolean | null | undefined>;
+  navigator?: Pick<Navigator, 'sendBeacon'>;
+  window?: Pick<Window, 'location'>;
+  fetcher?: typeof fetch;
+}
+
+export interface HydrationFailurePayload {
+  event: 'facetheory.hydration_failure';
+  framework: string;
+  message: string;
+  errorClass: string;
+  path: string;
+  componentStack?: string;
+  digest?: string;
+  tags?: Record<string, string>;
+}
+
+export type HydrationFailureReporter = (
+  error: unknown,
+  errorInfo?: unknown,
+) => void;
 
 interface FaceHydrationFetchResponse {
   headers: Pick<Headers, 'get'>;
@@ -30,7 +58,9 @@ interface FaceHydrationFetchResponse {
   url: string;
 }
 
-export function readFaceInlineHydrationData<T = unknown>(doc?: Document): T | null;
+export function readFaceInlineHydrationData<T = unknown>(
+  doc?: Document,
+): T | null;
 export function readFaceInlineHydrationData<T = unknown>(
   options?: ReadFaceHydrationDataOptions,
 ): T | null;
@@ -66,10 +96,12 @@ export async function loadFaceHydrationData<T = unknown>(
   if (dataUrl === null) return null;
 
   const fetchOptions: FetchExternalFaceHydrationDataOptions = { document: doc };
-  if (options.allowedOrigin !== undefined) fetchOptions.allowedOrigin = options.allowedOrigin;
+  if (options.allowedOrigin !== undefined)
+    fetchOptions.allowedOrigin = options.allowedOrigin;
   if (options.baseUrl !== undefined) fetchOptions.baseUrl = options.baseUrl;
   if (options.fetcher !== undefined) fetchOptions.fetcher = options.fetcher;
-  if (options.requestInit !== undefined) fetchOptions.requestInit = options.requestInit;
+  if (options.requestInit !== undefined)
+    fetchOptions.requestInit = options.requestInit;
   return fetchExternalFaceHydrationData<T>(dataUrl, fetchOptions);
 }
 
@@ -80,7 +112,9 @@ export async function fetchExternalFaceHydrationData<T = unknown>(
   const requestUrl = resolveSameOriginFaceHydrationUrl(dataUrl, options);
   const fetcher = options.fetcher ?? globalThis.fetch;
   if (typeof fetcher !== 'function') {
-    throw new Error('FaceTheory hydration loader requires fetch in the current environment');
+    throw new Error(
+      'FaceTheory hydration loader requires fetch in the current environment',
+    );
   }
 
   const response = await fetcher(
@@ -115,7 +149,11 @@ export async function fetchExternalFaceHydrationData<T = unknown>(
   }
 
   const contentType = response.headers.get('content-type');
-  if (contentType !== null && contentType.trim() !== '' && !isJsonContentType(contentType)) {
+  if (
+    contentType !== null &&
+    contentType.trim() !== '' &&
+    !isJsonContentType(contentType)
+  ) {
     throw new Error('FaceTheory hydration data response was not JSON');
   }
 
@@ -135,6 +173,37 @@ export async function fetchExternalFaceHydrationData<T = unknown>(
   return data as T;
 }
 
+export function reportHydrationFailure(
+  options: ReportHydrationFailureOptions,
+): HydrationFailureReporter {
+  const endpoint = resolveSameOriginHydrationFailureEndpoint(options);
+
+  return (error: unknown, errorInfo?: unknown): void => {
+    const payload = JSON.stringify(
+      buildHydrationFailurePayload(options, error, errorInfo),
+    );
+
+    const beaconNavigator = options.navigator ?? resolveGlobalNavigator();
+    if (beaconNavigator?.sendBeacon?.(endpoint.toString(), payload)) {
+      return;
+    }
+
+    const fetcher = options.fetcher ?? globalThis.fetch;
+    if (typeof fetcher !== 'function') return;
+
+    void Promise.resolve(
+      fetcher(endpoint.toString(), {
+        body: payload,
+        credentials: 'same-origin',
+        headers: { 'content-type': 'application/json' },
+        keepalive: true,
+        method: 'POST',
+        redirect: 'error',
+      }),
+    ).catch(() => undefined);
+  };
+}
+
 export function resolveSameOriginFaceHydrationUrl(
   dataUrl: string | URL,
   options: ResolveFaceHydrationUrlOptions = {},
@@ -151,7 +220,9 @@ export function resolveSameOriginFaceHydrationUrl(
   try {
     resolved = new URL(raw, baseHref);
   } catch (error) {
-    throw new Error('FaceTheory hydration data URL is invalid', { cause: error });
+    throw new Error('FaceTheory hydration data URL is invalid', {
+      cause: error,
+    });
   }
 
   if (!isHttpUrl(resolved)) {
@@ -165,6 +236,122 @@ export function resolveSameOriginFaceHydrationUrl(
   return resolved;
 }
 
+function resolveSameOriginHydrationFailureEndpoint(
+  options: ReportHydrationFailureOptions,
+): URL {
+  try {
+    return resolveSameOriginFaceHydrationUrl(options.endpoint, options);
+  } catch (error) {
+    throw new Error(
+      'FaceTheory hydration failure endpoint must be a same-origin http(s) URL',
+      { cause: error },
+    );
+  }
+}
+
+function buildHydrationFailurePayload(
+  options: ReportHydrationFailureOptions,
+  error: unknown,
+  errorInfo: unknown,
+): HydrationFailurePayload {
+  const payload: HydrationFailurePayload = {
+    event: 'facetheory.hydration_failure',
+    framework: normalizeHydrationFailureLabel(options.framework, 'unknown'),
+    message: hydrationFailureMessage(error),
+    errorClass: hydrationFailureErrorClass(error),
+    path: options.route ?? resolveHydrationFailurePath(options),
+  };
+
+  const componentStack = readHydrationFailureString(
+    errorInfo,
+    'componentStack',
+  );
+  if (componentStack) payload.componentStack = componentStack;
+  const digest = readHydrationFailureString(errorInfo, 'digest');
+  if (digest) payload.digest = digest;
+
+  const tags = normalizeHydrationFailureTags(options.tags);
+  if (Object.keys(tags).length > 0) payload.tags = tags;
+
+  return payload;
+}
+
+function resolveHydrationFailurePath(
+  options: ReportHydrationFailureOptions,
+): string {
+  const location =
+    options.window?.location ??
+    options.document?.defaultView?.location ??
+    (typeof window !== 'undefined' ? window.location : null);
+  if (!location) return '';
+  return `${location.pathname}${location.search}`;
+}
+
+function hydrationFailureMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return String(error ?? 'Unknown hydration failure');
+}
+
+function hydrationFailureErrorClass(error: unknown): string {
+  if (error && typeof error === 'object') {
+    const name = normalizeHydrationFailureLabel(
+      (error as { name?: unknown }).name,
+      '',
+    );
+    if (name) return name;
+    const ctorName = normalizeHydrationFailureLabel(
+      (error as { constructor?: { name?: unknown } }).constructor?.name,
+      '',
+    );
+    if (ctorName) return ctorName;
+    return 'Object';
+  }
+
+  const typeName = normalizeHydrationFailureLabel(typeof error, 'Unknown');
+  return typeName === 'Unknown' ? typeName : `NonError_${typeName}`;
+}
+
+function readHydrationFailureString(
+  value: unknown,
+  key: string,
+): string | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = (value as Record<string, unknown>)[key];
+  const normalized = String(raw ?? '').trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeHydrationFailureTags(
+  tags:
+    | Record<string, string | number | boolean | null | undefined>
+    | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(tags ?? {})) {
+    const normalizedKey = normalizeHydrationFailureLabel(key, '');
+    if (!normalizedKey || value === null || value === undefined) continue;
+    out[normalizedKey] = String(value);
+  }
+  return out;
+}
+
+function normalizeHydrationFailureLabel(
+  value: unknown,
+  fallback: string,
+): string {
+  const normalized = String(value ?? '')
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return normalized || fallback;
+}
+
+function resolveGlobalNavigator(): Pick<Navigator, 'sendBeacon'> | null {
+  if (typeof navigator === 'undefined') return null;
+  return navigator;
+}
+
 function resolveReadHydrationDocument(
   input: ReadFaceHydrationDataInput | undefined,
 ): Document {
@@ -175,34 +362,44 @@ function resolveReadHydrationDocument(
 function resolveHydrationDocument(doc: Document | undefined): Document {
   if (doc !== undefined) return doc;
   if (typeof document !== 'undefined') return document;
-  throw new Error('FaceTheory hydration loader requires document in the current environment');
+  throw new Error(
+    'FaceTheory hydration loader requires document in the current environment',
+  );
 }
 
 function isDocumentLike(value: unknown): value is Document {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as { getElementById?: unknown }).getElementById === 'function' &&
+    typeof (value as { getElementById?: unknown }).getElementById ===
+      'function' &&
     typeof (value as { querySelector?: unknown }).querySelector === 'function'
   );
 }
 
-function readInlineHydrationScript(doc: Document):
-  | { present: false }
-  | { present: true; text: string } {
+function readInlineHydrationScript(
+  doc: Document,
+): { present: false } | { present: true; text: string } {
   const el = doc.getElementById(FACE_HYDRATION_DATA_SCRIPT_ID);
   if (!isJsonHydrationScriptElement(el)) return { present: false };
   return { present: true, text: el.textContent ?? '' };
 }
 
-function isJsonHydrationScriptElement(el: Element | null): el is HTMLScriptElement {
+function isJsonHydrationScriptElement(
+  el: Element | null,
+): el is HTMLScriptElement {
   if (el?.tagName.toLowerCase() !== 'script') return false;
   return isJsonScriptType(el.getAttribute('type'));
 }
 
 function isJsonScriptType(type: string | null): boolean {
-  const mediaType = String(type ?? '').split(';', 1)[0]?.trim().toLowerCase();
-  return mediaType === 'application/json' || Boolean(mediaType?.endsWith('+json'));
+  const mediaType = String(type ?? '')
+    .split(';', 1)[0]
+    ?.trim()
+    .toLowerCase();
+  return (
+    mediaType === 'application/json' || Boolean(mediaType?.endsWith('+json'))
+  );
 }
 
 function readExternalHydrationUrl(doc: Document): string | null {
@@ -212,7 +409,9 @@ function readExternalHydrationUrl(doc: Document): string | null {
     if (href) return href;
   }
 
-  const byRel = doc.querySelector(`link[rel="${FACE_HYDRATION_DATA_LINK_REL}"]`);
+  const byRel = doc.querySelector(
+    `link[rel="${FACE_HYDRATION_DATA_LINK_REL}"]`,
+  );
   if (!byRel) return null;
   const href = byRel.getAttribute('href');
   return href || null;
@@ -228,15 +427,20 @@ function parseHydrationJson<T>(text: string): T {
   }
 }
 
-function resolveHydrationBaseHref(options: ResolveFaceHydrationUrlOptions): string {
-  const fallback = resolveDocumentBaseHref(options.document) ?? resolveGlobalBaseHref();
+function resolveHydrationBaseHref(
+  options: ResolveFaceHydrationUrlOptions,
+): string {
+  const fallback =
+    resolveDocumentBaseHref(options.document) ?? resolveGlobalBaseHref();
   if (options.baseUrl !== undefined) {
     try {
       return fallback === null
         ? new URL(String(options.baseUrl)).toString()
         : new URL(String(options.baseUrl), fallback).toString();
     } catch (error) {
-      throw new Error('FaceTheory hydration baseUrl is invalid', { cause: error });
+      throw new Error('FaceTheory hydration baseUrl is invalid', {
+        cause: error,
+      });
     }
   }
 
@@ -270,7 +474,9 @@ function resolveHydrationAllowedOrigin(
   try {
     base = new URL(baseHref);
   } catch (error) {
-    throw new Error('FaceTheory hydration baseUrl is invalid', { cause: error });
+    throw new Error('FaceTheory hydration baseUrl is invalid', {
+      cause: error,
+    });
   }
 
   if (!isHttpUrl(base)) {
@@ -284,7 +490,9 @@ function normalizeAllowedOrigin(origin: string | URL): string {
   try {
     parsed = new URL(String(origin));
   } catch (error) {
-    throw new Error('FaceTheory hydration allowedOrigin is invalid', { cause: error });
+    throw new Error('FaceTheory hydration allowedOrigin is invalid', {
+      cause: error,
+    });
   }
 
   if (!isHttpUrl(parsed)) {
@@ -314,7 +522,9 @@ function isHttpUrl(url: URL): boolean {
   return url.protocol === 'http:' || url.protocol === 'https:';
 }
 
-function createHydrationRequestInit(requestInit: RequestInit | undefined): RequestInit {
+function createHydrationRequestInit(
+  requestInit: RequestInit | undefined,
+): RequestInit {
   return {
     credentials: 'same-origin',
     redirect: 'follow',
@@ -323,7 +533,9 @@ function createHydrationRequestInit(requestInit: RequestInit | undefined): Reque
   };
 }
 
-function withHydrationAcceptHeader(headers: HeadersInit | undefined): HeadersInit {
+function withHydrationAcceptHeader(
+  headers: HeadersInit | undefined,
+): HeadersInit {
   if (headers === undefined || isHeaderRecord(headers)) {
     return { accept: 'application/json', ...(headers ?? {}) };
   }
@@ -333,7 +545,9 @@ function withHydrationAcceptHeader(headers: HeadersInit | undefined): HeadersIni
   return merged;
 }
 
-function isHeaderRecord(headers: HeadersInit): headers is Record<string, string> {
+function isHeaderRecord(
+  headers: HeadersInit,
+): headers is Record<string, string> {
   return !Array.isArray(headers) && !isHeadersLike(headers);
 }
 
@@ -350,7 +564,9 @@ function assertHydrationFetchResponse(
   response: unknown,
 ): asserts response is FaceHydrationFetchResponse {
   if (typeof response !== 'object' || response === null) {
-    throw new Error('FaceTheory hydration data fetch returned an invalid response');
+    throw new Error(
+      'FaceTheory hydration data fetch returned an invalid response',
+    );
   }
 
   const candidate = response as Partial<FaceHydrationFetchResponse>;
@@ -362,11 +578,15 @@ function assertHydrationFetchResponse(
     !candidate.headers ||
     typeof candidate.headers.get !== 'function'
   ) {
-    throw new Error('FaceTheory hydration data fetch returned an invalid response');
+    throw new Error(
+      'FaceTheory hydration data fetch returned an invalid response',
+    );
   }
 }
 
 function isJsonContentType(contentType: string): boolean {
   const mediaType = contentType.split(';', 1)[0]?.trim().toLowerCase();
-  return mediaType === 'application/json' || Boolean(mediaType?.endsWith('+json'));
+  return (
+    mediaType === 'application/json' || Boolean(mediaType?.endsWith('+json'))
+  );
 }

--- a/ts/src/html.ts
+++ b/ts/src/html.ts
@@ -81,6 +81,7 @@ export interface HTMLDocumentStreamParts {
   bodyAttrs?: FaceAttributes;
   head?: string;
   body: AsyncIterable<Uint8Array>;
+  onStreamError?: (err: unknown) => void;
 }
 
 import { utf8 } from './bytes.js';
@@ -102,6 +103,11 @@ export async function* streamHTMLDocument(
   } catch (err) {
     // Avoid breaking the full HTML document shape on streaming errors.
     // Do not include error details in HTML (may contain sensitive information).
+    try {
+      parts.onStreamError?.(err);
+    } catch {
+      // Telemetry hooks must not alter emitted streaming bytes.
+    }
     console.error('FaceTheory: streaming body error', err);
     yield utf8('<template data-facetheory-stream-error="true"></template>');
   }

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -131,6 +131,7 @@ export interface ReleaseIsrLeaseInput {
 
 export interface IsrMetaStore {
   get: (cacheKey: string) => Promise<IsrMetaRecord | null>;
+  invalidate: (cacheKey: string) => Promise<void>;
   tryAcquireLease: (
     input: TryAcquireIsrLeaseInput,
   ) => Promise<TryAcquireIsrLeaseResult>;
@@ -279,6 +280,10 @@ export class InMemoryIsrMetaStore implements IsrMetaStore {
   async get(cacheKey: string): Promise<IsrMetaRecord | null> {
     const record = this.records.get(cacheKey);
     return record ? cloneIsrMetaRecord(record) : null;
+  }
+
+  async invalidate(cacheKey: string): Promise<void> {
+    this.records.delete(cacheKey);
   }
 
   async tryAcquireLease(

--- a/ts/src/isr.ts
+++ b/ts/src/isr.ts
@@ -2,10 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 
 import { utf8 } from './bytes.js';
 import { safeJson } from './html.js';
-import {
-  reportFaceError,
-  type FaceObservabilityHooks,
-} from './ops.js';
+import { reportFaceError, type FaceObservabilityHooks } from './ops.js';
 import {
   requiresStrictCspDocumentValidation,
   validateStrictCspDocument,
@@ -557,6 +554,10 @@ export function createIsrRuntime(options: FaceIsrOptions): IsrRuntime {
         throw err;
       }
 
+      if (!acquire.acquired) {
+        emitIsrLeaseContentionMetric(runtimeOptions, input);
+      }
+
       if (acquire.acquired && acquire.leaseToken) {
         return regenerateAndCommit(
           runtimeOptions,
@@ -782,6 +783,8 @@ async function regenerateAndCommit(
   staleRecord: IsrMetaRecord,
   rememberRecord: (record: IsrMetaRecord | null) => void,
 ): Promise<FaceResponse> {
+  const regenerationMetricStartedAt = metricNow();
+  let regenerationOutcome = 'error';
   const generatedAt = runtimeOptions.now();
   const htmlPointer = buildHtmlPointer(
     cacheKey,
@@ -850,6 +853,8 @@ async function regenerateAndCommit(
       ...(etag !== null ? { etag } : {}),
     });
 
+    regenerationOutcome = 'success';
+
     const committedRecord: IsrMetaRecord = {
       ...createDefaultMetaRecord(cacheKey, revalidateSeconds),
       htmlPointer,
@@ -878,16 +883,61 @@ async function regenerateAndCommit(
         runtimeOptions.now(),
         true,
       );
-      if (stale) return stale;
+      if (stale) {
+        regenerationOutcome = 'stale_after_error';
+        return stale;
+      }
     }
     throw err;
   } finally {
+    emitIsrRegenerationMetric(
+      runtimeOptions,
+      input,
+      Math.max(0, metricNow() - regenerationMetricStartedAt),
+      regenerationOutcome,
+    );
     await runtimeOptions.metaStore.releaseLease({
       cacheKey,
       leaseOwner,
       leaseToken,
     });
   }
+}
+
+function emitIsrLeaseContentionMetric(
+  runtimeOptions: CreateIsrRuntimeOptions,
+  input: HandleIsrFaceInput,
+): void {
+  runtimeOptions.observability?.metric?.({
+    name: 'facetheory.isr.lease_contention',
+    value: 1,
+    tags: {
+      method: input.ctx.request.method,
+      route_pattern: input.routePattern,
+      policy: runtimeOptions.lockContentionPolicy,
+    },
+  });
+}
+
+function emitIsrRegenerationMetric(
+  runtimeOptions: CreateIsrRuntimeOptions,
+  input: HandleIsrFaceInput,
+  durationMs: number,
+  outcome: string,
+): void {
+  runtimeOptions.observability?.metric?.({
+    name: 'facetheory.isr.regeneration_ms',
+    value: durationMs,
+    tags: {
+      method: input.ctx.request.method,
+      route_pattern: input.routePattern,
+      outcome,
+    },
+  });
+}
+
+function metricNow(): number {
+  return Date.now();
 }
 
 async function staleResponseForMetadataFailure(
@@ -1119,7 +1169,9 @@ function normalizeRuntimeOptions(
   };
 }
 
-function normalizeVaryCookies(varyCookies: readonly string[]): readonly string[] {
+function normalizeVaryCookies(
+  varyCookies: readonly string[],
+): readonly string[] {
   return [...new Set(varyCookies.map((name) => String(name).trim()))].filter(
     (name) => name.length > 0,
   );

--- a/ts/src/ops.ts
+++ b/ts/src/ops.ts
@@ -40,6 +40,21 @@ export interface FaceRequestCompletedLogRecord {
   errorClass: string | null;
 }
 
+export interface FaceStreamErrorLogRecord {
+  level: 'error';
+  event: 'facetheory.stream_error';
+  requestId: string;
+  method: string;
+  path: string;
+  routePattern: string;
+  mode: FaceMode | 'none';
+  errorClass: string;
+}
+
+export type FaceObservabilityLogRecord =
+  | FaceRequestCompletedLogRecord
+  | FaceStreamErrorLogRecord;
+
 export interface FaceMetricRecord {
   name: string;
   value: number;
@@ -56,7 +71,7 @@ export interface FaceObservabilityHooks {
   /**
    * Structured log sink.
    */
-  log?: (record: FaceRequestCompletedLogRecord) => void;
+  log?: (record: FaceObservabilityLogRecord) => void;
 
   /**
    * Minimal metrics sink (counters / histograms depending on backend).

--- a/ts/src/tabletheory/index.ts
+++ b/ts/src/tabletheory/index.ts
@@ -28,12 +28,17 @@ function normalizeRevalidateSeconds(value: number): number {
   return Math.max(0, numeric);
 }
 
-function recordFromTableTheoryMeta(cacheKey: string, meta: FaceTheoryIsrMeta): IsrMetaRecord {
+function recordFromTableTheoryMeta(
+  cacheKey: string,
+  meta: FaceTheoryIsrMeta,
+): IsrMetaRecord {
   return {
     cacheKey,
     htmlPointer: meta.htmlPointer ?? null,
     generatedAt: Number(meta.generatedAtMs ?? 0),
-    revalidateSeconds: normalizeRevalidateSeconds(Number(meta.revalidateSeconds ?? 0)),
+    revalidateSeconds: normalizeRevalidateSeconds(
+      Number(meta.revalidateSeconds ?? 0),
+    ),
     status: DEFAULT_STATUS,
     contentType: DEFAULT_CONTENT_TYPE,
     etag: typeof meta.etag === 'string' ? meta.etag : null,
@@ -43,7 +48,10 @@ function recordFromTableTheoryMeta(cacheKey: string, meta: FaceTheoryIsrMeta): I
   };
 }
 
-function defaultRecord(cacheKey: string, fallbackRevalidateSeconds: number): IsrMetaRecord {
+function defaultRecord(
+  cacheKey: string,
+  fallbackRevalidateSeconds: number,
+): IsrMetaRecord {
   return {
     cacheKey,
     htmlPointer: null,
@@ -58,6 +66,15 @@ function defaultRecord(cacheKey: string, fallbackRevalidateSeconds: number): Isr
   };
 }
 
+export class IsrInvalidateUnsupportedError extends Error {
+  constructor(readonly cacheKey: string) {
+    super(
+      `FaceTheory ISR invalidate("${cacheKey}") is not supported by the TableTheory adapter yet; pending TableTheory coordination must add a first-class invalidation/delete operation to the FaceTheory ISR metadata store before this adapter can invalidate records.`,
+    );
+    this.name = 'IsrInvalidateUnsupportedError';
+  }
+}
+
 export interface TableTheoryIsrMetaStoreAdapterOptions {
   defaultStatus?: number;
   defaultContentType?: string;
@@ -68,12 +85,17 @@ export class TableTheoryIsrMetaStoreAdapter implements IsrMetaStore {
   private readonly defaultStatus: number;
   private readonly defaultContentType: string;
 
-  constructor(inner: FaceTheoryIsrMetaStore, options: TableTheoryIsrMetaStoreAdapterOptions = {}) {
+  constructor(
+    inner: FaceTheoryIsrMetaStore,
+    options: TableTheoryIsrMetaStoreAdapterOptions = {},
+  ) {
     this.inner = inner;
     this.defaultStatus = Number.isFinite(options.defaultStatus ?? NaN)
       ? Math.trunc(Number(options.defaultStatus))
       : DEFAULT_STATUS;
-    this.defaultContentType = String(options.defaultContentType ?? DEFAULT_CONTENT_TYPE).trim() || DEFAULT_CONTENT_TYPE;
+    this.defaultContentType =
+      String(options.defaultContentType ?? DEFAULT_CONTENT_TYPE).trim() ||
+      DEFAULT_CONTENT_TYPE;
   }
 
   async get(cacheKey: string): Promise<IsrMetaRecord | null> {
@@ -86,7 +108,13 @@ export class TableTheoryIsrMetaStoreAdapter implements IsrMetaStore {
     };
   }
 
-  async tryAcquireLease(input: TryAcquireIsrLeaseInput): Promise<TryAcquireIsrLeaseResult> {
+  async invalidate(cacheKey: string): Promise<void> {
+    throw new IsrInvalidateUnsupportedError(cacheKey);
+  }
+
+  async tryAcquireLease(
+    input: TryAcquireIsrLeaseInput,
+  ): Promise<TryAcquireIsrLeaseResult> {
     const existingMeta = await this.inner.get({ cacheKey: input.cacheKey });
     const base = existingMeta
       ? {
@@ -130,7 +158,10 @@ export class TableTheoryIsrMetaStoreAdapter implements IsrMetaStore {
   }
 
   async commitGeneration(input: CommitIsrGenerationInput): Promise<void> {
-    if (!Number.isFinite(input.revalidateSeconds) || input.revalidateSeconds <= 0) {
+    if (
+      !Number.isFinite(input.revalidateSeconds) ||
+      input.revalidateSeconds <= 0
+    ) {
       throw new Error(
         `TableTheory FaceTheoryIsrMetaStore requires revalidateSeconds > 0 (got ${input.revalidateSeconds})`,
       );
@@ -160,7 +191,9 @@ export interface CreateTableTheoryIsrMetaStoreOptions extends TableTheoryIsrMeta
   config: FaceTheoryIsrMetaStoreConfig;
 }
 
-export function createTableTheoryIsrMetaStore(options: CreateTableTheoryIsrMetaStoreOptions): IsrMetaStore {
+export function createTableTheoryIsrMetaStore(
+  options: CreateTableTheoryIsrMetaStoreOptions,
+): IsrMetaStore {
   const inner = createFaceTheoryIsrMetaStore(options.config);
   return new TableTheoryIsrMetaStoreAdapter(inner, options);
 }

--- a/ts/src/testing/index.ts
+++ b/ts/src/testing/index.ts
@@ -1,0 +1,786 @@
+import assert from 'node:assert/strict';
+import { inspect } from 'node:util';
+
+import { createFaceApp, type FaceAppOptions } from '../app.js';
+import { validateStrictCspDocument } from '../security.js';
+import type {
+  CookieMap,
+  FaceBody,
+  FaceHeaders,
+  FaceModule,
+  FaceRequest,
+  FaceResponse,
+  Query,
+} from '../types.js';
+import {
+  canonicalizeHeaders,
+  cloneCookies,
+  cloneQuery,
+  normalizePath,
+  parseQueryString,
+} from '../types.js';
+
+export interface BuildFaceRequestOptions {
+  method?: string;
+  path?: string;
+  url?: string | URL;
+  query?: Query;
+  headers?: FaceTestHeaders;
+  cookies?: CookieMap;
+  body?: string | Uint8Array;
+  isBase64?: boolean;
+  cspNonce?: string | null;
+  requestId?: string;
+}
+
+export type FaceTestHeaders = Record<
+  string,
+  string | number | boolean | readonly (string | number | boolean)[]
+>;
+
+export interface RenderFaceOptions extends BuildFaceRequestOptions {
+  request?: FaceRequest | BuildFaceRequestOptions;
+  app?: Omit<FaceAppOptions, 'faces'>;
+}
+
+export interface RenderedFace {
+  request: FaceRequest;
+  response: FaceResponse;
+  body: Uint8Array;
+  html: string;
+  text: string;
+  status: number;
+  headers: FaceHeaders;
+}
+
+export interface FaceAppLike {
+  handle: (request: FaceRequest) => Promise<FaceResponse> | FaceResponse;
+}
+
+export type RenderFaceTarget = FaceModule | readonly FaceModule[] | FaceAppLike;
+
+export interface HydrationEquivalentConsoleMessage {
+  level: 'error' | 'warn';
+  args: readonly unknown[];
+  text: string;
+}
+
+export type FaceTestWindow = Window &
+  Record<PropertyKey, unknown> & {
+    cancelAnimationFrame: (handle: number) => void;
+    close?: () => void;
+    console: Pick<Console, 'error' | 'warn'>;
+    document: Document;
+    getComputedStyle: typeof getComputedStyle;
+    location: Location;
+    navigator: Navigator;
+    requestAnimationFrame: (callback: FrameRequestCallback) => number;
+  };
+
+export interface HydrationEquivalentContext {
+  window: FaceTestWindow;
+  document: Document;
+  container: Element;
+  htmlBefore: string;
+}
+
+export interface HydrationEquivalentResult {
+  htmlBefore: string;
+  htmlAfter: string;
+  consoleMessages: HydrationEquivalentConsoleMessage[];
+}
+
+export interface HydrationEquivalentOptions {
+  html: string;
+  hydrate: (context: HydrationEquivalentContext) => Promise<void> | void;
+  selector?: string;
+  url?: string | URL;
+  fetcher?: typeof fetch;
+  failOnUnexpectedFetch?: boolean;
+  flush?: (context: HydrationEquivalentContext) => Promise<void> | void;
+  normalizeHtml?: (html: string) => string;
+  allowConsoleMessage?: (message: HydrationEquivalentConsoleMessage) => boolean;
+}
+
+export interface StrictCspDocumentAssertionOptions {
+  allowedOrigin?: string | URL;
+  cspNonce?: string | null;
+  scopeSelector?: string;
+  url?: string | URL;
+}
+
+export interface StrictCspFetchFixture {
+  body: string;
+  contentType?: string;
+  status?: number;
+  url?: string;
+}
+
+export interface StrictCspFixtureFetchResult {
+  fetcher: typeof fetch;
+  requests: string[];
+}
+
+export interface InstallFaceTestBrowserGlobalsOptions {
+  fetcher?: typeof fetch;
+  failOnUnexpectedFetch?: boolean;
+}
+
+interface TestDom {
+  window: FaceTestWindow;
+  close: () => void;
+}
+
+interface JsdomModule {
+  JSDOM: new (
+    html?: string,
+    options?: { pretendToBeVisual?: boolean; url?: string },
+  ) => {
+    window: Window & { close: () => void };
+  };
+}
+
+const DEFAULT_TEST_URL = 'http://localhost/';
+const DEFAULT_TEST_REQUEST_ID = 'facetheory-test-request';
+const REQUEST_ID_HEADER = 'x-request-id';
+const RAW_HEAD_ALLOWED_TAGS = new Set(['link', 'meta', 'script', 'title']);
+
+export function buildFaceRequest(
+  options: BuildFaceRequestOptions = {},
+): FaceRequest {
+  const requestUrl = resolveBuildFaceRequestUrl(options);
+  const headers = canonicalizeTestHeaders(options.headers);
+  if (!hasFirstHeader(headers, REQUEST_ID_HEADER)) {
+    headers[REQUEST_ID_HEADER] = [
+      normalizeRequestId(options.requestId ?? DEFAULT_TEST_REQUEST_ID),
+    ];
+  }
+
+  const request: FaceRequest = {
+    method: normalizeTestMethod(options.method),
+    path: normalizePath(requestUrl.pathname),
+    query:
+      options.query !== undefined
+        ? cloneQuery(options.query)
+        : parseQueryString(requestUrl.search),
+    headers,
+  };
+
+  if (options.cookies !== undefined)
+    request.cookies = cloneCookies(options.cookies);
+  if (options.body !== undefined) request.body = toRequestBody(options.body);
+  if (options.isBase64 !== undefined)
+    request.isBase64 = Boolean(options.isBase64);
+  if (options.cspNonce !== undefined) request.cspNonce = options.cspNonce;
+
+  return request;
+}
+
+export async function renderFace(
+  target: RenderFaceTarget,
+  options: RenderFaceOptions = {},
+): Promise<RenderedFace> {
+  const request = buildFaceRequest(requestOptionsForRender(options));
+  const app = resolveFaceAppLike(target, options);
+  const response = await app.handle(request);
+  const body = await collectFaceBody(response.body);
+  const text = new TextDecoder('utf-8', { fatal: false }).decode(body);
+  const collectedResponse: FaceResponse = {
+    ...response,
+    body,
+  };
+
+  return {
+    request,
+    response: collectedResponse,
+    body,
+    html: text,
+    text,
+    status: response.status,
+    headers: response.headers,
+  };
+}
+
+export async function assertHydrationEquivalent(
+  options: HydrationEquivalentOptions,
+): Promise<HydrationEquivalentResult> {
+  const dom = await createTestDom(
+    options.html,
+    String(options.url ?? DEFAULT_TEST_URL),
+  );
+  const restoreGlobals = installFaceTestBrowserGlobals(dom.window, {
+    ...(options.fetcher ? { fetcher: options.fetcher } : {}),
+    failOnUnexpectedFetch: options.failOnUnexpectedFetch ?? true,
+  });
+  const consoleCapture = captureHydrationConsole(dom.window);
+
+  try {
+    const doc = dom.window.document;
+    const container = resolveHydrationContainer(
+      doc,
+      options.selector ?? 'body',
+    );
+    const normalize = options.normalizeHtml ?? normalizeComparableHtml;
+    const htmlBefore = normalize(container.innerHTML);
+    const context: HydrationEquivalentContext = {
+      window: dom.window,
+      document: doc,
+      container,
+      htmlBefore,
+    };
+
+    await options.hydrate(context);
+    if (options.flush) {
+      await options.flush(context);
+    } else {
+      await flushFaceTestBrowserTasks();
+    }
+
+    const htmlAfter = normalize(container.innerHTML);
+    const consoleMessages = consoleCapture.messages();
+    const unexpectedHydrationMessages = consoleMessages.filter(
+      (message) =>
+        isHydrationConsoleMessage(message) &&
+        !(options.allowConsoleMessage?.(message) ?? false),
+    );
+
+    assert.equal(
+      unexpectedHydrationMessages.length,
+      0,
+      formatHydrationConsoleFailure(unexpectedHydrationMessages),
+    );
+    assert.equal(
+      htmlAfter,
+      htmlBefore,
+      formatHydrationDomFailure(htmlBefore, htmlAfter),
+    );
+
+    return { htmlBefore, htmlAfter, consoleMessages };
+  } finally {
+    consoleCapture.restore();
+    restoreGlobals();
+    dom.close();
+  }
+}
+
+export async function assertStrictCspDocument(
+  html: string,
+  options: StrictCspDocumentAssertionOptions = {},
+): Promise<void> {
+  validateStrictCspDocument(String(html), {
+    cspNonce: options.cspNonce ?? null,
+    policy: { inlineScripts: false, inlineStyles: false, rawHead: false },
+  });
+
+  const dom = await createTestDom(
+    String(html),
+    String(options.url ?? DEFAULT_TEST_URL),
+  );
+  try {
+    assertStrictCspDom(dom.window.document, options);
+  } finally {
+    dom.close();
+  }
+}
+
+export function assertStrictCspDom(
+  doc: Document,
+  options: StrictCspDocumentAssertionOptions = {},
+): void {
+  const allowedOrigin = new URL(
+    String(
+      options.allowedOrigin ??
+        doc.defaultView?.location.origin ??
+        DEFAULT_TEST_URL,
+    ),
+  ).origin;
+  assertNoInlineHeadOrBodyTags(doc, allowedOrigin);
+  assertNoRawHeadNodes(doc);
+  assertNoUnsafeAttributes(doc, options.scopeSelector ?? 'html');
+}
+
+export function createStrictCspFixtureFetch(
+  fixtures: Record<string, StrictCspFetchFixture | string | unknown>,
+  options: { baseUrl?: string | URL } = {},
+): StrictCspFixtureFetchResult {
+  const baseUrl = String(options.baseUrl ?? DEFAULT_TEST_URL);
+  const normalized = new Map<string, StrictCspFetchFixture>();
+
+  for (const [key, value] of Object.entries(fixtures)) {
+    const url = new URL(key, baseUrl).toString();
+    if (typeof value === 'string') {
+      normalized.set(url, { body: value, contentType: contentTypeForUrl(url) });
+    } else if (isFetchFixture(value)) {
+      normalized.set(url, value);
+    } else {
+      normalized.set(url, {
+        body: JSON.stringify(value),
+        contentType: 'application/json; charset=utf-8',
+      });
+    }
+  }
+
+  const requests: string[] = [];
+  const fetcher = (async (input) => {
+    const url = new URL(String(input), baseUrl).toString();
+    requests.push(url);
+    const fixture = normalized.get(url);
+    if (!fixture) {
+      return new Response('Not Found', {
+        status: 404,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }
+
+    return new Response(fixture.body, {
+      status: fixture.status ?? 200,
+      headers: {
+        'content-type': fixture.contentType ?? contentTypeForUrl(url),
+      },
+    });
+  }) as typeof fetch;
+
+  return { fetcher, requests };
+}
+
+export function installFaceTestBrowserGlobals(
+  win: FaceTestWindow,
+  options: InstallFaceTestBrowserGlobalsOptions = {},
+): () => void {
+  const previous = new Map<PropertyKey, unknown>();
+  const had = new Map<PropertyKey, boolean>();
+  const winRecord = win as FaceTestWindow & Record<PropertyKey, unknown>;
+
+  const setGlobal = (name: PropertyKey, value: unknown): void => {
+    had.set(name, Object.prototype.hasOwnProperty.call(globalThis, name));
+    previous.set(name, (globalThis as Record<PropertyKey, unknown>)[name]);
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      value,
+      writable: true,
+    });
+  };
+
+  installWindowPolyfills(win);
+
+  setGlobal('window', win);
+  setGlobal('document', win.document);
+  setGlobal('navigator', win.navigator);
+  setGlobal('HTMLElement', winRecord.HTMLElement);
+  setGlobal('SVGElement', winRecord.SVGElement);
+  setGlobal('Element', winRecord.Element);
+  setGlobal('Node', winRecord.Node);
+  setGlobal('Text', winRecord.Text);
+  setGlobal('Comment', winRecord.Comment);
+  setGlobal('CustomEvent', winRecord.CustomEvent);
+  setGlobal('Event', winRecord.Event);
+  setGlobal('MutationObserver', winRecord.MutationObserver);
+  setGlobal('getComputedStyle', win.getComputedStyle.bind(win));
+  if ('ResizeObserver' in win) {
+    setGlobal('ResizeObserver', winRecord.ResizeObserver);
+  }
+  setGlobal('requestAnimationFrame', win.requestAnimationFrame.bind(win));
+  setGlobal('cancelAnimationFrame', win.cancelAnimationFrame.bind(win));
+
+  if (options.fetcher) {
+    setGlobal('fetch', options.fetcher);
+  } else if (options.failOnUnexpectedFetch) {
+    setGlobal('fetch', unexpectedHydrationFetch);
+  }
+
+  return () => {
+    for (const [name, existed] of had) {
+      if (existed) {
+        Object.defineProperty(globalThis, name, {
+          configurable: true,
+          value: previous.get(name),
+          writable: true,
+        });
+      } else {
+        Reflect.deleteProperty(
+          globalThis as Record<PropertyKey, unknown>,
+          name,
+        );
+      }
+    }
+  };
+}
+
+export async function flushFaceTestBrowserTasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function createTestDom(html: string, url: string): Promise<TestDom> {
+  let jsdom: JsdomModule;
+  try {
+    jsdom = (await import('jsdom')) as unknown as JsdomModule;
+  } catch (error) {
+    throw new Error(
+      'FaceTheory testing helpers require jsdom. Install jsdom in the consumer test workspace before using @theory-cloud/facetheory/testing DOM helpers.',
+      { cause: error },
+    );
+  }
+
+  const dom = new jsdom.JSDOM(html, { pretendToBeVisual: true, url });
+  const win = dom.window as FaceTestWindow & { close: () => void };
+  return {
+    window: win,
+    close: () => win.close(),
+  };
+}
+
+function resolveBuildFaceRequestUrl(options: BuildFaceRequestOptions): URL {
+  const raw = String(options.url ?? options.path ?? '/');
+  return new URL(raw, DEFAULT_TEST_URL);
+}
+
+function normalizeTestMethod(method: string | undefined): string {
+  const normalized = String(method ?? 'GET')
+    .trim()
+    .toUpperCase();
+  return normalized || 'GET';
+}
+
+function normalizeRequestId(value: string): string {
+  const normalized = String(value ?? '').trim();
+  return normalized || DEFAULT_TEST_REQUEST_ID;
+}
+
+function canonicalizeTestHeaders(
+  headers: FaceTestHeaders | undefined,
+): FaceHeaders {
+  const converted: FaceHeaders = {};
+  for (const [name, rawValues] of Object.entries(headers ?? {})) {
+    const values = Array.isArray(rawValues) ? rawValues : [rawValues];
+    converted[name] = values.map((value) => String(value));
+  }
+  return canonicalizeHeaders(converted);
+}
+
+function hasFirstHeader(headers: FaceHeaders, name: string): boolean {
+  return String(headers[name]?.[0] ?? '').trim() !== '';
+}
+
+function toRequestBody(body: string | Uint8Array): Uint8Array {
+  return body instanceof Uint8Array
+    ? Uint8Array.from(body)
+    : new TextEncoder().encode(body);
+}
+
+function requestOptionsForRender(
+  options: RenderFaceOptions,
+): FaceRequest | BuildFaceRequestOptions {
+  return options.request ?? options;
+}
+
+function resolveFaceAppLike(
+  target: RenderFaceTarget,
+  options: RenderFaceOptions,
+): FaceAppLike {
+  if (
+    isFaceAppLike(target) &&
+    !isFaceModule(target) &&
+    !Array.isArray(target)
+  ) {
+    return target;
+  }
+
+  const faces = Array.isArray(target) ? [...target] : [target];
+  return createFaceApp({
+    ...(options.app ?? {}),
+    faces,
+  });
+}
+
+function isFaceAppLike(value: unknown): value is FaceAppLike {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { handle?: unknown }).handle === 'function'
+  );
+}
+
+function isFaceModule(value: unknown): value is FaceModule {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { render?: unknown }).render === 'function' &&
+    typeof (value as { route?: unknown }).route === 'string' &&
+    typeof (value as { mode?: unknown }).mode === 'string'
+  );
+}
+
+async function collectFaceBody(body: FaceBody): Promise<Uint8Array> {
+  if (body instanceof Uint8Array) return Uint8Array.from(body);
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for await (const chunk of body) {
+    const normalized =
+      chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+    chunks.push(normalized);
+    total += normalized.byteLength;
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function resolveHydrationContainer(doc: Document, selector: string): Element {
+  const container = doc.querySelector(selector);
+  assert.ok(
+    container,
+    `FaceTheory hydration test selector not found: ${selector}`,
+  );
+  return container;
+}
+
+function normalizeComparableHtml(html: string): string {
+  return html.trim();
+}
+
+function captureHydrationConsole(win: FaceTestWindow): {
+  messages: () => HydrationEquivalentConsoleMessage[];
+  restore: () => void;
+} {
+  const messages: HydrationEquivalentConsoleMessage[] = [];
+  const originalConsoleError = console.error;
+  const originalConsoleWarn = console.warn;
+  const originalWindowConsoleError = win.console.error;
+  const originalWindowConsoleWarn = win.console.warn;
+
+  const record =
+    (level: 'error' | 'warn') =>
+    (...args: unknown[]): void => {
+      messages.push({ level, args, text: formatConsoleArgs(args) });
+    };
+
+  console.error = record('error');
+  console.warn = record('warn');
+  win.console.error = record('error');
+  win.console.warn = record('warn');
+
+  return {
+    messages: () => [...messages],
+    restore: () => {
+      console.error = originalConsoleError;
+      console.warn = originalConsoleWarn;
+      win.console.error = originalWindowConsoleError;
+      win.console.warn = originalWindowConsoleWarn;
+    },
+  };
+}
+
+function formatConsoleArgs(args: readonly unknown[]): string {
+  return args.map((arg) => inspect(arg, { depth: 5 })).join(' ');
+}
+
+function isHydrationConsoleMessage(
+  message: HydrationEquivalentConsoleMessage,
+): boolean {
+  return /hydrat|server-rendered html|server rendered html|expected server html|text content did not match|did not match/i.test(
+    message.text,
+  );
+}
+
+function formatHydrationConsoleFailure(
+  messages: readonly HydrationEquivalentConsoleMessage[],
+): string {
+  if (messages.length === 0)
+    return 'FaceTheory hydration emitted no mismatch warnings';
+  return [
+    'FaceTheory hydration emitted framework mismatch warnings:',
+    ...messages.map((message) => `- ${message.level}: ${message.text}`),
+  ].join('\n');
+}
+
+function formatHydrationDomFailure(before: string, after: string): string {
+  return [
+    'FaceTheory hydration changed the tested DOM subtree.',
+    'Server HTML:',
+    before,
+    'Client HTML:',
+    after,
+  ].join('\n');
+}
+
+function installWindowPolyfills(win: FaceTestWindow): void {
+  const winRecord = win as FaceTestWindow & Record<PropertyKey, unknown>;
+  const originalGetComputedStyle = win.getComputedStyle.bind(win);
+  win.getComputedStyle = ((elt: Element) =>
+    originalGetComputedStyle(elt)) as typeof win.getComputedStyle;
+
+  if (typeof win.matchMedia !== 'function') {
+    winRecord.matchMedia = () => ({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    });
+  }
+
+  if (!('ResizeObserver' in win)) {
+    winRecord.ResizeObserver = class FaceTheoryTestResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    };
+  }
+
+  if (typeof win.requestAnimationFrame !== 'function') {
+    let nextFrameId = 1;
+    const frameTimers = new Map<number, ReturnType<typeof setTimeout>>();
+    winRecord.requestAnimationFrame = (
+      callback: FrameRequestCallback,
+    ): number => {
+      const id = nextFrameId++;
+      const timer = setTimeout(() => {
+        frameTimers.delete(id);
+        callback(Date.now());
+      }, 0);
+      frameTimers.set(id, timer);
+      return id;
+    };
+    winRecord.cancelAnimationFrame = (id: number): void => {
+      const timer = frameTimers.get(id);
+      if (timer) clearTimeout(timer);
+      frameTimers.delete(id);
+    };
+  }
+}
+
+function unexpectedHydrationFetch(input: RequestInfo | URL): Promise<Response> {
+  return Promise.reject(
+    new Error(
+      `FaceTheory hydration test attempted an unexpected fetch for ${String(input)}`,
+    ),
+  );
+}
+
+function assertNoRawHeadNodes(doc: Document): void {
+  for (const node of Array.from(doc.head.childNodes)) {
+    if (node.nodeType === doc.TEXT_NODE) {
+      assert.equal(
+        node.textContent?.trim() ?? '',
+        '',
+        `strict CSP raw head text node: ${node.textContent ?? ''}`,
+      );
+      continue;
+    }
+
+    assert.notEqual(
+      node.nodeType,
+      doc.COMMENT_NODE,
+      'strict CSP raw head comment node',
+    );
+
+    if (node.nodeType === doc.ELEMENT_NODE) {
+      const tagName = (node as Element).tagName.toLowerCase();
+      assert.ok(
+        RAW_HEAD_ALLOWED_TAGS.has(tagName),
+        `strict CSP unexpected raw head element: ${(node as Element).outerHTML}`,
+      );
+    }
+  }
+}
+
+function assertNoInlineHeadOrBodyTags(
+  doc: Document,
+  allowedOrigin: string,
+): void {
+  for (const script of Array.from(doc.querySelectorAll('script'))) {
+    const src = script.getAttribute('src');
+    assert.ok(src, `strict CSP inline script tag: ${script.outerHTML}`);
+    assert.equal(
+      script.textContent?.trim() ?? '',
+      '',
+      `strict CSP script body: ${script.outerHTML}`,
+    );
+    assertSameOriginUrl(src, allowedOrigin, doc.URL, 'strict CSP script src');
+  }
+
+  const styleTag = doc.querySelector('style');
+  assert.equal(
+    styleTag,
+    null,
+    `strict CSP inline style tag: ${styleTag?.outerHTML ?? ''}`,
+  );
+
+  for (const link of Array.from(doc.querySelectorAll('link[href]'))) {
+    const href = link.getAttribute('href');
+    if (href)
+      assertSameOriginUrl(href, allowedOrigin, doc.URL, 'strict CSP link href');
+  }
+}
+
+function assertNoUnsafeAttributes(doc: Document, scopeSelector: string): void {
+  const scopes = Array.from(doc.querySelectorAll(scopeSelector));
+  assert.ok(
+    scopes.length > 0,
+    `strict CSP validation scope not found: ${scopeSelector}`,
+  );
+
+  for (const scope of scopes) {
+    const elements = [scope, ...Array.from(scope.querySelectorAll('*'))];
+    for (const element of elements) {
+      for (const name of element.getAttributeNames()) {
+        assert.ok(
+          !/^on[a-z]/i.test(name),
+          `strict CSP inline event handler attribute ${name}: ${element.outerHTML}`,
+        );
+        assert.notEqual(
+          name.toLowerCase(),
+          'style',
+          `strict CSP inline style attribute: ${element.outerHTML}`,
+        );
+      }
+    }
+  }
+}
+
+function assertSameOriginUrl(
+  value: string,
+  allowedOrigin: string,
+  baseUrl: string,
+  label: string,
+): void {
+  const url = new URL(value, baseUrl);
+  assert.equal(
+    url.origin,
+    allowedOrigin,
+    `${label} must be same-origin: ${url.toString()}`,
+  );
+}
+
+function contentTypeForUrl(url: string): string {
+  const pathname = new URL(url, DEFAULT_TEST_URL).pathname;
+  if (pathname.endsWith('.json')) return 'application/json; charset=utf-8';
+  if (
+    pathname.endsWith('.html') ||
+    pathname === '/' ||
+    !pathname.includes('.')
+  ) {
+    return 'text/html; charset=utf-8';
+  }
+  return 'text/plain; charset=utf-8';
+}
+
+function isFetchFixture(value: unknown): value is StrictCspFetchFixture {
+  return Boolean(
+    value &&
+    typeof value === 'object' &&
+    'body' in value &&
+    typeof (value as StrictCspFetchFixture).body === 'string',
+  );
+}

--- a/ts/test/unit/client-hydration.test.ts
+++ b/ts/test/unit/client-hydration.test.ts
@@ -8,6 +8,7 @@ import {
   loadFaceHydrationData,
   readFaceExternalHydrationDataUrl,
   readFaceInlineHydrationData,
+  reportHydrationFailure,
   resolveSameOriginFaceHydrationUrl,
 } from '../../src/client/index.js';
 
@@ -34,7 +35,10 @@ test('client hydration loader: reads inline hydration before external links', as
 
   try {
     let fetchCalls = 0;
-    const data = await loadFaceHydrationData<{ roles: string[]; subject: string }>({
+    const data = await loadFaceHydrationData<{
+      roles: string[];
+      subject: string;
+    }>({
       document: dom.window.document,
       fetcher: async () => {
         fetchCalls += 1;
@@ -91,7 +95,9 @@ test('client hydration loader: treats spoofed inline markers as absent', async (
 
       assert.equal(readFaceInlineHydrationData(dom.window.document), null);
       assert.deepEqual(data, { route: 'external-home' });
-      assert.deepEqual(fetched, ['https://app.test/_facetheory/ssr-data/home.json']);
+      assert.deepEqual(fetched, [
+        'https://app.test/_facetheory/ssr-data/home.json',
+      ]);
     } finally {
       dom.window.close();
     }
@@ -134,9 +140,10 @@ test('client hydration loader: fetches same-origin external hydration data', asy
       readFaceExternalHydrationDataUrl(dom.window.document),
       '/_facetheory/ssr-data/home.json',
     );
-    assert.deepEqual(fetched.map((entry) => entry.input), [
-      'https://app.test/_facetheory/ssr-data/home.json',
-    ]);
+    assert.deepEqual(
+      fetched.map((entry) => entry.input),
+      ['https://app.test/_facetheory/ssr-data/home.json'],
+    );
     assert.equal(fetched[0]?.init?.credentials, 'same-origin');
     assert.equal(fetched[0]?.init?.redirect, 'follow');
     assert.equal(
@@ -155,12 +162,18 @@ test('client hydration loader: fetches same-origin external hydration data', asy
 });
 
 test('client hydration loader: returns null when no hydration marker is present', async () => {
-  const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>', {
-    url: 'https://app.test/empty',
-  });
+  const dom = new JSDOM(
+    '<!doctype html><html><head></head><body></body></html>',
+    {
+      url: 'https://app.test/empty',
+    },
+  );
 
   try {
-    assert.equal(await loadFaceHydrationData({ document: dom.window.document }), null);
+    assert.equal(
+      await loadFaceHydrationData({ document: dom.window.document }),
+      null,
+    );
   } finally {
     dom.window.close();
   }
@@ -294,4 +307,125 @@ test('client hydration loader: rejects non-JSON and invalid JSON responses', asy
     }),
     /hydration data response was not valid JSON/,
   );
+});
+
+test('client hydration beacon: reports opted-in hydrate failures with same-origin sendBeacon', () => {
+  const dom = new JSDOM(
+    '<!doctype html><html><body><main id="root"></main></body></html>',
+    {
+      url: 'https://app.test/checkout?cart=cart_test',
+    },
+  );
+
+  try {
+    const beacons: Array<{ body: string; url: string }> = [];
+    Object.defineProperty(dom.window.navigator, 'sendBeacon', {
+      configurable: true,
+      value: (url: string | URL, data?: BodyInit | null) => {
+        beacons.push({ url: String(url), body: String(data ?? '') });
+        return true;
+      },
+    });
+
+    const report = reportHydrationFailure({
+      document: dom.window.document,
+      endpoint: '/ops/hydration-failure',
+      framework: 'react',
+      navigator: dom.window.navigator,
+      tags: { surface: 'checkout', ignored: null },
+    });
+
+    assert.equal(beacons.length, 0);
+
+    report(
+      new Error('Hydration failed because the server HTML did not match'),
+      {
+        componentStack: 'at Checkout',
+        digest: 'react-digest',
+      },
+    );
+
+    assert.equal(beacons.length, 1);
+    const firstBeacon = beacons[0];
+    assert.ok(firstBeacon);
+    assert.equal(firstBeacon.url, 'https://app.test/ops/hydration-failure');
+    assert.deepEqual(JSON.parse(firstBeacon.body), {
+      componentStack: 'at Checkout',
+      digest: 'react-digest',
+      errorClass: 'Error',
+      event: 'facetheory.hydration_failure',
+      framework: 'react',
+      message: 'Hydration failed because the server HTML did not match',
+      path: '/checkout?cart=cart_test',
+      tags: { surface: 'checkout' },
+    });
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('client hydration beacon: falls back to same-origin keepalive fetch', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'https://app.test/account',
+  });
+
+  try {
+    const posts: Array<{
+      body: string | null;
+      input: string;
+      init: RequestInit | undefined;
+    }> = [];
+    const report = reportHydrationFailure({
+      document: dom.window.document,
+      endpoint: '/ops/hydration-failure',
+      framework: 'vue',
+      fetcher: async (input, init) => {
+        posts.push({
+          input: String(input),
+          init,
+          body: typeof init?.body === 'string' ? init.body : null,
+        });
+        return new Response(null, { status: 204 });
+      },
+      navigator: { sendBeacon: () => false },
+    });
+
+    report('Vue hydration mismatch');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0]?.input, 'https://app.test/ops/hydration-failure');
+    assert.equal(posts[0]?.init?.method, 'POST');
+    assert.equal(posts[0]?.init?.credentials, 'same-origin');
+    assert.equal(posts[0]?.init?.keepalive, true);
+    assert.equal(posts[0]?.init?.redirect, 'error');
+    assert.deepEqual(JSON.parse(posts[0]?.body ?? '{}'), {
+      errorClass: 'NonError_string',
+      event: 'facetheory.hydration_failure',
+      framework: 'vue',
+      message: 'Vue hydration mismatch',
+      path: '/account',
+    });
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('client hydration beacon: rejects cross-origin endpoints before wiring', () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'https://app.test/',
+  });
+
+  try {
+    assert.throws(
+      () =>
+        reportHydrationFailure({
+          document: dom.window.document,
+          endpoint: 'https://evil.test/ops/hydration-failure',
+        }),
+      /hydration failure endpoint must be a same-origin/,
+    );
+  } finally {
+    dom.window.close();
+  }
 });

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -131,6 +131,43 @@ test('isr: stale burst triggers one regeneration and waiters share result', asyn
   );
 });
 
+test('isr: in-memory invalidate deletes meta so the next request regenerates', async () => {
+  const htmlStore = new InMemoryHtmlStore();
+  const metaStore = new InMemoryIsrMetaStore();
+  let renderCount = 0;
+
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/invalidate',
+        mode: 'isr',
+        revalidateSeconds: 60,
+        render: () => ({ html: `<main>render-${++renderCount}</main>` }),
+      },
+    ],
+    isr: { htmlStore, metaStore },
+  });
+
+  const warm = await app.handle({ method: 'GET', path: '/invalidate' });
+  assert.equal(warm.headers['x-facetheory-isr']?.[0], 'miss');
+  assert.ok(decodeBody(warm.body as Uint8Array).includes('render-1'));
+
+  const hit = await app.handle({ method: 'GET', path: '/invalidate' });
+  assert.equal(hit.headers['x-facetheory-isr']?.[0], 'hit');
+  assert.ok(decodeBody(hit.body as Uint8Array).includes('render-1'));
+
+  const cacheKey = metaStore.debugSnapshot()[0]?.cacheKey;
+  assert.ok(cacheKey);
+  assert.ok(cacheKey.includes('default::/invalidate?'));
+  await metaStore.invalidate(cacheKey);
+  assert.deepEqual(metaStore.debugSnapshot(), []);
+
+  const regenerated = await app.handle({ method: 'GET', path: '/invalidate' });
+  assert.equal(regenerated.headers['x-facetheory-isr']?.[0], 'miss');
+  assert.ok(decodeBody(regenerated.body as Uint8Array).includes('render-2'));
+  assert.equal(renderCount, 2);
+});
+
 test('isr: regeneration failure serves stale and keeps pointer intact', async () => {
   const htmlStore = new InMemoryHtmlStore();
   const metaStore = new InMemoryIsrMetaStore();
@@ -765,6 +802,10 @@ class RecordingMetaStore implements IsrMetaStore {
     return await this.inner.get(cacheKey);
   }
 
+  async invalidate(cacheKey: string): Promise<void> {
+    await this.inner.invalidate(cacheKey);
+  }
+
   async tryAcquireLease(
     input: TryAcquireIsrLeaseInput,
   ): Promise<TryAcquireIsrLeaseResult> {
@@ -786,6 +827,10 @@ class CspMetadataDroppingMetaStore implements IsrMetaStore {
 
   async get(cacheKey: string): Promise<IsrMetaRecord | null> {
     return dropCspMetadata(await this.inner.get(cacheKey));
+  }
+
+  async invalidate(cacheKey: string): Promise<void> {
+    await this.inner.invalidate(cacheKey);
   }
 
   async tryAcquireLease(
@@ -838,6 +883,10 @@ class ToggleableFailingMetaStore implements IsrMetaStore {
     return await this.inner.get(cacheKey);
   }
 
+  async invalidate(cacheKey: string): Promise<void> {
+    await this.inner.invalidate(cacheKey);
+  }
+
   async tryAcquireLease(
     input: TryAcquireIsrLeaseInput,
   ): Promise<TryAcquireIsrLeaseResult> {
@@ -863,6 +912,10 @@ class StatusContentTypeDroppingMetaStore implements IsrMetaStore {
 
   async get(cacheKey: string): Promise<IsrMetaRecord | null> {
     return dropStatusContentType(await this.inner.get(cacheKey));
+  }
+
+  async invalidate(cacheKey: string): Promise<void> {
+    await this.inner.invalidate(cacheKey);
   }
 
   async tryAcquireLease(

--- a/ts/test/unit/isr.test.ts
+++ b/ts/test/unit/isr.test.ts
@@ -67,6 +67,7 @@ test('isr: stale burst triggers one regeneration and waiters share result', asyn
 
   let nowMs = 1_000;
   let renderCount = 0;
+  const metrics: Array<Record<string, unknown>> = [];
 
   const app = createFaceApp({
     faces: [
@@ -81,6 +82,10 @@ test('isr: stale burst triggers one regeneration and waiters share result', asyn
         },
       },
     ],
+    observability: {
+      metric: (record) =>
+        metrics.push(record as unknown as Record<string, unknown>),
+    },
     isr: {
       htmlStore,
       metaStore,
@@ -112,6 +117,18 @@ test('isr: stale burst triggers one regeneration and waiters share result', asyn
       ),
     );
   }
+
+  const leaseContentionMetrics = metrics.filter(
+    (metric) => metric.name === 'facetheory.isr.lease_contention',
+  );
+  assert.ok(leaseContentionMetrics.length >= 1);
+  assert.ok(
+    leaseContentionMetrics.every(
+      (metric) =>
+        (metric.tags as Record<string, string>).route_pattern ===
+        '/posts/{slug}',
+    ),
+  );
 });
 
 test('isr: regeneration failure serves stale and keeps pointer intact', async () => {
@@ -990,7 +1007,8 @@ test('isr: cache hits preserve status and content type from HTML metadata', asyn
 test('isr: metadata get failure serves last-known stale entry with degraded state', async () => {
   const htmlStore = new InMemoryHtmlStore();
   const metaStore = new ToggleableFailingMetaStore();
-  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> =
+    [];
   const metrics: Array<Record<string, unknown>> = [];
 
   let nowMs = 10_000;
@@ -1018,7 +1036,8 @@ test('isr: metadata get failure serves last-known stale entry with degraded stat
           err,
           ctx: ctx as unknown as Record<string, unknown>,
         }),
-      metric: (record) => metrics.push(record as unknown as Record<string, unknown>),
+      metric: (record) =>
+        metrics.push(record as unknown as Record<string, unknown>),
     },
   });
 
@@ -1037,10 +1056,7 @@ test('isr: metadata get failure serves last-known stale entry with degraded stat
 
   assert.equal(stale.status, 200);
   assert.ok(decodeBody(stale.body as Uint8Array).includes('read-1'));
-  assert.equal(
-    stale.headers['x-facetheory-isr']?.[0],
-    'stale-metadata-error',
-  );
+  assert.equal(stale.headers['x-facetheory-isr']?.[0], 'stale-metadata-error');
   assert.equal(renderCount, 1);
   assert.equal(observedErrors.length, 1);
   assert.equal(observedErrors[0]?.err, metadataError);
@@ -1059,7 +1075,8 @@ test('isr: metadata get failure serves last-known stale entry with degraded stat
 test('isr: metadata get failure honors error policy instead of serving stale', async () => {
   const htmlStore = new InMemoryHtmlStore();
   const metaStore = new ToggleableFailingMetaStore();
-  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> =
+    [];
 
   let nowMs = 40_000;
   let renderCount = 0;
@@ -1182,7 +1199,8 @@ test('isr: metadata-failure last-known records evict least-recent cache keys', a
 test('isr: lease failure serves current stale entry with degraded state', async () => {
   const htmlStore = new InMemoryHtmlStore();
   const metaStore = new ToggleableFailingMetaStore();
-  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> =
+    [];
 
   let nowMs = 20_000;
   let renderCount = 0;
@@ -1225,10 +1243,7 @@ test('isr: lease failure serves current stale entry with degraded state', async 
 
   assert.equal(stale.status, 200);
   assert.ok(decodeBody(stale.body as Uint8Array).includes('lease-1'));
-  assert.equal(
-    stale.headers['x-facetheory-isr']?.[0],
-    'stale-metadata-error',
-  );
+  assert.equal(stale.headers['x-facetheory-isr']?.[0], 'stale-metadata-error');
   assert.equal(renderCount, 1);
   assert.equal(observedErrors.length, 1);
   assert.equal(observedErrors[0]?.err, leaseError);
@@ -1240,7 +1255,8 @@ test('isr: metadata failure without a serveable entry returns 500 through onErro
   const htmlStore = new InMemoryHtmlStore();
   const metaStore = new ToggleableFailingMetaStore();
   const metadataError = new Error('metadata unavailable before warm');
-  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> = [];
+  const observedErrors: Array<{ err: unknown; ctx: Record<string, unknown> }> =
+    [];
   metaStore.getError = metadataError;
 
   const app = createFaceApp({

--- a/ts/test/unit/ops.test.ts
+++ b/ts/test/unit/ops.test.ts
@@ -25,12 +25,21 @@ test('FaceApp: observability hooks receive request + ISR state + render duration
     observability: {
       now,
       log: (record) => logs.push(record as unknown as Record<string, unknown>),
-      metric: (record) => metrics.push(record as unknown as Record<string, unknown>),
+      metric: (record) =>
+        metrics.push(record as unknown as Record<string, unknown>),
     },
   });
 
-  await app.handle({ method: 'GET', path: '/isr', headers: { 'x-request-id': ['req-1'] } });
-  await app.handle({ method: 'GET', path: '/isr', headers: { 'x-request-id': ['req-2'] } });
+  await app.handle({
+    method: 'GET',
+    path: '/isr',
+    headers: { 'x-request-id': ['req-1'] },
+  });
+  await app.handle({
+    method: 'GET',
+    path: '/isr',
+    headers: { 'x-request-id': ['req-2'] },
+  });
 
   assert.equal(logs.length, 2);
 
@@ -49,15 +58,45 @@ test('FaceApp: observability hooks receive request + ISR state + render duration
   const requestMetrics = metrics.filter((m) => m.name === 'facetheory.request');
   assert.equal(requestMetrics.length, 2);
   assert.equal(
-    (requestMetrics[0]?.tags as Record<string, string> | undefined)?.error_class,
+    (requestMetrics[0]?.tags as Record<string, string> | undefined)
+      ?.error_class,
     '',
   );
 
-  const renderMetrics = metrics.filter((m) => m.name === 'facetheory.render_ms');
+  assert.equal(
+    (requestMetrics[0]?.tags as Record<string, string> | undefined)?.cold_start,
+    '1',
+  );
+  assert.equal(
+    (requestMetrics[1]?.tags as Record<string, string> | undefined)?.cold_start,
+    '0',
+  );
+
+  const isrCacheMetrics = metrics.filter(
+    (m) => m.name === 'facetheory.isr.cache',
+  );
+  assert.deepEqual(
+    isrCacheMetrics.map(
+      (metric) => (metric.tags as Record<string, string>).state,
+    ),
+    ['miss', 'hit'],
+  );
+
+  const regenerationMetrics = metrics.filter(
+    (m) => m.name === 'facetheory.isr.regeneration_ms',
+  );
+  assert.equal(regenerationMetrics.length, 1);
+  assert.equal(
+    (regenerationMetrics[0]?.tags as Record<string, string> | undefined)
+      ?.outcome,
+    'success',
+  );
+
+  const renderMetrics = metrics.filter(
+    (m) => m.name === 'facetheory.render_ms',
+  );
   assert.equal(renderMetrics.length, 1);
 });
-
-
 
 test('FaceApp: request metrics tag deterministic render errors by class', async () => {
   const renderError = new TypeError('sensitive typed failure');
@@ -75,8 +114,10 @@ test('FaceApp: request metrics tag deterministic render errors by class', async 
       },
     ],
     observability: {
-      onError: (err, ctx) => errors.push({ err, ctx: ctx as unknown as Record<string, unknown> }),
-      metric: (record) => metrics.push(record as unknown as Record<string, unknown>),
+      onError: (err, ctx) =>
+        errors.push({ err, ctx: ctx as unknown as Record<string, unknown> }),
+      metric: (record) =>
+        metrics.push(record as unknown as Record<string, unknown>),
     },
   });
 

--- a/ts/test/unit/streaming.test.ts
+++ b/ts/test/unit/streaming.test.ts
@@ -250,11 +250,11 @@ test('FaceApp: strict CSP streaming responses are coerced to validated buffered 
 test('FaceApp: strict CSP streaming with nonce validates the full document before responding', async () => {
   let streamChunksRead = 0;
   const metrics: Array<{ name: string; tags?: Record<string, string> }> = [];
-  const logs: Array<{ isStream?: boolean }> = [];
+  const logs: Array<Record<string, unknown>> = [];
   const app = createFaceApp({
     observability: {
       metric: (entry) => metrics.push(entry),
-      log: (entry) => logs.push(entry),
+      log: (entry) => logs.push(entry as unknown as Record<string, unknown>),
     },
     faces: [
       {
@@ -920,32 +920,71 @@ test('react adapter: streaming applies CSP nonce to all inline style/script tags
 });
 
 test('FaceApp: streaming body error emits marker and closes document', async () => {
-  const app = createFaceApp({
-    faces: [
-      {
-        route: '/',
-        mode: 'ssr',
-        render: () => ({
-          headTags: [{ type: 'title', text: 'Err' }],
-          html: (async function* () {
-            yield utf8('<main>ok</main>');
-            throw new Error('boom');
-          })(),
-        }),
-      },
-    ],
-  });
+  const createStreamingErrorApp = (
+    observability?: Parameters<typeof createFaceApp>[0]['observability'],
+  ) =>
+    createFaceApp({
+      ...(observability ? { observability } : {}),
+      faces: [
+        {
+          route: '/',
+          mode: 'ssr',
+          render: () => ({
+            headTags: [{ type: 'title', text: 'Err' }],
+            html: (async function* () {
+              yield utf8('<main>ok</main>');
+              throw new Error('boom');
+            })(),
+          }),
+        },
+      ],
+    });
 
   const originalConsoleError = console.error;
   console.error = () => {};
   try {
-    const resp = await app.handle({ method: 'GET', path: '/' });
+    const baselineResp = await createStreamingErrorApp().handle({
+      method: 'GET',
+      path: '/',
+    });
+    const baselineFull = new TextDecoder().decode(
+      await collectBody(baselineResp.body),
+    );
+
+    const logs: Array<Record<string, unknown>> = [];
+    const metrics: Array<Record<string, unknown>> = [];
+    const resp = await createStreamingErrorApp({
+      log: (record) => logs.push(record as unknown as Record<string, unknown>),
+      metric: (record) =>
+        metrics.push(record as unknown as Record<string, unknown>),
+    }).handle({
+      method: 'GET',
+      path: '/',
+      headers: { 'x-request-id': ['req-stream'] },
+    });
     assert.ok(!(resp.body instanceof Uint8Array));
 
     const full = new TextDecoder().decode(await collectBody(resp.body));
+    assert.equal(full, baselineFull);
     assert.ok(full.includes('<main>ok</main>'));
     assert.ok(full.includes('data-facetheory-stream-error="true"'));
     assert.ok(full.endsWith('</body></html>'));
+
+    const streamLog = logs.find(
+      (record) => record.event === 'facetheory.stream_error',
+    );
+    assert.ok(streamLog);
+    assert.equal(streamLog.requestId, 'req-stream');
+    assert.equal(streamLog.errorClass, 'Error');
+
+    const streamMetric = metrics.find(
+      (record) => record.name === 'facetheory.stream_error',
+    );
+    assert.ok(streamMetric);
+    assert.equal(
+      (streamMetric.tags as Record<string, string>).error_class,
+      'Error',
+    );
   } finally {
     console.error = originalConsoleError;
   }

--- a/ts/test/unit/tabletheory-isr-meta-store.test.ts
+++ b/ts/test/unit/tabletheory-isr-meta-store.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { TableTheoryIsrMetaStoreAdapter } from '../../src/tabletheory/index.js';
+import {
+  IsrInvalidateUnsupportedError,
+  TableTheoryIsrMetaStoreAdapter,
+} from '../../src/tabletheory/index.js';
 
 test('tabletheory adapter: get returns null when missing', async () => {
   const adapter = new TableTheoryIsrMetaStoreAdapter({
@@ -154,3 +157,21 @@ test('tabletheory adapter: commitGeneration maps args to TableTheory store', asy
   assert.equal(seen.etag, '"e"');
 });
 
+test('tabletheory adapter: invalidate throws pending-coordination error', async () => {
+  const adapter = new TableTheoryIsrMetaStoreAdapter({
+    get: async () => null,
+    tryAcquireLease: async () => null,
+    commitGeneration: async () => {},
+    releaseLease: async () => {},
+  } as any);
+
+  await assert.rejects(
+    () => adapter.invalidate('cache-key'),
+    (err: unknown) => {
+      assert.ok(err instanceof IsrInvalidateUnsupportedError);
+      assert.equal(err.cacheKey, 'cache-key');
+      assert.match(String(err.message), /pending TableTheory coordination/i);
+      return true;
+    },
+  );
+});

--- a/ts/test/unit/testing.test.ts
+++ b/ts/test/unit/testing.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  assertHydrationEquivalent,
+  assertStrictCspDocument,
+  buildFaceRequest,
+  createStrictCspFixtureFetch,
+  renderFace,
+} from '../../src/testing/index.js';
+import type { FaceModule } from '../../src/types.js';
+
+test('testing subpath: buildFaceRequest and renderFace render a Face without Lambda events', async () => {
+  const request = buildFaceRequest({
+    url: 'https://example.test/hello?name=Ada&tag=one&tag=two',
+    headers: { cookie: 'session=test' },
+    cspNonce: 'nonce-test',
+  });
+
+  assert.equal(request.method, 'GET');
+  assert.equal(request.path, '/hello');
+  assert.deepEqual(request.query, { name: ['Ada'], tag: ['one', 'two'] });
+  assert.deepEqual(request.headers?.['x-request-id'], [
+    'facetheory-test-request',
+  ]);
+
+  const face: FaceModule<{ name: string }> = {
+    route: '/hello',
+    mode: 'ssr',
+    load: (ctx) => ({ name: ctx.request.query.name?.[0] ?? 'unknown' }),
+    render: (_ctx, data) => ({
+      head: { title: 'Hello' },
+      html: `<main id="root"><h1>Hello ${data.name}</h1></main>`,
+    }),
+  };
+
+  const rendered = await renderFace(face, { request });
+
+  assert.equal(rendered.status, 200);
+  assert.equal(rendered.request.path, '/hello');
+  assert.match(rendered.html, /<title>Hello<\/title>/);
+  assert.match(rendered.html, /<h1>Hello Ada<\/h1>/);
+  assert.deepEqual(rendered.headers['x-request-id'], [
+    'facetheory-test-request',
+  ]);
+});
+
+test('testing subpath: assertHydrationEquivalent detects DOM drift and hydration warnings', async () => {
+  const html =
+    '<!doctype html><html><body><main id="root"><span>Stable</span></main></body></html>';
+
+  await assertHydrationEquivalent({
+    html,
+    selector: '#root',
+    hydrate: () => undefined,
+  });
+
+  await assert.rejects(
+    () =>
+      assertHydrationEquivalent({
+        html,
+        selector: '#root',
+        hydrate: ({ container }) => {
+          const span = container.querySelector('span');
+          if (span) span.textContent = 'Changed';
+        },
+      }),
+    /hydration changed the tested DOM subtree/,
+  );
+
+  await assert.rejects(
+    () =>
+      assertHydrationEquivalent({
+        html,
+        selector: '#root',
+        hydrate: ({ window }) => {
+          window.console.error(
+            'Hydration failed because server HTML did not match',
+          );
+        },
+      }),
+    /framework mismatch warnings/,
+  );
+});
+
+test('testing subpath: strict CSP assertions and fixture fetch are reusable by consumers', async () => {
+  await assertStrictCspDocument(
+    '<!doctype html><html><head><script src="/app.js"></script><link rel="stylesheet" href="/app.css"></head><body><main id="root"></main></body></html>',
+  );
+
+  await assert.rejects(
+    () =>
+      assertStrictCspDocument(
+        '<!doctype html><html><head><script>window.__bad = true</script></head><body></body></html>',
+      ),
+    /inline script/,
+  );
+
+  const { fetcher, requests } = createStrictCspFixtureFetch({
+    '/data.json': { ok: true },
+  });
+  const response = await fetcher('http://localhost/data.json');
+  assert.equal(
+    response.headers.get('content-type'),
+    'application/json; charset=utf-8',
+  );
+  assert.deepEqual(await response.json(), { ok: true });
+  assert.deepEqual(requests, ['http://localhost/data.json']);
+});


### PR DESCRIPTION
## Summary
- add the `@theory-cloud/facetheory/testing` subpath with Face request builders, Face rendering helpers, hydration equivalence assertions, and strict-CSP fixture helpers
- add an opt-in client `reportHydrationFailure({ endpoint })` helper for same-origin hydration failure beacons
- add ISR/cache/stream observability metrics, structured stream-error logging, and first-request cold-start metric tagging without changing stream bytes
- add `IsrMetaStore.invalidate(cacheKey)`, in-memory invalidation, and explicit TableTheory unsupported error pending coordination

Refs THE-2480
Refs THE-2481
Refs THE-2482
Refs THE-2483

## Validation
- `cd ts && npm run check` — PASS (639 tests: 638 pass, 1 skipped)
- `cd ts && node --import tsx --test test/unit/testing.test.ts` — PASS (3 tests)
- `cd ts && node --import tsx --test test/unit/client-hydration.test.ts` — PASS (13 tests)
- `cd ts && node --import tsx --test test/unit/isr.test.ts test/unit/tabletheory-isr-meta-store.test.ts` — PASS (33 tests)
- `cd ts && node --import tsx --test test/unit/ops.test.ts test/unit/streaming.test.ts` — PASS (21 tests)
- `bash scripts/verify-ts-pack.sh` — PASS (`theory-cloud-facetheory-3.8.1.tgz`)
- `bash scripts/verify-version-alignment.sh` — PASS (3.8.1)
- `cd ts && timeout 10s npm run example:streaming:serve` — server started on `http://localhost:4173/`, then timed out as expected because the script is a long-running server; streaming unit/golden tests above substitute for non-hanging completion
- `git diff --check origin/theorymcp/theorycloud/facetheory/product-strengthening-plans-2026-07-02..HEAD` — PASS

## Notes
- No hosted-auth source changes; M8 shared-core adapter boundary is preserved.
- TableTheory invalidate remains intentionally unsupported here; production support needs a TableTheory first-class invalidation/delete operation before FaceTheory can wire the adapter.
- Hydration beacon is opt-in only; importing/wiring is required for any client behavior change.