### PR TITLE
feat(vite): middleware-mode dev server with HMR (THE-2486)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -230,6 +230,34 @@ If a route still needs FaceTheory-owned inline scripts or styles, use the nonce-
 HTML only: pass `FaceRequest.cspNonce`, include the matching nonce in your CSP header, and do not cache that HTML as
 SSG/ISR unless the header and cached nonce stay identical for every request.
 
+## Run The Vite SSR Dev Loop
+
+The Vite middleware dev server is a development loop only. It does not create a
+second production deploy path and does not replace the production
+`viteAssetsForEntry(manifest, ...)` manifest flow used by SSG, SSR, ISR, or
+Lambda deployments.
+
+The React/Vite SSR example has a ready dev script:
+
+```bash
+cd ts/examples/vite-ssr-react
+npm run dev
+```
+
+Open `http://localhost:5174/`. The server is created with
+`vite.createServer({ server: { middlewareMode: true }, appType: "custom" })`;
+Vite handles `/@vite/client`, `/src/*`, CSS, and module HMR while FaceTheory
+mounts the FaceApp for application routes. The server render uses
+`vite.ssrLoadModule()` for the SSR entry on each request, so an edit to
+`src/app.tsx` is reflected by refreshing the page without a manual rebuild. In
+production, keep using the build + manifest path:
+
+```bash
+cd ts
+npm run example:vite:ssr:build
+npm run example:vite:ssr:serve
+```
+
 ## Add An OAC-Safe Mutating SSR Form
 
 When a FaceTheory app is deployed through `AppTheorySsrSite` with Lambda Function URL OAC and `AWS_IAM`, native browser

--- a/ts/examples/vite-ssr-react/README.md
+++ b/ts/examples/vite-ssr-react/README.md
@@ -28,3 +28,18 @@ npm run example:vite:ssr:serve
 ```
 
 Then open `http://localhost:4174/`.
+
+## Develop
+
+From `ts/examples/vite-ssr-react/`:
+
+```bash
+npm run dev
+```
+
+This starts the FaceTheory Vite middleware dev server on
+`http://localhost:5174/`. Vite serves `/@vite/client` and `/src/*` client
+assets directly for HMR while FaceTheory handles application routes through the
+SSR FaceApp. The server entry is loaded through Vite's module graph on each
+request, so edits to `src/app.tsx` are reflected by refreshing the page without
+running a build.

--- a/ts/examples/vite-ssr-react/package.json
+++ b/ts/examples/vite-ssr-react/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node --import tsx ../../src/dev-cli.ts --entry src/entry-server.tsx --factory createViteSSRExampleDevApp --port 5174"
+  }
+}

--- a/ts/examples/vite-ssr-react/src/entry-server.tsx
+++ b/ts/examples/vite-ssr-react/src/entry-server.tsx
@@ -3,11 +3,18 @@ import * as React from 'react';
 import { createFaceApp } from '../../../src/app.js';
 import { createReactFace } from '../../../src/adapters/react.js';
 import type { ViteManifest } from '../../../src/vite.js';
-import { viteAssetsForEntry, viteHydrationForEntry } from '../../../src/vite.js';
+import {
+  viteAssetsForEntry,
+  viteDevAssetsForEntry,
+  viteDevHydrationForEntry,
+  viteHydrationForEntry,
+} from '../../../src/vite.js';
 
 import { App } from './app.js';
 
