### PR TITLE
feat(ssg): improve SSG build throughput

### DIFF
--- a/docs/modes/ssg.md
+++ b/docs/modes/ssg.md
@@ -42,15 +42,35 @@ Use `generateStaticParams` for parameterized routes:
 
 ```typescript
 import { buildSsgSite } from '@theory-cloud/facetheory';
-import { app } from './app.js';
+import { faces } from './app.js';
 
 await buildSsgSite({
-  app,
+  faces,
   outDir: './dist-static',
 });
 ```
 
 The CLI form is `npm run ssg` (defined in `ts/package.json` as `tsx src/ssg-cli.ts`). See `ts/examples/ssg-basic/` for a working end-to-end build + serve.
+
+## Throughput and route failures
+
+SSG builds are serial by default (`concurrency: 1`) to preserve the historical build shape. Raise the bounded route-render concurrency when a build has many independent pages:
+
+```typescript
+await buildSsgSite({
+  faces,
+  outDir: './dist-static',
+  concurrency: 4,
+});
+```
+
+The CLI equivalent is:
+
+```bash
+npm run ssg -- --entry ./ssg.config.ts --out ./dist-static --concurrency 4
+```
+
+When one route fails, FaceTheory continues rendering the remaining planned routes. Successful pages and the manifest for those pages are still written, then the build reports the failed routes and exits non-zero (or `buildSsgSite` rejects with `SsgBuildFailedError` for programmatic callers).
 
 ## Related helpers
 

--- a/docs/modes/ssg.md
+++ b/docs/modes/ssg.md
@@ -72,6 +72,28 @@ npm run ssg -- --entry ./ssg.config.ts --out ./dist-static --concurrency 4
 
 When one route fails, FaceTheory continues rendering the remaining planned routes. Successful pages and the manifest for those pages are still written, then the build reports the failed routes and exits non-zero (or `buildSsgSite` rejects with `SsgBuildFailedError` for programmatic callers).
 
+## Incremental builds
+
+Full clean output remains the default: `buildSsgSite` removes the output directory before writing so removed routes or stale assets do not linger.
+
+Use incremental builds when a local or CI cache already holds the previous SSG output and you want unchanged route files to keep their existing bytes and mtimes:
+
+```typescript
+await buildSsgSite({
+  faces,
+  outDir: './dist-static',
+  incremental: true,
+});
+```
+
+The CLI flag is:
+
+```bash
+npm run ssg -- --entry ./ssg.config.ts --out ./dist-static --incremental
+```
+
+Incremental mode does not run `rm -rf` on the output directory. Each route is still rendered so FaceTheory can compute a SHA-256 content hash over the rendered HTML and any emitted hydration sidecar. If the hash matches the previous `.facetheory/ssg-manifest.json` entry and the expected files are still present with matching bytes, FaceTheory skips rewriting that route and reports it in `skippedRoutes`. Run a full clean build when you need to prune routes or files that no longer exist.
+
 ## Related helpers
 
 - `planSsgPages(faces)` — preview the routes and params the build will produce, without writing files.

--- a/ts/src/ssg-cli.ts
+++ b/ts/src/ssg-cli.ts
@@ -219,8 +219,12 @@ function isDirectExecution(): boolean {
 }
 
 if (isDirectExecution()) {
-  runSsgCli().catch((err) => {
-    console.error(err instanceof Error ? err.message : String(err));
-    process.exitCode = 1;
-  });
+  runSsgCli()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((err) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 1;
+    });
 }

--- a/ts/src/ssg-cli.ts
+++ b/ts/src/ssg-cli.ts
@@ -24,6 +24,7 @@ interface ParsedSsgCliArgs {
   outDir: string;
   trailingSlash?: SsgTrailingSlashPolicy;
   concurrency?: number;
+  incremental: boolean;
   allowNetwork: boolean;
   emitHydrationData: boolean;
 }
@@ -38,6 +39,7 @@ export async function runSsgCli(argv: string[] = process.argv.slice(2)): Promise
 
   const trailingSlash = args.trailingSlash ?? moduleOptions.trailingSlash;
   const concurrency = args.concurrency ?? moduleOptions.concurrency;
+  const incremental = args.incremental || (moduleOptions.incremental ?? false);
   const allowNetwork = args.allowNetwork || (moduleOptions.allowNetwork ?? false);
   const emitHydrationData = args.emitHydrationData || (moduleOptions.emitHydrationData ?? false);
 
@@ -47,6 +49,7 @@ export async function runSsgCli(argv: string[] = process.argv.slice(2)): Promise
     outDir: path.resolve(args.outDir),
     allowNetwork,
     emitHydrationData,
+    incremental,
     ...(trailingSlash !== undefined ? { trailingSlash } : {}),
     ...(concurrency !== undefined ? { concurrency } : {}),
   };
@@ -63,7 +66,7 @@ export async function runSsgCli(argv: string[] = process.argv.slice(2)): Promise
   }
 
   console.log(
-    `SSG complete: ${buildResult.pages.length} page(s) written to ${buildResult.outDir} (manifest: ${buildResult.manifestFile})`,
+    `SSG complete: ${buildResult.pages.length} page(s) written to ${buildResult.outDir} (manifest: ${buildResult.manifestFile})${formatSkippedRoutesSuffix(buildResult.skippedRoutes?.length ?? 0)}`,
   );
   return 0;
 }
@@ -73,6 +76,7 @@ function parseSsgCliArgs(argv: string[]): ParsedSsgCliArgs {
   let outDir = '';
   let trailingSlash: SsgTrailingSlashPolicy | undefined;
   let concurrency: number | undefined;
+  let incremental = false;
   let allowNetwork = false;
   let emitHydrationData = false;
 
@@ -108,6 +112,10 @@ function parseSsgCliArgs(argv: string[]): ParsedSsgCliArgs {
       i += 1;
       continue;
     }
+    if (arg === '--incremental') {
+      incremental = true;
+      continue;
+    }
     if (arg === '--allow-network') {
       allowNetwork = true;
       continue;
@@ -122,6 +130,7 @@ function parseSsgCliArgs(argv: string[]): ParsedSsgCliArgs {
         showHelp: true,
         entryPath: '',
         outDir: '',
+        incremental,
         allowNetwork,
         emitHydrationData,
         ...(trailingSlash !== undefined ? { trailingSlash } : {}),
@@ -141,6 +150,7 @@ function parseSsgCliArgs(argv: string[]): ParsedSsgCliArgs {
     outDir,
     ...(trailingSlash !== undefined ? { trailingSlash } : {}),
     ...(concurrency !== undefined ? { concurrency } : {}),
+    incremental,
     allowNetwork,
     emitHydrationData,
   };
@@ -177,6 +187,7 @@ function printUsage(): void {
       'Options:',
       '  --trailing-slash <always|never>   HTML output style (default: always)',
       '  --concurrency <count>             Render routes with bounded concurrency (default: 1)',
+      '  --incremental                     Skip unchanged writes using the SSG manifest',
       '  --emit-hydration-data             Write hydration JSON files when present',
       '  --allow-network                   Allow real fetch() calls during SSG',
     ].join('\n'),
@@ -185,7 +196,7 @@ function printUsage(): void {
 
 function printSsgBuildFailure(error: SsgBuildFailedError): void {
   console.error(
-    `SSG failed: ${error.failedRoutes.length} route(s) failed; ${error.result.pages.length} page(s) written to ${error.result.outDir}`,
+    `SSG failed: ${error.failedRoutes.length} route(s) failed; ${error.result.pages.length} page(s) written to ${error.result.outDir}${formatSkippedRoutesSuffix(error.result.skippedRoutes?.length ?? 0)}`,
   );
   for (const failedRoute of error.failedRoutes) {
     const status =
@@ -194,6 +205,11 @@ function printSsgBuildFailure(error: SsgBuildFailedError): void {
       `- ${failedRoute.path} (${failedRoute.routePattern})${status}: ${failedRoute.message}`,
     );
   }
+}
+
+function formatSkippedRoutesSuffix(skippedCount: number): string {
+  if (skippedCount === 0) return '';
+  return `; ${skippedCount} unchanged page(s) skipped`;
 }
 
 function isDirectExecution(): boolean {

--- a/ts/src/ssg-cli.ts
+++ b/ts/src/ssg-cli.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { buildSsgSite, type BuildSsgSiteOptions, type SsgTrailingSlashPolicy } from './ssg.js';
+import {
+  buildSsgSite,
+  SsgBuildFailedError,
+  type BuildSsgSiteOptions,
+  type SsgTrailingSlashPolicy,
+} from './ssg.js';
 import type { FaceModule } from './types.js';
 
 interface SsgCliConfigModule {
@@ -18,6 +23,7 @@ interface ParsedSsgCliArgs {
   entryPath: string;
   outDir: string;
   trailingSlash?: SsgTrailingSlashPolicy;
+  concurrency?: number;
   allowNetwork: boolean;
   emitHydrationData: boolean;
 }
@@ -31,6 +37,7 @@ export async function runSsgCli(argv: string[] = process.argv.slice(2)): Promise
   const faces = resolveFaces(config);
 
   const trailingSlash = args.trailingSlash ?? moduleOptions.trailingSlash;
+  const concurrency = args.concurrency ?? moduleOptions.concurrency;
   const allowNetwork = args.allowNetwork || (moduleOptions.allowNetwork ?? false);
   const emitHydrationData = args.emitHydrationData || (moduleOptions.emitHydrationData ?? false);
 
@@ -41,9 +48,19 @@ export async function runSsgCli(argv: string[] = process.argv.slice(2)): Promise
     allowNetwork,
     emitHydrationData,
     ...(trailingSlash !== undefined ? { trailingSlash } : {}),
+    ...(concurrency !== undefined ? { concurrency } : {}),
   };
 
-  const buildResult = await buildSsgSite(buildOptions);
+  let buildResult: Awaited<ReturnType<typeof buildSsgSite>>;
+  try {
+    buildResult = await buildSsgSite(buildOptions);
+  } catch (error) {
+    if (error instanceof SsgBuildFailedError) {
+      printSsgBuildFailure(error);
+      return 1;
+    }
+    throw error;
+  }
 
   console.log(
     `SSG complete: ${buildResult.pages.length} page(s) written to ${buildResult.outDir} (manifest: ${buildResult.manifestFile})`,
@@ -55,6 +72,7 @@ function parseSsgCliArgs(argv: string[]): ParsedSsgCliArgs {
   let entryPath = '';
   let outDir = '';
   let trailingSlash: SsgTrailingSlashPolicy | undefined;
+  let concurrency: number | undefined;
   let allowNetwork = false;
   let emitHydrationData = false;
 
@@ -83,6 +101,13 @@ function parseSsgCliArgs(argv: string[]): ParsedSsgCliArgs {
       i += 1;
       continue;
     }
+    if (arg === '--concurrency') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('missing value for --concurrency');
+      concurrency = parseConcurrency(value);
+      i += 1;
+      continue;
+    }
     if (arg === '--allow-network') {
       allowNetwork = true;
       continue;
@@ -100,6 +125,7 @@ function parseSsgCliArgs(argv: string[]): ParsedSsgCliArgs {
         allowNetwork,
         emitHydrationData,
         ...(trailingSlash !== undefined ? { trailingSlash } : {}),
+        ...(concurrency !== undefined ? { concurrency } : {}),
       };
     }
     throw new Error(`unknown argument: ${arg}`);
@@ -114,9 +140,18 @@ function parseSsgCliArgs(argv: string[]): ParsedSsgCliArgs {
     entryPath,
     outDir,
     ...(trailingSlash !== undefined ? { trailingSlash } : {}),
+    ...(concurrency !== undefined ? { concurrency } : {}),
     allowNetwork,
     emitHydrationData,
   };
+}
+
+function parseConcurrency(value: string): number {
+  const concurrency = Number(value);
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error('invalid value for --concurrency (expected a positive integer)');
+  }
+  return concurrency;
 }
 
 async function loadSsgConfigModule(entryPath: string): Promise<SsgCliConfigModule> {
@@ -141,10 +176,24 @@ function printUsage(): void {
       '',
       'Options:',
       '  --trailing-slash <always|never>   HTML output style (default: always)',
+      '  --concurrency <count>             Render routes with bounded concurrency (default: 1)',
       '  --emit-hydration-data             Write hydration JSON files when present',
       '  --allow-network                   Allow real fetch() calls during SSG',
     ].join('\n'),
   );
+}
+
+function printSsgBuildFailure(error: SsgBuildFailedError): void {
+  console.error(
+    `SSG failed: ${error.failedRoutes.length} route(s) failed; ${error.result.pages.length} page(s) written to ${error.result.outDir}`,
+  );
+  for (const failedRoute of error.failedRoutes) {
+    const status =
+      failedRoute.status === undefined ? '' : ` [status ${failedRoute.status}]`;
+    console.error(
+      `- ${failedRoute.path} (${failedRoute.routePattern})${status}: ${failedRoute.message}`,
+    );
+  }
 }
 
 function isDirectExecution(): boolean {

--- a/ts/src/ssg.ts
+++ b/ts/src/ssg.ts
@@ -23,6 +23,7 @@ export interface BuildSsgSiteOptions {
   faces: FaceModule[];
   outDir: string;
   clean?: boolean;
+  concurrency?: number;
   trailingSlash?: SsgTrailingSlashPolicy;
   write404Fallback?: boolean;
   emitHydrationData?: boolean;
@@ -38,6 +39,13 @@ export interface SsgPageEntry {
   status: number;
   contentType: string;
   hydrationDataFile?: string;
+}
+
+export interface SsgFailedRoute {
+  routePattern: string;
+  path: string;
+  message: string;
+  status?: number;
 }
 
 export interface SsgManifest {
@@ -58,6 +66,7 @@ export interface BuildSsgSiteResult {
   manifestFile: string;
   pages: SsgPageEntry[];
   notFoundFile?: string;
+  failedRoutes?: SsgFailedRoute[];
 }
 
 interface SsgRouteSegment {
@@ -74,7 +83,45 @@ interface SsgHydrationSidecar {
   data: unknown;
 }
 
+type FaceApp = ReturnType<typeof createFaceApp>;
+
+type SsgPageBuildOutcome =
+  | {
+      ok: true;
+      entry: SsgPageEntry;
+      html: string;
+    }
+  | {
+      ok: false;
+      failure: SsgFailedRoute;
+    };
+
+class SsgRouteBuildError extends Error {
+  readonly status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'SsgRouteBuildError';
+    if (status !== undefined) {
+      this.status = status;
+    }
+  }
+}
+
+export class SsgBuildFailedError extends Error {
+  readonly failedRoutes: SsgFailedRoute[];
+  readonly result: BuildSsgSiteResult & { failedRoutes: SsgFailedRoute[] };
+
+  constructor(result: BuildSsgSiteResult & { failedRoutes: SsgFailedRoute[] }) {
+    super(formatSsgBuildFailureMessage(result.failedRoutes));
+    this.name = 'SsgBuildFailedError';
+    this.failedRoutes = result.failedRoutes;
+    this.result = result;
+  }
+}
+
 const DEFAULT_ASSET_MANIFEST_PATH = '.vite/manifest.json';
+const SSG_MANIFEST_FILE = '.facetheory/ssg-manifest.json';
 const DEFAULT_404_HTML = renderHTMLDocument({
   head: '<title>Not Found</title>',
   body: '<h1>Not Found</h1><template data-facetheory-ssg-404="true"></template>',
@@ -88,6 +135,7 @@ export async function buildSsgSite(
   const trailingSlash = options.trailingSlash ?? 'always';
   const write404Fallback = options.write404Fallback ?? true;
   const emitHydrationData = options.emitHydrationData ?? false;
+  const concurrency = normalizeSsgConcurrency(options.concurrency ?? 1);
   const assetManifestPath =
     options.assetManifestPath ?? DEFAULT_ASSET_MANIFEST_PATH;
   const allowNetwork = options.allowNetwork ?? false;
@@ -108,74 +156,40 @@ export async function buildSsgSite(
   const plannedPages = await planSsgPages(options.faces);
 
   const builtPages: SsgPageEntry[] = [];
+  const failedRoutes: SsgFailedRoute[] = [];
   const htmlByPath = new Map<string, string>();
 
-  await withFetchGuard(
+  const buildOutcomes = await withFetchGuard(
     {
       allowNetwork,
       ...(fetchImpl !== undefined ? { fetch: fetchImpl } : {}),
     },
-    async () => {
-      for (const page of plannedPages) {
-        const response = await app.handle({ method: 'GET', path: page.path });
-        if (response.status >= 500) {
-          const networkHint =
-            !allowNetwork && fetchImpl === undefined
-              ? ' Network access is disabled by default during SSG; mock fetch or set allowNetwork:true.'
-              : '';
-          throw new Error(
-            `SSG route "${page.path}" returned status ${response.status}; build aborted.${networkHint}`,
-          );
-        }
-        if (response.isBase64) {
-          throw new Error(
-            `SSG route "${page.path}" returned isBase64=true; only text/html responses are supported`,
-          );
-        }
-
-        const body = await collectBody(response.body);
-        const html = new TextDecoder().decode(body);
-        const file = ssgFilePathForRoute(page.path, trailingSlash);
-        const contentType =
-          firstHeaderValue(response.headers, 'content-type') ??
-          'text/html; charset=utf-8';
-
-        await writeOutFile(outDir, file, html);
-
-        const strictHydrationSidecar = strictHydrationSidecars.get(page.path);
-        let hydrationDataFile: string | undefined;
-        if (strictHydrationSidecar !== undefined) {
-          hydrationDataFile = ssgHydrationDataFilePathForRoute(page.path);
-          await writeOutFile(
-            outDir,
-            hydrationDataFile,
-            `${safeJson(strictHydrationSidecar.data)}\n`,
-          );
-        } else if (emitHydrationData) {
-          const hydrationJson = extractHydrationDataJson(html);
-          if (hydrationJson !== null) {
-            hydrationDataFile = ssgHydrationDataFilePathForRoute(page.path);
-            await writeOutFile(outDir, hydrationDataFile, `${hydrationJson}\n`);
-          }
-        }
-
-        const entry: SsgPageEntry = {
-          routePattern: page.routePattern,
-          path: page.path,
-          file,
-          status: response.status,
-          contentType,
-        };
-        if (hydrationDataFile !== undefined) {
-          entry.hydrationDataFile = hydrationDataFile;
-        }
-        builtPages.push(entry);
-        htmlByPath.set(page.path, html);
-      }
-    },
+    async () =>
+      mapWithConcurrency(plannedPages, concurrency, (page) =>
+        buildSsgPage({
+          app,
+          page,
+          outDir,
+          trailingSlash,
+          emitHydrationData,
+          strictHydrationSidecars,
+          allowNetwork,
+          hasFetchOverride: fetchImpl !== undefined,
+        }),
+      ),
   );
 
+  for (const outcome of buildOutcomes) {
+    if (outcome.ok) {
+      builtPages.push(outcome.entry);
+      htmlByPath.set(outcome.entry.path, outcome.html);
+      continue;
+    }
+    failedRoutes.push(outcome.failure);
+  }
+
   builtPages.sort((left, right) => left.path.localeCompare(right.path));
+  failedRoutes.sort((left, right) => left.path.localeCompare(right.path));
 
   let notFoundFile: string | undefined;
   if (write404Fallback) {
@@ -199,19 +213,31 @@ export async function buildSsgSite(
     manifest.notFoundFile = notFoundFile;
   }
 
-  const manifestFile = '.facetheory/ssg-manifest.json';
+  const manifestFile = SSG_MANIFEST_FILE;
   await writeOutFile(
     outDir,
     manifestFile,
     `${JSON.stringify(manifest, null, 2)}\n`,
   );
 
-  return {
+  const result: BuildSsgSiteResult = {
     outDir,
     manifestFile,
     pages: builtPages,
     ...(notFoundFile !== undefined ? { notFoundFile } : {}),
   };
+
+  if (failedRoutes.length > 0) {
+    const failedResult: BuildSsgSiteResult & {
+      failedRoutes: SsgFailedRoute[];
+    } = {
+      ...result,
+      failedRoutes,
+    };
+    throw new SsgBuildFailedError(failedResult);
+  }
+
+  return result;
 }
 
 export async function planSsgPages(
@@ -278,6 +304,95 @@ export async function planSsgPages(
   return planned;
 }
 
+async function buildSsgPage(options: {
+  app: FaceApp;
+  page: PlannedPage;
+  outDir: string;
+  trailingSlash: SsgTrailingSlashPolicy;
+  emitHydrationData: boolean;
+  strictHydrationSidecars: Map<string, SsgHydrationSidecar>;
+  allowNetwork: boolean;
+  hasFetchOverride: boolean;
+}): Promise<SsgPageBuildOutcome> {
+  const {
+    app,
+    page,
+    outDir,
+    trailingSlash,
+    emitHydrationData,
+    strictHydrationSidecars,
+    allowNetwork,
+    hasFetchOverride,
+  } = options;
+
+  try {
+    const response = await app.handle({ method: 'GET', path: page.path });
+    if (response.status >= 500) {
+      const networkHint =
+        !allowNetwork && !hasFetchOverride
+          ? ' Network access is disabled by default during SSG; mock fetch or set allowNetwork:true.'
+          : '';
+      throw new SsgRouteBuildError(
+        `SSG route "${page.path}" returned status ${response.status}.${networkHint}`,
+        response.status,
+      );
+    }
+    if (response.isBase64) {
+      throw new SsgRouteBuildError(
+        `SSG route "${page.path}" returned isBase64=true; only text/html responses are supported`,
+      );
+    }
+
+    const body = await collectBody(response.body);
+    const html = new TextDecoder().decode(body);
+    const file = ssgFilePathForRoute(page.path, trailingSlash);
+    const contentType =
+      firstHeaderValue(response.headers, 'content-type') ??
+      'text/html; charset=utf-8';
+
+    await writeOutFile(outDir, file, html);
+
+    const strictHydrationSidecar = strictHydrationSidecars.get(page.path);
+    let hydrationDataFile: string | undefined;
+    if (strictHydrationSidecar !== undefined) {
+      hydrationDataFile = ssgHydrationDataFilePathForRoute(page.path);
+      await writeOutFile(
+        outDir,
+        hydrationDataFile,
+        `${safeJson(strictHydrationSidecar.data)}\n`,
+      );
+    } else if (emitHydrationData) {
+      const hydrationJson = extractHydrationDataJson(html);
+      if (hydrationJson !== null) {
+        hydrationDataFile = ssgHydrationDataFilePathForRoute(page.path);
+        await writeOutFile(outDir, hydrationDataFile, `${hydrationJson}\n`);
+      }
+    }
+
+    const entry: SsgPageEntry = {
+      routePattern: page.routePattern,
+      path: page.path,
+      file,
+      status: response.status,
+      contentType,
+    };
+    if (hydrationDataFile !== undefined) {
+      entry.hydrationDataFile = hydrationDataFile;
+    }
+
+    return {
+      ok: true,
+      entry,
+      html,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      failure: failedRouteForError(page, error),
+    };
+  }
+}
+
 function withSsgStrictHydrationSidecars(
   faces: FaceModule[],
   sidecars: Map<string, SsgHydrationSidecar>,
@@ -327,6 +442,35 @@ function externalizeSsgHydration(
     dataUrl,
     bootstrapModule: hydration.bootstrapModule,
   };
+}
+
+function failedRouteForError(
+  page: PlannedPage,
+  error: unknown,
+): SsgFailedRoute {
+  const failure: SsgFailedRoute = {
+    routePattern: page.routePattern,
+    path: page.path,
+    message: errorMessage(error),
+  };
+  if (error instanceof SsgRouteBuildError && error.status !== undefined) {
+    failure.status = error.status;
+  }
+  return failure;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function formatSsgBuildFailureMessage(failedRoutes: SsgFailedRoute[]): string {
+  const routeWord = failedRoutes.length === 1 ? 'route' : 'routes';
+  const routeList = failedRoutes.map((route) => route.path).join(', ');
+  const routeMessages = failedRoutes
+    .map((route) => `${route.path}: ${route.message}`)
+    .join('\n');
+  return `SSG build failed for ${failedRoutes.length} ${routeWord}: ${routeList}\n${routeMessages}`;
 }
 
 export function ssgFilePathForRoute(
@@ -496,10 +640,44 @@ function extractHydrationDataJson(html: string): string | null {
   return json.length > 0 ? json : null;
 }
 
-async function withFetchGuard(
+function normalizeSsgConcurrency(value: number): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error('SSG concurrency must be a positive integer');
+  }
+  return value;
+}
+
+async function mapWithConcurrency<T, U>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<U>,
+): Promise<U[]> {
+  if (items.length === 0) return [];
+
+  const results = new Array<U>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index] as T, index);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      await worker();
+    }),
+  );
+  return results;
+}
+
+async function withFetchGuard<T>(
   options: { allowNetwork: boolean; fetch?: typeof fetch },
-  fn: () => Promise<void>,
-): Promise<void> {
+  fn: () => Promise<T>,
+): Promise<T> {
   const globalRef = globalThis as { fetch?: typeof fetch };
   const originalFetch = globalRef.fetch;
 
@@ -524,7 +702,7 @@ async function withFetchGuard(
   }
 
   try {
-    await fn();
+    return await fn();
   } finally {
     if (originalFetch !== undefined) {
       globalRef.fetch = originalFetch;

--- a/ts/src/ssg.ts
+++ b/ts/src/ssg.ts
@@ -1,4 +1,5 @@
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { createFaceApp } from './app.js';
@@ -24,6 +25,7 @@ export interface BuildSsgSiteOptions {
   outDir: string;
   clean?: boolean;
   concurrency?: number;
+  incremental?: boolean;
   trailingSlash?: SsgTrailingSlashPolicy;
   write404Fallback?: boolean;
   emitHydrationData?: boolean;
@@ -39,6 +41,7 @@ export interface SsgPageEntry {
   status: number;
   contentType: string;
   hydrationDataFile?: string;
+  contentHash?: string;
 }
 
 export interface SsgFailedRoute {
@@ -46,6 +49,15 @@ export interface SsgFailedRoute {
   path: string;
   message: string;
   status?: number;
+}
+
+export interface SsgSkippedRoute {
+  routePattern: string;
+  path: string;
+  file: string;
+  reason: 'content-hash-match';
+  contentHash: string;
+  hydrationDataFile?: string;
 }
 
 export interface SsgManifest {
@@ -67,6 +79,7 @@ export interface BuildSsgSiteResult {
   pages: SsgPageEntry[];
   notFoundFile?: string;
   failedRoutes?: SsgFailedRoute[];
+  skippedRoutes?: SsgSkippedRoute[];
 }
 
 interface SsgRouteSegment {
@@ -90,6 +103,7 @@ type SsgPageBuildOutcome =
       ok: true;
       entry: SsgPageEntry;
       html: string;
+      skippedRoute?: SsgSkippedRoute;
     }
   | {
       ok: false;
@@ -131,7 +145,8 @@ export async function buildSsgSite(
   options: BuildSsgSiteOptions,
 ): Promise<BuildSsgSiteResult> {
   const outDir = path.resolve(options.outDir);
-  const clean = options.clean ?? true;
+  const incremental = options.incremental ?? false;
+  const clean = incremental ? false : (options.clean ?? true);
   const trailingSlash = options.trailingSlash ?? 'always';
   const write404Fallback = options.write404Fallback ?? true;
   const emitHydrationData = options.emitHydrationData ?? false;
@@ -144,6 +159,12 @@ export async function buildSsgSite(
   if (clean) {
     await rm(outDir, { recursive: true, force: true });
   }
+  const previousManifest = incremental
+    ? await readPreviousSsgManifest(outDir)
+    : null;
+  const previousPagesByPath = new Map(
+    (previousManifest?.pages ?? []).map((entry) => [entry.path, entry]),
+  );
   await mkdir(outDir, { recursive: true });
 
   const strictHydrationSidecars = new Map<string, SsgHydrationSidecar>();
@@ -157,6 +178,7 @@ export async function buildSsgSite(
 
   const builtPages: SsgPageEntry[] = [];
   const failedRoutes: SsgFailedRoute[] = [];
+  const skippedRoutes: SsgSkippedRoute[] = [];
   const htmlByPath = new Map<string, string>();
 
   const buildOutcomes = await withFetchGuard(
@@ -165,23 +187,29 @@ export async function buildSsgSite(
       ...(fetchImpl !== undefined ? { fetch: fetchImpl } : {}),
     },
     async () =>
-      mapWithConcurrency(plannedPages, concurrency, (page) =>
-        buildSsgPage({
+      mapWithConcurrency(plannedPages, concurrency, (page) => {
+        const previousEntry = previousPagesByPath.get(page.path);
+        return buildSsgPage({
           app,
           page,
           outDir,
           trailingSlash,
           emitHydrationData,
           strictHydrationSidecars,
+          incremental,
+          ...(previousEntry !== undefined ? { previousEntry } : {}),
           allowNetwork,
           hasFetchOverride: fetchImpl !== undefined,
-        }),
-      ),
+        });
+      }),
   );
 
   for (const outcome of buildOutcomes) {
     if (outcome.ok) {
       builtPages.push(outcome.entry);
+      if (outcome.skippedRoute !== undefined) {
+        skippedRoutes.push(outcome.skippedRoute);
+      }
       htmlByPath.set(outcome.entry.path, outcome.html);
       continue;
     }
@@ -190,6 +218,7 @@ export async function buildSsgSite(
 
   builtPages.sort((left, right) => left.path.localeCompare(right.path));
   failedRoutes.sort((left, right) => left.path.localeCompare(right.path));
+  skippedRoutes.sort((left, right) => left.path.localeCompare(right.path));
 
   let notFoundFile: string | undefined;
   if (write404Fallback) {
@@ -225,6 +254,7 @@ export async function buildSsgSite(
     manifestFile,
     pages: builtPages,
     ...(notFoundFile !== undefined ? { notFoundFile } : {}),
+    ...(skippedRoutes.length > 0 ? { skippedRoutes } : {}),
   };
 
   if (failedRoutes.length > 0) {
@@ -311,6 +341,8 @@ async function buildSsgPage(options: {
   trailingSlash: SsgTrailingSlashPolicy;
   emitHydrationData: boolean;
   strictHydrationSidecars: Map<string, SsgHydrationSidecar>;
+  incremental: boolean;
+  previousEntry?: SsgPageEntry;
   allowNetwork: boolean;
   hasFetchOverride: boolean;
 }): Promise<SsgPageBuildOutcome> {
@@ -321,6 +353,8 @@ async function buildSsgPage(options: {
     trailingSlash,
     emitHydrationData,
     strictHydrationSidecars,
+    incremental,
+    previousEntry,
     allowNetwork,
     hasFetchOverride,
   } = options;
@@ -350,40 +384,57 @@ async function buildSsgPage(options: {
       firstHeaderValue(response.headers, 'content-type') ??
       'text/html; charset=utf-8';
 
-    await writeOutFile(outDir, file, html);
-
     const strictHydrationSidecar = strictHydrationSidecars.get(page.path);
     let hydrationDataFile: string | undefined;
+    let hydrationDataContent: string | undefined;
     if (strictHydrationSidecar !== undefined) {
       hydrationDataFile = ssgHydrationDataFilePathForRoute(page.path);
-      await writeOutFile(
-        outDir,
-        hydrationDataFile,
-        `${safeJson(strictHydrationSidecar.data)}\n`,
-      );
+      hydrationDataContent = `${safeJson(strictHydrationSidecar.data)}\n`;
     } else if (emitHydrationData) {
       const hydrationJson = extractHydrationDataJson(html);
       if (hydrationJson !== null) {
         hydrationDataFile = ssgHydrationDataFilePathForRoute(page.path);
-        await writeOutFile(outDir, hydrationDataFile, `${hydrationJson}\n`);
+        hydrationDataContent = `${hydrationJson}\n`;
       }
     }
 
+    const contentHash = hashSsgRenderedOutput(html, hydrationDataContent);
     const entry: SsgPageEntry = {
       routePattern: page.routePattern,
       path: page.path,
       file,
       status: response.status,
       contentType,
+      contentHash,
     };
     if (hydrationDataFile !== undefined) {
       entry.hydrationDataFile = hydrationDataFile;
+    }
+
+    const skippedRoute = await ssgSkippedRouteIfUnchanged({
+      incremental,
+      outDir,
+      entry,
+      html,
+      ...(hydrationDataContent !== undefined ? { hydrationDataContent } : {}),
+      ...(previousEntry !== undefined ? { previousEntry } : {}),
+    });
+
+    if (skippedRoute === undefined) {
+      await writeOutFile(outDir, file, html);
+      if (
+        hydrationDataFile !== undefined &&
+        hydrationDataContent !== undefined
+      ) {
+        await writeOutFile(outDir, hydrationDataFile, hydrationDataContent);
+      }
     }
 
     return {
       ok: true,
       entry,
       html,
+      ...(skippedRoute !== undefined ? { skippedRoute } : {}),
     };
   } catch (error) {
     return {
@@ -471,6 +522,118 @@ function formatSsgBuildFailureMessage(failedRoutes: SsgFailedRoute[]): string {
     .map((route) => `${route.path}: ${route.message}`)
     .join('\n');
   return `SSG build failed for ${failedRoutes.length} ${routeWord}: ${routeList}\n${routeMessages}`;
+}
+
+async function readPreviousSsgManifest(
+  outDir: string,
+): Promise<SsgManifest | null> {
+  const manifestPath = path.resolve(outDir, SSG_MANIFEST_FILE);
+  let raw: string;
+  try {
+    raw = await readFile(manifestPath, 'utf8');
+  } catch (error) {
+    if (errorHasCode(error, 'ENOENT')) return null;
+    throw error;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<SsgManifest>;
+    if (parsed.version !== 1 || !Array.isArray(parsed.pages)) return null;
+    return parsed as SsgManifest;
+  } catch {
+    return null;
+  }
+}
+
+function hashSsgRenderedOutput(
+  html: string,
+  hydrationDataContent: string | undefined,
+): string {
+  const hash = createHash('sha256');
+  hash.update('facetheory:ssg-output:v1\0html\0');
+  hash.update(html);
+  hash.update('\0hydration-data\0');
+  if (hydrationDataContent !== undefined) {
+    hash.update(hydrationDataContent);
+  }
+  return `sha256-${hash.digest('hex')}`;
+}
+
+async function ssgSkippedRouteIfUnchanged(options: {
+  incremental: boolean;
+  outDir: string;
+  entry: SsgPageEntry;
+  html: string;
+  hydrationDataContent?: string;
+  previousEntry?: SsgPageEntry;
+}): Promise<SsgSkippedRoute | undefined> {
+  const {
+    incremental,
+    outDir,
+    entry,
+    html,
+    hydrationDataContent,
+    previousEntry,
+  } = options;
+
+  if (!incremental) return undefined;
+  if (entry.contentHash === undefined) return undefined;
+  if (previousEntry?.contentHash !== entry.contentHash) return undefined;
+  if (previousEntry.file !== entry.file) return undefined;
+  if (previousEntry.hydrationDataFile !== entry.hydrationDataFile) {
+    return undefined;
+  }
+  if (!(await ssgOutputFileMatches(outDir, entry.file, html))) {
+    return undefined;
+  }
+  if (entry.hydrationDataFile !== undefined) {
+    if (hydrationDataContent === undefined) return undefined;
+    if (
+      !(await ssgOutputFileMatches(
+        outDir,
+        entry.hydrationDataFile,
+        hydrationDataContent,
+      ))
+    ) {
+      return undefined;
+    }
+  }
+
+  const skippedRoute: SsgSkippedRoute = {
+    routePattern: entry.routePattern,
+    path: entry.path,
+    file: entry.file,
+    reason: 'content-hash-match',
+    contentHash: entry.contentHash,
+  };
+  if (entry.hydrationDataFile !== undefined) {
+    skippedRoute.hydrationDataFile = entry.hydrationDataFile;
+  }
+  return skippedRoute;
+}
+
+async function ssgOutputFileMatches(
+  outDir: string,
+  relativePath: string,
+  expectedContent: string,
+): Promise<boolean> {
+  const absolutePath = path.resolve(outDir, relativePath);
+  assertSafeSsgOutputPath(outDir, relativePath, absolutePath);
+  try {
+    return (await readFile(absolutePath, 'utf8')) === expectedContent;
+  } catch (error) {
+    if (errorHasCode(error, 'ENOENT')) return false;
+    throw error;
+  }
+}
+
+function errorHasCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === code
+  );
 }
 
 export function ssgFilePathForRoute(

--- a/ts/test/unit/ssg.test.ts
+++ b/ts/test/unit/ssg.test.ts
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { buildSsgSite } from '../../src/ssg.js';
+import { buildSsgSite, SsgBuildFailedError } from '../../src/ssg.js';
+import { runSsgCli } from '../../src/ssg-cli.js';
 import type { FaceModule } from '../../src/types.js';
 
 async function listFilesRecursively(rootDir: string): Promise<string[]> {
@@ -37,6 +38,34 @@ async function readSnapshot(rootDir: string): Promise<Record<string, string>> {
     snapshot[file] = content;
   }
   return snapshot;
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function trackedSsgFaces(track: {
+  active: number;
+  maxActive: number;
+}): FaceModule[] {
+  return ['/alpha', '/beta', '/gamma'].map((route) => ({
+    route,
+    mode: 'ssg',
+    render: async (ctx) => {
+      track.active += 1;
+      track.maxActive = Math.max(track.maxActive, track.active);
+      try {
+        await delay(10);
+        return {
+          html: `<main>${ctx.request.path}</main>`,
+        };
+      } finally {
+        track.active -= 1;
+      }
+    },
+  }));
 }
 
 test('ssg: static + param routes produce deterministic files and manifest', async () => {
@@ -143,6 +172,144 @@ test('ssg: static + param routes produce deterministic files and manifest', asyn
     const snapshotB = await readSnapshot(outB);
     assert.deepEqual(snapshotA, snapshotB);
   } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('ssg: concurrency defaults to serial and can be raised', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-concurrency-'));
+  const serialOut = path.resolve(tempRoot, 'serial');
+  const parallelOut = path.resolve(tempRoot, 'parallel');
+  const serialTrack = { active: 0, maxActive: 0 };
+  const parallelTrack = { active: 0, maxActive: 0 };
+
+  try {
+    await buildSsgSite({
+      faces: trackedSsgFaces(serialTrack),
+      outDir: serialOut,
+      write404Fallback: false,
+    });
+    await buildSsgSite({
+      faces: trackedSsgFaces(parallelTrack),
+      outDir: parallelOut,
+      concurrency: 2,
+      write404Fallback: false,
+    });
+
+    assert.equal(serialTrack.maxActive, 1);
+    assert.equal(parallelTrack.maxActive, 2);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('ssg: route failures are reported after successful pages write', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-failures-'));
+  const outDir = path.resolve(tempRoot, 'out');
+
+  const faces: FaceModule[] = [
+    {
+      route: '/alpha',
+      mode: 'ssg',
+      render: () => ({ html: '<main>alpha</main>' }),
+    },
+    {
+      route: '/beta',
+      mode: 'ssg',
+      render: () => ({ html: '<main>beta</main>' }),
+    },
+    {
+      route: '/fail',
+      mode: 'ssg',
+      render: () => ({ status: 500, html: '<main>failed</main>' }),
+    },
+  ];
+
+  try {
+    let caught: unknown;
+    try {
+      await buildSsgSite({ faces, outDir, concurrency: 2 });
+    } catch (error) {
+      caught = error;
+    }
+
+    assert.ok(caught instanceof SsgBuildFailedError);
+    assert.deepEqual(
+      caught.failedRoutes.map((route) => ({
+        path: route.path,
+        routePattern: route.routePattern,
+        status: route.status,
+      })),
+      [{ path: '/fail', routePattern: '/fail', status: 500 }],
+    );
+    assert.deepEqual(
+      caught.result.pages.map((page) => page.path),
+      ['/alpha', '/beta'],
+    );
+
+    const alphaHtml = await readFile(path.resolve(outDir, 'alpha/index.html'), 'utf8');
+    const betaHtml = await readFile(path.resolve(outDir, 'beta/index.html'), 'utf8');
+    assert.ok(alphaHtml.includes('<main>alpha</main>'));
+    assert.ok(betaHtml.includes('<main>beta</main>'));
+    await assert.rejects(
+      readFile(path.resolve(outDir, 'fail/index.html'), 'utf8'),
+      /ENOENT/,
+    );
+
+    const manifestRaw = await readFile(
+      path.resolve(outDir, '.facetheory/ssg-manifest.json'),
+      'utf8',
+    );
+    const manifest = JSON.parse(manifestRaw) as {
+      pages: Array<{ path: string }>;
+    };
+    assert.deepEqual(
+      manifest.pages.map((page) => page.path),
+      ['/alpha', '/beta'],
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('ssg cli: --concurrency reports isolated route failures as non-zero', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-cli-'));
+  const entryPath = path.resolve(tempRoot, 'ssg-config.mjs');
+  const outDir = path.resolve(tempRoot, 'out');
+  const errors: string[] = [];
+  const originalError = console.error;
+
+  await writeFile(
+    entryPath,
+    [
+      'export const faces = [',
+      '  { route: "/ok", mode: "ssg", render: () => ({ html: "<main>ok</main>" }) },',
+      '  { route: "/bad", mode: "ssg", render: () => ({ status: 500, html: "<main>bad</main>" }) },',
+      '];',
+      '',
+    ].join('\n'),
+  );
+
+  try {
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    };
+
+    const exitCode = await runSsgCli([
+      '--entry',
+      entryPath,
+      '--out',
+      outDir,
+      '--concurrency',
+      '2',
+    ]);
+
+    assert.equal(exitCode, 1);
+    assert.ok(errors.join('\n').includes('SSG failed: 1 route(s) failed'));
+    const okHtml = await readFile(path.resolve(outDir, 'ok/index.html'), 'utf8');
+    assert.ok(okHtml.includes('<main>ok</main>'));
+  } finally {
+    console.error = originalError;
     await rm(tempRoot, { recursive: true, force: true });
   }
 });

--- a/ts/test/unit/ssg.test.ts
+++ b/ts/test/unit/ssg.test.ts
@@ -1,7 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -176,6 +183,105 @@ test('ssg: static + param routes produce deterministic files and manifest', asyn
   }
 });
 
+test('ssg: incremental builds skip unchanged route outputs', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-incremental-'));
+  const outDir = path.resolve(tempRoot, 'out');
+  const indexPath = path.resolve(outDir, 'index.html');
+  const markerPath = path.resolve(outDir, 'marker.txt');
+  let content = 'first';
+  let renderCount = 0;
+
+  const faces: FaceModule[] = [
+    {
+      route: '/',
+      mode: 'ssg',
+      render: () => {
+        renderCount += 1;
+        return {
+          html: `<main>${content}</main>`,
+        };
+      },
+    },
+  ];
+
+  try {
+    await buildSsgSite({
+      faces,
+      outDir,
+      write404Fallback: false,
+    });
+
+    const firstManifest = JSON.parse(
+      await readFile(path.resolve(outDir, '.facetheory/ssg-manifest.json'), 'utf8'),
+    ) as {
+      pages: Array<{ path: string; contentHash?: string }>;
+    };
+    const firstHash = firstManifest.pages[0]?.contentHash;
+    assert.match(firstHash ?? '', /^sha256-[a-f0-9]{64}$/);
+
+    await writeFile(markerPath, 'kept across incremental builds');
+    const beforeSkipMtime = (await stat(indexPath, { bigint: true })).mtimeNs;
+    await delay(20);
+
+    const skipped = await buildSsgSite({
+      faces,
+      outDir,
+      incremental: true,
+      write404Fallback: false,
+    });
+
+    assert.equal(renderCount, 2);
+    assert.deepEqual(
+      skipped.skippedRoutes?.map((route) => ({
+        path: route.path,
+        reason: route.reason,
+        contentHash: route.contentHash,
+      })),
+      [
+        {
+          path: '/',
+          reason: 'content-hash-match',
+          contentHash: firstHash,
+        },
+      ],
+    );
+    assert.equal(
+      (await stat(indexPath, { bigint: true })).mtimeNs,
+      beforeSkipMtime,
+    );
+    assert.equal(
+      await readFile(markerPath, 'utf8'),
+      'kept across incremental builds',
+    );
+
+    content = 'second';
+    await delay(20);
+    const rewritten = await buildSsgSite({
+      faces,
+      outDir,
+      incremental: true,
+      write404Fallback: false,
+    });
+
+    assert.equal(renderCount, 3);
+    assert.equal(rewritten.skippedRoutes, undefined);
+    assert.match(await readFile(indexPath, 'utf8'), /<main>second<\/main>/);
+    assert.equal(
+      await readFile(markerPath, 'utf8'),
+      'kept across incremental builds',
+    );
+
+    await buildSsgSite({
+      faces,
+      outDir,
+      write404Fallback: false,
+    });
+    await assert.rejects(readFile(markerPath, 'utf8'), /ENOENT/);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('ssg: concurrency defaults to serial and can be raised', async () => {
   const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-concurrency-'));
   const serialOut = path.resolve(tempRoot, 'serial');
@@ -310,6 +416,40 @@ test('ssg cli: --concurrency reports isolated route failures as non-zero', async
     assert.ok(okHtml.includes('<main>ok</main>'));
   } finally {
     console.error = originalError;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('ssg cli: --incremental reports skipped unchanged pages', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-cli-incremental-'));
+  const entryPath = path.resolve(tempRoot, 'ssg-config.mjs');
+  const outDir = path.resolve(tempRoot, 'out');
+  const logs: string[] = [];
+  const originalLog = console.log;
+
+  await writeFile(
+    entryPath,
+    [
+      'export const faces = [',
+      '  { route: "/", mode: "ssg", render: () => ({ html: "<main>ok</main>" }) },',
+      '];',
+      '',
+    ].join('\n'),
+  );
+
+  try {
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    };
+
+    assert.equal(await runSsgCli(['--entry', entryPath, '--out', outDir]), 0);
+    assert.equal(
+      await runSsgCli(['--entry', entryPath, '--out', outDir, '--incremental']),
+      0,
+    );
+    assert.ok(logs.join('\n').includes('1 unchanged page(s) skipped'));
+  } finally {
+    console.log = originalLog;
     await rm(tempRoot, { recursive: true, force: true });
   }
 });

--- a/ts/test/unit/ssg.test.ts
+++ b/ts/test/unit/ssg.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import test from 'node:test';
 
 import {
@@ -11,10 +12,52 @@ import {
 } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 
 import { buildSsgSite, SsgBuildFailedError } from '../../src/ssg.js';
 import { runSsgCli } from '../../src/ssg-cli.js';
 import type { FaceModule } from '../../src/types.js';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const ssgCliEntrypoint = path.resolve(packageRoot, 'src/ssg-cli.ts');
+
+interface SsgCliProcessResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+
+async function runSsgCliEntrypoint(args: string[]): Promise<SsgCliProcessResult> {
+  return await new Promise<SsgCliProcessResult>((resolve, reject) => {
+    execFile(
+      process.execPath,
+      ['--import', 'tsx', ssgCliEntrypoint, ...args],
+      {
+        cwd: packageRoot,
+        encoding: 'utf8',
+        maxBuffer: 1024 * 1024,
+        timeout: 10_000,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const childError = error as NodeJS.ErrnoException & {
+            code?: number | string | null;
+            killed?: boolean;
+            signal?: NodeJS.Signals | null;
+          };
+          if (childError.killed || childError.signal || typeof childError.code !== 'number') {
+            reject(error);
+            return;
+          }
+          resolve({ exitCode: childError.code, stderr, stdout });
+          return;
+        }
+
+        resolve({ exitCode: 0, stderr, stdout });
+      },
+    );
+  });
+}
 
 async function listFilesRecursively(rootDir: string): Promise<string[]> {
   const out: string[] = [];
@@ -416,6 +459,42 @@ test('ssg cli: --concurrency reports isolated route failures as non-zero', async
     assert.ok(okHtml.includes('<main>ok</main>'));
   } finally {
     console.error = originalError;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('ssg cli: entrypoint exits non-zero for isolated route failures', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-cli-entrypoint-'));
+  const entryPath = path.resolve(tempRoot, 'ssg-config.mjs');
+  const outDir = path.resolve(tempRoot, 'out');
+
+  await writeFile(
+    entryPath,
+    [
+      'export const faces = [',
+      '  { route: "/ok", mode: "ssg", render: () => ({ html: "<main>ok</main>" }) },',
+      '  { route: "/bad", mode: "ssg", render: () => ({ status: 500, html: "<main>bad</main>" }) },',
+      '];',
+      '',
+    ].join('\n'),
+  );
+
+  try {
+    const result = await runSsgCliEntrypoint([
+      '--entry',
+      entryPath,
+      '--out',
+      outDir,
+      '--concurrency',
+      '2',
+    ]);
+
+    assert.equal(result.exitCode, 1);
+    assert.ok(result.stderr.includes('SSG failed: 1 route(s) failed'));
+    assert.ok(result.stderr.includes('/bad'));
+    const okHtml = await readFile(path.resolve(outDir, 'ok/index.html'), 'utf8');
+    assert.ok(okHtml.includes('<main>ok</main>'));
+  } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Milestone
M10 ssg-throughput — strengthen SSG build/runtime tooling with bounded concurrency, route-level failure reporting, and content-hash incremental writes.

## Refs
Refs THE-2484
Refs THE-2485

## Render modes and adapters affected
SSG core/tooling only. Adapter-neutral; no React/Vue/Svelte adapter API changes.

## Determinism impact
Preserves deterministic content per path. Write ordering is intentionally not a public contract. Incremental mode still renders each route before hashing rendered HTML + hydration sidecar bytes, and skips only when the new hash and existing files match the prior manifest.

## Backward compatibility
Additive only; no intentional 3.x consumer break. Default SSG behavior remains clean + serial (`concurrency: 1`, `incremental: false`).

## Tasks
- [x] THE-2484 / FT strengthen #26: Parallelize SSG builds with per-route error isolation
- [x] THE-2485 / FT strengthen #27: Add incremental SSG builds

## Validation
- [x] `cd ts && npm run check` — pass
- [x] `cd ts && npx tsx test/unit/ssg.test.ts` — pass (13 tests)
- [x] `cd ts && npm run example:ssg:build` — pass
- [x] `cd ts && timeout 5s npm run example:ssg:serve` — server started at `http://localhost:4175`, then timeout stopped it
- [x] `git diff --check theorymcp/theorycloud/facetheory/product-strengthening-plans-2026-07-02..HEAD` — pass
- [x] `git diff --check` — pass
- [x] `git log --show-signature theorymcp/theorycloud/facetheory/product-strengthening-plans-2026-07-02..HEAD` — both commits have good git signatures

## Version / dist / pack guards
Not applicable: no version, dist, package, lockfile, or release/packaging files touched.

## Cross-repo coordination
None required.