-export function createViteSSRExampleApp(manifest: ViteManifest) {
+const CLIENT_ENTRY = 'src/entry-client.tsx';
+
+function createViteSSRExampleAppWithAssets(manifest: ViteManifest | null) {
   return createFaceApp({
     faces: [
       createReactFace<{ message: string }>({
@@ -20,13 +27,25 @@ export function createViteSSRExampleApp(manifest: ViteManifest) {
           React.createElement(App, { message: data.message }),
         ),
         renderOptions: async (_ctx, data) => {
-          const { headTags } = viteAssetsForEntry(manifest, 'src/entry-client.tsx', {
-            includeAssets: true,
-          });
-          const hydration = viteHydrationForEntry(manifest, 'src/entry-client.tsx', data);
+          const { headTags } = manifest
+            ? viteAssetsForEntry(manifest, CLIENT_ENTRY, {
+                includeAssets: true,
+              })
+            : viteDevAssetsForEntry(CLIENT_ENTRY);
+          const hydration = manifest
+            ? viteHydrationForEntry(manifest, CLIENT_ENTRY, data)
+            : viteDevHydrationForEntry(CLIENT_ENTRY, data);
           return { headTags, hydration };
         },
       }),
     ],
   });
+}
+
+export function createViteSSRExampleApp(manifest: ViteManifest) {
+  return createViteSSRExampleAppWithAssets(manifest);
+}
+
+export function createViteSSRExampleDevApp() {
+  return createViteSSRExampleAppWithAssets(null);
 }

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@theory-cloud/facetheory",
       "version": "3.8.1",
       "license": "Apache-2.0",
+      "bin": {
+        "facetheory-dev": "dist/dev-cli.js"
+      },
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.1053.0",
         "@emotion/cache": "^11.14.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -30,6 +30,9 @@
   "files": [
     "dist"
   ],
+  "bin": {
+    "facetheory-dev": "./dist/dev-cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -62,6 +65,10 @@
     "./testing": {
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js"
+    },
+    "./dev": {
+      "types": "./dist/dev.d.ts",
+      "import": "./dist/dev.js"
     },
     "./aws-s3": {
       "types": "./dist/aws-s3/index.d.ts",
@@ -208,6 +215,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/copy-svelte-sources.mjs",
+    "dev": "npm run example:vite:ssr:dev",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint . --max-warnings=0",
     "format": "prettier --write .",
@@ -222,6 +230,7 @@
     "example:streaming:serve": "tsx examples/react-ssr-streaming/node-server.ts",
     "example:vue:streaming:serve": "tsx examples/vue-ssr-streaming/node-server.ts",
     "example:vite:ssr:build": "vite build --config examples/vite-ssr-react/vite.config.ts && vite build --ssr src/entry-server.tsx --config examples/vite-ssr-react/vite.config.ts",
+    "example:vite:ssr:dev": "node --import tsx src/dev-cli.ts --root examples/vite-ssr-react --entry src/entry-server.tsx --factory createViteSSRExampleDevApp --port 5174",
     "example:vite:ssr:serve": "tsx examples/vite-ssr-react/node-server.ts",
     "example:vite:vue:build": "vite build --config examples/vite-ssr-vue/vite.config.ts && vite build --ssr src/entry-server.ts --config examples/vite-ssr-vue/vite.config.ts",
     "example:vite:vue:serve": "tsx examples/vite-ssr-vue/node-server.ts",

--- a/ts/src/dev-cli.ts
+++ b/ts/src/dev-cli.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+import path from 'node:path';
+
+import {
+  startViteMiddlewareDevServer,
+  type ViteMiddlewareFaceAppContext,
+} from './dev.js';
+import type { FaceApp } from './app.js';
+
+interface DevCliArgs {
+  root?: string;
+  entry?: string;
+  factory?: string;
+  port?: number;
+  host?: string;
+  help: boolean;
+}
+
+function readOptionValue(argv: string[], index: number, name: string): string {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`Missing value for --${name}`);
+  }
+  return value;
+}
+
+function parseArgs(argv: string[]): DevCliArgs {
+  const parsed: DevCliArgs = { help: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index] ?? '';
+    const [inlineName, inlineValue] = arg.startsWith('--') ? arg.slice(2).split('=', 2) : ['', undefined];
+    const name = inlineName === 'export' ? 'factory' : inlineName;
+
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+      continue;
+    }
+
+    if (name === 'root' || name === 'entry' || name === 'factory' || name === 'host') {
+      const value = inlineValue ?? readOptionValue(argv, index, name);
+      if (inlineValue === undefined) index += 1;
+      parsed[name] = value;
+      continue;
+    }
+
+    if (name === 'port') {
+      const value = inlineValue ?? readOptionValue(argv, index, name);
+      if (inlineValue === undefined) index += 1;
+      const port = Number(value);
+      if (!Number.isInteger(port) || port < 0 || port > 65535) {
+        throw new Error(`Invalid --port value: ${value}`);
+      }
+      parsed.port = port;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`FaceTheory Vite middleware dev server
+
+Usage:
+  facetheory-dev --entry src/entry-server.tsx --factory createViteDevApp [--root .] [--port 5173] [--host localhost]
+
+The server entry is loaded through vite.ssrLoadModule() on each SSR request.
+The named factory export must return a FaceApp.
+`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isFaceApp(value: unknown): value is FaceApp {
+  return isRecord(value) && typeof value.handle === 'function';
+}
+
+type FaceAppFactoryExport = (
+  context: ViteMiddlewareFaceAppContext,
+) => FaceApp | Promise<FaceApp>;
+
+function factoryFromModule(
+  module: unknown,
+  factoryName: string,
+): FaceAppFactoryExport {
+  if (!isRecord(module)) {
+    throw new Error('Vite SSR module did not evaluate to an object');
+  }
+
+  const factory = module[factoryName];
+  if (typeof factory !== 'function') {
+    throw new Error(`Vite SSR module missing FaceApp factory export "${factoryName}"`);
+  }
+
+  return async (context: ViteMiddlewareFaceAppContext): Promise<FaceApp> => {
+    const app = await factory(context);
+    if (!isFaceApp(app)) {
+      throw new Error(`FaceApp factory export "${factoryName}" did not return a FaceApp`);
+    }
+    return app;
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const root = path.resolve(args.root ?? process.cwd());
+  const entry = args.entry ?? 'src/entry-server.tsx';
+  const factoryName = args.factory ?? 'createViteDevApp';
+
+  const devServer = await startViteMiddlewareDevServer(
+    {
+      root,
+      entry,
+      createApp: async (context) => {
+        const factory = factoryFromModule(context.module, factoryName);
+        return factory(context);
+      },
+    },
+    {
+      port: args.port ?? 5173,
+      ...(args.host !== undefined ? { host: args.host } : {}),
+    },
+  );
+
+  console.log(`FaceTheory Vite dev server listening on ${devServer.url}`);
+
+  const shutdown = async () => {
+    await devServer.close();
+  };
+
+  process.once('SIGINT', () => {
+    void shutdown().finally(() => process.exit(0));
+  });
+  process.once('SIGTERM', () => {
+    void shutdown().finally(() => process.exit(0));
+  });
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ts/src/dev.ts
+++ b/ts/src/dev.ts
@@ -1,0 +1,330 @@
+import { once } from 'node:events';
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import type { InlineConfig } from 'vite';
+
+import type { FaceApp } from './app.js';
+import type { FaceHeaders, FaceRequest, FaceResponse } from './types.js';
+
+export type ViteMiddlewareDevNext = (err?: unknown) => void;
+
+export interface ViteMiddlewareStack {
+  (req: IncomingMessage, res: ServerResponse, next: ViteMiddlewareDevNext): void;
+}
+
+export interface ViteMiddlewareDevServerLike {
+  middlewares: ViteMiddlewareStack;
+  ssrLoadModule(id: string): Promise<unknown>;
+  ssrFixStacktrace?: (err: Error) => void;
+  close(): Promise<void>;
+}
+
+export type ViteCreateServer = (
+  config: InlineConfig,
+) => Promise<ViteMiddlewareDevServerLike>;
+
+export interface ViteMiddlewareFaceAppContext<TModule = unknown> {
+  module: TModule;
+  vite: ViteMiddlewareDevServerLike;
+  request: IncomingMessage;
+}
+
+export type ViteMiddlewareFaceAppFactory<TModule = unknown> = (
+  context: ViteMiddlewareFaceAppContext<TModule>,
+) => FaceApp | Promise<FaceApp>;
+
+export interface ViteMiddlewareDevServerOptions<TModule = unknown> {
+  root?: string;
+  entry: string;
+  createApp: ViteMiddlewareFaceAppFactory<TModule>;
+  vite?: InlineConfig;
+  createServer?: ViteCreateServer;
+}
+
+export interface ViteMiddlewareDevListenOptions {
+  port?: number;
+  host?: string;
+}
+
+export interface ViteMiddlewareDevListenResult {
+  address: AddressInfo | string | null;
+  url: string;
+}
+
+export interface ViteMiddlewareDevServer {
+  vite: ViteMiddlewareDevServerLike;
+  server: Server;
+  listen(
+    options?: ViteMiddlewareDevListenOptions,
+  ): Promise<ViteMiddlewareDevListenResult>;
+  close(): Promise<void>;
+}
+
+export interface StartedViteMiddlewareDevServer extends ViteMiddlewareDevServer {
+  address: AddressInfo | string | null;
+  url: string;
+}
+
+async function defaultCreateViteServer(
+  config: InlineConfig,
+): Promise<ViteMiddlewareDevServerLike> {
+  const vite = await import('vite');
+  return vite.createServer(config) as Promise<ViteMiddlewareDevServerLike>;
+}
+
+function normalizeViteModuleId(entry: string): string {
+  const trimmed = String(entry ?? '').trim();
+  if (!trimmed) {
+    throw new Error('FaceTheory Vite dev server entry must not be empty');
+  }
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function headersFromIncomingMessage(req: IncomingMessage): FaceHeaders {
+  const headers: FaceHeaders = {};
+
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    const headerName = name.toLowerCase();
+    headers[headerName] = Array.isArray(value) ? [...value] : [value];
+  }
+
+  return headers;
+}
+
+async function readIncomingBody(req: IncomingMessage): Promise<Uint8Array> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+function faceRequestFromIncomingMessage(
+  req: IncomingMessage,
+  body: Uint8Array,
+): FaceRequest {
+  const request: FaceRequest = {
+    method: req.method ?? 'GET',
+    path: req.url ?? '/',
+    headers: headersFromIncomingMessage(req),
+  };
+
+  if (body.byteLength > 0) {
+    request.body = body;
+  }
+
+  return request;
+}
+
+function applyResponseHeaders(res: ServerResponse, response: FaceResponse) {
+  const setCookieValues: string[] = [];
+
+  for (const [name, values] of Object.entries(response.headers)) {
+    if (name.toLowerCase() === 'set-cookie') {
+      setCookieValues.push(...values);
+      continue;
+    }
+    res.setHeader(name, values.length === 1 ? values[0] ?? '' : values.join(', '));
+  }
+
+  setCookieValues.push(...response.cookies);
+  if (setCookieValues.length > 0) {
+    res.setHeader('set-cookie', setCookieValues);
+  }
+}
+
+async function writeChunk(res: ServerResponse, chunk: Uint8Array) {
+  if (!res.write(chunk)) {
+    await once(res, 'drain');
+  }
+}
+
+async function writeFaceResponse(
+  req: IncomingMessage,
+  res: ServerResponse,
+  response: FaceResponse,
+) {
+  res.statusCode = response.status;
+  applyResponseHeaders(res, response);
+
+  if (req.method === 'HEAD') {
+    res.end();
+    return;
+  }
+
+  if (response.body instanceof Uint8Array) {
+    res.end(response.body);
+    return;
+  }
+
+  for await (const chunk of response.body) {
+    await writeChunk(res, chunk);
+  }
+  res.end();
+}
+
+async function handleFaceAppRequest(
+  app: FaceApp,
+  req: IncomingMessage,
+  res: ServerResponse,
+) {
+  const body = await readIncomingBody(req);
+  const response = await app.handle(faceRequestFromIncomingMessage(req, body));
+  await writeFaceResponse(req, res, response);
+}
+
+function devErrorBody(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? err.message;
+  }
+  return String(err);
+}
+
+function sendDevError(
+  vite: ViteMiddlewareDevServerLike,
+  err: unknown,
+  res: ServerResponse,
+) {
+  if (err instanceof Error) {
+    vite.ssrFixStacktrace?.(err);
+  }
+
+  if (!res.headersSent) {
+    res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+  }
+  res.end(devErrorBody(err));
+}
+
+function listenUrl(address: AddressInfo | string | null, host?: string): string {
+  if (typeof address === 'string') return address;
+  if (!address) return '';
+
+  const rawHost = host ?? address.address;
+  const hostname =
+    rawHost === '' || rawHost === '::' || rawHost === '0.0.0.0'
+      ? 'localhost'
+      : rawHost.includes(':')
+        ? `[${rawHost}]`
+        : rawHost;
+
+  return `http://${hostname}:${address.port}/`;
+}
+
+async function closeServer(server: Server, listening: boolean): Promise<void> {
+  if (!listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+export async function createViteMiddlewareDevServer<TModule = unknown>(
+  options: ViteMiddlewareDevServerOptions<TModule>,
+): Promise<ViteMiddlewareDevServer> {
+  const entry = normalizeViteModuleId(options.entry);
+  const createServer = options.createServer ?? defaultCreateViteServer;
+  const viteConfig = options.vite ?? {};
+  const viteServerConfig = viteConfig.server ?? {};
+  const root = options.root ?? viteConfig.root;
+  const mergedConfig: InlineConfig = {
+    ...viteConfig,
+    appType: 'custom',
+    server: {
+      ...viteServerConfig,
+      middlewareMode: true,
+    },
+  };
+  if (root !== undefined) {
+    mergedConfig.root = root;
+  }
+  const vite = await createServer(mergedConfig);
+
+  const server = createHttpServer((req, res) => {
+    try {
+      vite.middlewares(req, res, (middlewareErr?: unknown) => {
+        if (res.writableEnded) return;
+        if (middlewareErr) {
+          sendDevError(vite, middlewareErr, res);
+          return;
+        }
+
+        void (async () => {
+          const module = (await vite.ssrLoadModule(entry)) as TModule;
+          const app = await options.createApp({ module, vite, request: req });
+          await handleFaceAppRequest(app, req, res);
+        })().catch((err: unknown) => {
+          sendDevError(vite, err, res);
+        });
+      });
+    } catch (err) {
+      sendDevError(vite, err, res);
+    }
+  });
+
+  let listening = false;
+
+  return {
+    vite,
+    server,
+    async listen(
+      listenOptions: ViteMiddlewareDevListenOptions = {},
+    ): Promise<ViteMiddlewareDevListenResult> {
+      const port = listenOptions.port ?? 5173;
+      const host = listenOptions.host;
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: Error) => {
+          server.off('listening', onListening);
+          reject(err);
+        };
+        const onListening = () => {
+          server.off('error', onError);
+          listening = true;
+          resolve();
+        };
+
+        server.once('error', onError);
+        server.once('listening', onListening);
+        if (host !== undefined) {
+          server.listen(port, host);
+        } else {
+          server.listen(port);
+        }
+      });
+
+      const address = server.address();
+      return {
+        address,
+        url: listenUrl(address, host),
+      };
+    },
+    async close(): Promise<void> {
+      await closeServer(server, listening);
+      listening = false;
+      await vite.close();
+    },
+  };
+}
+
+export async function startViteMiddlewareDevServer<TModule = unknown>(
+  options: ViteMiddlewareDevServerOptions<TModule>,
+  listenOptions: ViteMiddlewareDevListenOptions = {},
+): Promise<StartedViteMiddlewareDevServer> {
+  const devServer = await createViteMiddlewareDevServer(options);
+  const listened = await devServer.listen(listenOptions);
+  return {
+    ...devServer,
+    address: listened.address,
+    url: listened.url,
+  };
+}

--- a/ts/src/vite.ts
+++ b/ts/src/vite.ts
@@ -19,6 +19,11 @@ export interface ViteAssetsOptions {
   dynamicImports?: DynamicImportPolicy;
 }
 
+export interface ViteDevAssetsOptions {
+  base?: string;
+  hmrClient?: boolean;
+}
+
 export interface ViteExternalHydrationOptions extends ViteAssetsOptions {
   dataUrl: string;
   allowedOrigin?: string | URL;
@@ -122,6 +127,14 @@ function requireEntryChunk(manifest: ViteManifest, entry: string): ViteManifestC
     throw new Error(`vite manifest entry missing file: ${entry}`);
   }
   return chunk;
+}
+
+function normalizeDevEntryPath(entry: string): string {
+  const trimmed = String(entry ?? '').trim();
+  if (!trimmed) {
+    throw new Error('vite dev entry must not be empty');
+  }
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
 }
 
 function isAbsoluteOrProtocolRelativeUrl(value: string): boolean {
@@ -314,6 +327,29 @@ export function viteDynamicImportPolicy(): DynamicImportPolicy {
   return 'ignore';
 }
 
+export function viteDevAssetsForEntry(
+  entry: string,
+  options: ViteDevAssetsOptions = {},
+): { bootstrapModule: string; headTags: FaceHeadTag[] } {
+  const base = options.base ?? '/';
+  const hmrClient = options.hmrClient ?? true;
+  const normalizedEntry = normalizeDevEntryPath(entry);
+  const bootstrapModule = joinBase(base, normalizedEntry);
+  const headTags: FaceHeadTag[] = [];
+
+  if (hmrClient) {
+    headTags.push({
+      type: 'script',
+      attrs: {
+        type: 'module',
+        src: joinBase(base, '/@vite/client'),
+      },
+    });
+  }
+
+  return { bootstrapModule, headTags };
+}
+
 export function viteHydrationForEntry(
   manifest: ViteManifest,
   entry: string,
@@ -321,6 +357,15 @@ export function viteHydrationForEntry(
   options: ViteAssetsOptions = {},
 ): FaceHydration {
   const { bootstrapModule } = viteAssetsForEntry(manifest, entry, options);
+  return { data, bootstrapModule };
+}
+
+export function viteDevHydrationForEntry(
+  entry: string,
+  data: unknown,
+  options: ViteDevAssetsOptions = {},
+): FaceHydration {
+  const { bootstrapModule } = viteDevAssetsForEntry(entry, options);
   return { data, bootstrapModule };
 }
 

--- a/ts/test/unit/dev.test.ts
+++ b/ts/test/unit/dev.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createFaceApp } from '../../src/app.js';
+import {
+  createViteMiddlewareDevServer,
+  type ViteMiddlewareDevServerLike,
+} from '../../src/dev.js';
+
+async function fetchText(url: string): Promise<{ status: number; body: string }> {
+  const response = await fetch(url);
+  return {
+    status: response.status,
+    body: await response.text(),
+  };
+}
+
+test('vite dev server: Vite middleware serves dev assets before FaceApp routes', async () => {
+  let ssrLoads = 0;
+  let viteClosed = false;
+  const fakeVite: ViteMiddlewareDevServerLike = {
+    middlewares: (req, res, next) => {
+      if (req.url === '/@vite/client') {
+        res.writeHead(200, { 'content-type': 'text/javascript; charset=utf-8' });
+        res.end('export const hmr = true;');
+        return;
+      }
+      next();
+    },
+    ssrLoadModule: async () => {
+      ssrLoads += 1;
+      return {};
+    },
+    close: async () => {
+      viteClosed = true;
+    },
+  };
+
+  const devServer = await createViteMiddlewareDevServer({
+    entry: 'src/entry-server.tsx',
+    createServer: async (config) => {
+      assert.equal(config.appType, 'custom');
+      assert.equal(config.server?.middlewareMode, true);
+      return fakeVite;
+    },
+    createApp: () =>
+      createFaceApp({
+        faces: [
+          {
+            route: '/',
+            mode: 'ssr',
+            render: () => ({ html: '<main>FaceApp route</main>' }),
+          },
+        ],
+      }),
+  });
+
+  const { url } = await devServer.listen({ port: 0 });
+  try {
+    const response = await fetchText(`${url}@vite/client`);
+    assert.equal(response.status, 200);
+    assert.equal(response.body, 'export const hmr = true;');
+    assert.equal(ssrLoads, 0);
+  } finally {
+    await devServer.close();
+  }
+
+  assert.equal(viteClosed, true);
+});
+
+test('vite dev server: loads the SSR entry through Vite for FaceApp requests', async () => {
+  const loadedEntries: string[] = [];
+  const fakeVite: ViteMiddlewareDevServerLike = {
+    middlewares: (_req, _res, next) => {
+      next();
+    },
+    ssrLoadModule: async (id) => {
+      loadedEntries.push(id);
+      return {};
+    },
+    close: async () => {},
+  };
+
+  const devServer = await createViteMiddlewareDevServer({
+    entry: 'src/entry-server.tsx',
+    createServer: async () => fakeVite,
+    createApp: () =>
+      createFaceApp({
+        faces: [
+          {
+            route: '/',
+            mode: 'ssr',
+            render: () => ({
+              headers: { 'x-dev-loop': 'active' },
+              html: '<main>Vite SSR dev loop</main>',
+            }),
+          },
+        ],
+      }),
+  });
+
+  const { url } = await devServer.listen({ port: 0 });
+  try {
+    const response = await fetchText(url);
+    assert.equal(response.status, 200);
+    assert.match(response.body, /Vite SSR dev loop/);
+  } finally {
+    await devServer.close();
+  }
+
+  assert.deepEqual(loadedEntries, ['/src/entry-server.tsx']);
+});

--- a/ts/test/unit/vite.test.ts
+++ b/ts/test/unit/vite.test.ts
@@ -3,6 +3,8 @@ import test from 'node:test';
 
 import {
   externalHydrationForEntry,
+  viteDevAssetsForEntry,
+  viteDevHydrationForEntry,
   viteAssetsForEntry,
   viteDynamicImportPolicy,
   viteHydrationForEntry,
@@ -18,6 +20,12 @@ function hrefsByRel(headTags: Array<{ type: string; attrs: Record<string, unknow
   return linkTags(headTags)
     .filter((tag) => tag.attrs.rel === rel)
     .map((tag) => String(tag.attrs.href));
+}
+
+function scriptSrcs(headTags: Array<{ type: string; attrs: Record<string, unknown> }>) {
+  return headTags
+    .filter((tag): tag is { type: 'script'; attrs: Record<string, unknown> } => tag.type === 'script')
+    .map((tag) => String(tag.attrs.src));
 }
 
 test('vite: resolves bootstrap module + injects preload + css links', () => {
@@ -157,6 +165,57 @@ test('vite: hydration helper sets bootstrap module', () => {
 
   const hydration = viteHydrationForEntry(manifest, 'src/entry-client.tsx', { ok: true });
   assert.equal(hydration.bootstrapModule, '/assets/entry.aaa.js');
+  assert.deepEqual(hydration.data, { ok: true });
+});
+
+test('vite: dev assets stay separate from production manifest assets', () => {
+  const manifest = {
+    'src/entry-client.tsx': {
+      file: 'assets/entry.aaa.js',
+      css: ['assets/entry.aaa.css'],
+      imports: ['_vendor.bbb.js'],
+      isEntry: true,
+    },
+    '_vendor.bbb.js': {
+      file: 'assets/vendor.bbb.js',
+    },
+  } as const;
+
+  const production = viteAssetsForEntry(manifest, 'src/entry-client.tsx', {
+    includeAssets: true,
+  });
+  const dev = viteDevAssetsForEntry('src/entry-client.tsx');
+
+  assert.equal(production.bootstrapModule, '/assets/entry.aaa.js');
+  assert.deepEqual(
+    hrefsByRel(
+      production.headTags as Array<{ type: string; attrs: Record<string, unknown> }>,
+      'modulepreload',
+    ),
+    ['/assets/vendor.bbb.js'],
+  );
+  assert.deepEqual(
+    hrefsByRel(
+      production.headTags as Array<{ type: string; attrs: Record<string, unknown> }>,
+      'stylesheet',
+    ),
+    ['/assets/entry.aaa.css'],
+  );
+  assert.deepEqual(
+    scriptSrcs(production.headTags as Array<{ type: string; attrs: Record<string, unknown> }>),
+    [],
+  );
+
+  assert.equal(dev.bootstrapModule, '/src/entry-client.tsx');
+  assert.deepEqual(
+    scriptSrcs(dev.headTags as Array<{ type: string; attrs: Record<string, unknown> }>),
+    ['/@vite/client'],
+  );
+});
+
+test('vite: dev hydration helper uses source entry bootstrap module', () => {
+  const hydration = viteDevHydrationForEntry('src/entry-client.tsx', { ok: true });
+  assert.equal(hydration.bootstrapModule, '/src/entry-client.tsx');
   assert.deepEqual(hydration.data, { ok: true });
 });
 


### PR DESCRIPTION
## Milestone
M11 dev-loop — add the React/Vite SSR development loop for THE-2486.

## Linear
THE-2486 — FT strengthen #28: Add a Vite middleware dev server
https://linear.app/theorycloud/issue/THE-2486/ft-strengthen-28-add-a-vite-middleware-dev-server

## Render modes and adapters affected
SSR dev loop for the React/Vite example. Production SSR/SSG/ISR manifest asset resolution remains on the existing `viteAssetsForEntry(manifest, ...)` path.

## Determinism impact
Development-only asset-resolution branch. The production manifest path is untouched, and unit coverage asserts production manifest assets do not receive the dev `/@vite/client` branch.

## Changes
- Added `ts/src/dev.ts` Vite middleware-mode server helpers that mount a FaceApp after Vite middleware and load the SSR entry through `vite.ssrLoadModule()` per request.
- Added `facetheory-dev` bin wiring and root/example dev scripts.
- Added React Vite example dev factory and `npm run dev` entry.
- Documented the dev loop and explicit production build/manifest boundary.
- Added targeted dev-server tests and production-path regression coverage.

## Validation
- Baseline before edits: `cd ts && npm run check` — PASS on `74b3ba0f734b7fc6745ba54d866b0d4abde4e2b4`.
- Targeted tests: `cd ts && node --import tsx test/unit/dev.test.ts && node --import tsx test/unit/vite.test.ts` — PASS.
- Manual dev-loop smoke: `cd ts/examples/vite-ssr-react && npm run dev`; served `http://localhost:5174/`, emitted `/@vite/client` and `/src/entry-client.tsx`, served `/@vite/client`; editing `src/app.tsx` reflected in SSR output after refresh; editing `src/styles.css` reflected via Vite middleware and logged a Vite client HMR update.
- Final: `cd ts && npm run check` — PASS (`tests 649`, `pass 648`, `skipped 1`).
- `git diff --check` — PASS.
- `scripts/verify-version-alignment.sh` — PASS (`3.8.1`).

## Cross-repo coordination
None. No AppTheory/TableTheory/cloud changes.