### PR TITLE
fix(infra): converge deploy reference stacks on AppTheorySsrSite

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ export const handler = createLambdaUrlStreamingHandler({ app });
 
 `createLambdaUrlStreamingHandler()` expects Lambda's `awslambda.streamifyResponse` global at runtime. Outside Lambda, test request handling with `handleLambdaUrlEvent(app, event)` or pass the optional `awslambda` adapter explicitly.
 
+For the paved AWS deployment path, wrap the same `FaceApp` in AppTheory's `AppTheorySsrSite`: the SSR reference stack
+bundles a real `createFaceApp(...)` + `createAppTheoryFaceHandler({ app })` Lambda handler, and the SSG/ISR reference
+stack uses `AppTheorySsrSiteMode.SSG_ISR` for S3-primary HTML with Lambda fallback and TableTheory-backed ISR wiring.
+See the [CDK deployment walkthrough](https://facetheory.theorycloud.ai/cdk/) for scaffold → build → props → deploy →
+curl steps. Local synth/tests are deployment-shape proof only; do not claim live CloudFront proof without an authorized
+AWS deploy.
+
 The `v3.8.1` GitHub release also ships the matching `facetheory-reference-${FACETHEORY_VERSION}.tar.gz` bundle, which contains the canonical docs, runnable examples, and reference deployment stacks for offline use. <!-- x-release-please-version -->
 
 ## At a glance

--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -28,6 +28,13 @@ SSR/SSG/ISR.
 AppTheory CDK ships `AppTheorySsrSite`, which implements this topology and wires recommended environment variables onto
 your SSR Lambda function.
 
+FaceTheory's SSG/ISR reference stack (`infra/apptheory-ssg-isr-site/`) uses `AppTheorySsrSite` with
+`mode: AppTheorySsrSiteMode.SSG_ISR` for the CloudFront distribution, Lambda Function URL origin, generated edge
+rewrite/request-id functions, and ISR runtime env wiring. The stack keeps explicit FaceTheory-owned `BucketDeployment`
+resources for immutable assets, the Vite manifest, and SSG HTML because AppTheory v1.13.2 does not yet expose
+per-deployment `distributionPaths` invalidation controls for those uploads. Treat that as the remaining AppTheory
+coordination item; it is not permission to hand-roll the CloudFront distribution or origin group in FaceTheory.
+
 When using `AppTheorySsrSite` in `ssg-isr` mode:
 - use `staticPathPatterns` for cacheable extensionless HTML sections that should stay on S3
 - use `directS3PathPatterns` for raw object/data paths such as `/.vite/*` and `/_facetheory/data/*`
@@ -54,7 +61,7 @@ Function URLs durable.
 
 Reference example (FaceTheory repo):
 - `infra/apptheory-ssr-site/`
-- `infra/apptheory-ssg-isr-site/` (SSG origin-group + ISR example)
+- `infra/apptheory-ssg-isr-site/` (`AppTheorySsrSite` `SSG_ISR` mode with S3-primary HTML origin group + ISR example)
 
 When `wireRuntimeEnv:true` (default), the SSR function will receive:
 - `APPTHEORY_ASSETS_BUCKET`
@@ -177,7 +184,8 @@ Cons:
 - requires explicit URI rewrite discipline
 
 Reference stack:
-- `infra/apptheory-ssg-isr-site/`
+- `infra/apptheory-ssg-isr-site/`, which uses `AppTheorySsrSiteMode.SSG_ISR` for the origin group and generated edge
+  rewrite/request-id functions.
 
 ### Strategy B: explicit behaviors for known SSG routes (small route sets)
 

--- a/docs/cdk/README.md
+++ b/docs/cdk/README.md
@@ -240,4 +240,3 @@ local synth/tests/docs-build proof unless it actually deployed with authorized A
 - `infra/apptheory-ssr-site/` — SSR-only CloudFront + S3 assets + Lambda Function URL using a real FaceApp handler.
 - `infra/apptheory-ssg-isr-site/` — `AppTheorySsrSiteMode.SSG_ISR`, S3-primary HTML origin group, Lambda fallback, and
   TableTheory-backed ISR metadata wiring.
-

--- a/docs/cdk/README.md
+++ b/docs/cdk/README.md
@@ -5,17 +5,239 @@ permalink: /cdk/
 
 # FaceTheory CDK And AWS Notes
 
-These are sanctioned optional operator-facing docs for deployment and runbook guidance.
+FaceTheory's paved AWS deployment path is **AppTheory `AppTheorySsrSite`**: CloudFront in front of S3 and a Lambda
+Function URL, with FaceTheory rendering through a real `FaceApp`. The reference stacks in `infra/` are synth/test proof
+for that shape; they are not evidence that this checkout was deployed to a live AWS account.
 
-## Quick Links
+Use this page when you want one path from hello world to a CloudFront URL. Use
+[AWS Deployment Shape](./aws-deployment.md) for the deeper routing, cache, CSP, OAC, and ISR rationale, and
+[Operations Guide](./operations.md) for runbook posture.
 
-- [AWS Deployment Shape](./aws-deployment.md)
-- [Operations Guide](./operations.md)
+## The end-to-end path
 
-## Reference Stacks
+1. **Scaffold a real FaceTheory handler** — create a `FaceApp`, adapt it with `createAppTheoryFaceHandler`, and export
+   an AppTheory Lambda Function URL streaming handler.
+2. **Build client/static outputs** — place immutable assets under `assets/`, the Vite manifest at
+   `.vite/manifest.json`, and optional SSG HTML / hydration sidecars in the S3 upload tree.
+3. **Wrap it with `AppTheorySsrSite`** — let AppTheory own CloudFront, Function URL OAC, origin groups, request-id
+   propagation, and runtime env wiring.
+4. **Synthesize and test** — run the local stack tests/synth before touching AWS.
+5. **Deploy deliberately** — only an operator with the intended AWS account/region credentials should run `cdk deploy`.
+6. **Curl the CloudFront URL** — verify headers and route placement after the deploy. Do not claim live deployment proof
+   unless those commands were actually run against the deployed distribution.
 
-Code-local examples:
-- `infra/apptheory-ssr-site/`
-- `infra/apptheory-ssg-isr-site/`
+## 1. Scaffold the handler
 
-Use these docs for canonical operator guidance. Keep the infra folder READMEs focused on local stack context and commands.
+The minimal SSR handler shape mirrors `infra/apptheory-ssr-site/src/handler.ts`:
+
+```ts
+import { createApp, createLambdaFunctionURLStreamingHandler } from "@theory-cloud/apptheory";
+import { createFaceApp } from "@theory-cloud/facetheory";
+import { createAppTheoryFaceHandler } from "@theory-cloud/facetheory/apptheory";
+
+const faceApp = createFaceApp({
+  faces: [
+    {
+      route: "/",
+      mode: "ssr",
+      render: () => ({
+        headers: { "cache-control": "private, no-store" },
+        head: { title: "Hello FaceTheory" },
+        html: "<main><h1>Hello FaceTheory</h1></main>",
+      }),
+    },
+  ],
+});
+
+const app = createApp();
+const faceHandler = createAppTheoryFaceHandler({ app: faceApp });
+
+app.get("/", faceHandler);
+app.get("/{proxy+}", faceHandler);
+app.handle("HEAD", "/", faceHandler);
+app.handle("HEAD", "/{proxy+}", faceHandler);
+
+export const handler = createLambdaFunctionURLStreamingHandler(app);
+```
+
+Keep consumer data fetching in `load(ctx)` or request handlers, and escape any caller-controlled HTML. Head tags go
+through the FaceTheory head primitive (`head`, `headTags`, `styleTags`); do not emit ad-hoc document head strings in the
+component tree.
+
+## 2. Build assets and optional SSG output
+
+A Vite-style build typically produces:
+
+```text
+deploy/
+  assets/entry.<hash>.js
+  assets/entry.<hash>.css
+  .vite/manifest.json
+  ssg/index.html                    # optional SSG output
+  _facetheory/data/index.json        # optional strict-CSP SSG hydration data
+```
+
+The FaceTheory reference stacks keep explicit `BucketDeployment` resources for immutable assets, the Vite manifest, and
+SSG HTML. This preserves cache-control differences while `AppTheorySsrSite` owns the CloudFront distribution. AppTheory
+v1.13.2 does not yet expose per-deployment `distributionPaths` invalidation controls for those uploads; invalidate changed
+HTML and hydration JSON paths in your deployment pipeline until that AppTheory gap is closed.
+
+Local reference validation before any deploy:
+
+```bash
+cd infra/apptheory-ssr-site
+npm ci
+npm test
+
+cd ../apptheory-ssg-isr-site
+npm ci
+npm test
+```
+
+## 3. Wrap with `AppTheorySsrSite`
+
+### SSR-only hello world
+
+```ts
+import { CfnOutput, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
+import { AppTheorySsrSite } from "@theory-cloud/apptheory-cdk";
+
+const assetsBucket = new s3.Bucket(this, "AssetsBucket", {
+  blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+  encryption: s3.BucketEncryption.S3_MANAGED,
+  enforceSSL: true,
+  removalPolicy: RemovalPolicy.RETAIN,
+});
+
+const ssrFunction = new NodejsFunction(this, "SsrFunction", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  entry: "src/handler.ts",
+  handler: "handler",
+  timeout: Duration.seconds(10),
+  memorySize: 512,
+});
+
+new s3deploy.BucketDeployment(this, "AssetsDeployment", {
+  sources: [s3deploy.Source.asset("deploy/assets")],
+  destinationBucket: assetsBucket,
+  destinationKeyPrefix: "assets",
+});
+
+const site = new AppTheorySsrSite(this, "Site", {
+  ssrFunction,
+  ssrUrlAuthType: lambda.FunctionUrlAuthType.AWS_IAM,
+  assetsBucket,
+  assetsKeyPrefix: "assets",
+  assetsManifestKey: ".vite/manifest.json",
+  // Optional production edge controls:
+  domainName: "app.example.com",
+  certificateArn: "arn:aws:acm:us-east-1:111122223333:certificate/00000000-0000-0000-0000-000000000000",
+  webAclId: "arn:aws:wafv2:us-east-1:111122223333:global/webacl/example/00000000-0000-0000-0000-000000000000",
+});
+
+new CfnOutput(this, "CloudFrontDomainName", {
+  value: site.distribution.distributionDomainName,
+});
+```
+
+`AWS_IAM` is the default Function URL posture; AppTheory adds Lambda URL Origin Access Control so viewers reach Lambda
+through CloudFront, not through a public unauthenticated Function URL.
+
+### SSG + blocking ISR
+
+Use `SSG_ISR` mode when S3 should be the primary HTML origin and Lambda should handle SSR/ISR fallback on S3 `403`/`404`
+misses:
+
+```ts
+import { AppTheoryDynamoTable, AppTheorySsrSite, AppTheorySsrSiteMode } from "@theory-cloud/apptheory-cdk";
+
+const htmlStoreBucket = new s3.Bucket(this, "IsrBucket", {
+  blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+  encryption: s3.BucketEncryption.S3_MANAGED,
+  enforceSSL: true,
+  removalPolicy: RemovalPolicy.RETAIN,
+});
+
+const cacheTable = new AppTheoryDynamoTable(this, "CacheTable", {
+  partitionKeyName: "pk",
+  sortKeyName: "sk",
+  timeToLiveAttribute: "ttl",
+  removalPolicy: RemovalPolicy.RETAIN,
+});
+
+const site = new AppTheorySsrSite(this, "Site", {
+  mode: AppTheorySsrSiteMode.SSG_ISR,
+  ssrFunction,
+  ssrUrlAuthType: lambda.FunctionUrlAuthType.AWS_IAM,
+  assetsBucket,
+  assetsKeyPrefix: "assets",
+  assetsManifestKey: ".vite/manifest.json",
+  htmlStoreBucket,
+  htmlStoreKeyPrefix: "isr",
+  isrMetadataTable: cacheTable.table,
+  directS3PathPatterns: ["/.vite/*"],
+  ssrPathPatterns: ["/actions/*"], // form actions, auth callbacks, and other dynamic routes
+  domainName: "app.example.com",
+  certificateArn: "arn:aws:acm:us-east-1:111122223333:certificate/00000000-0000-0000-0000-000000000000",
+  webAclId: "arn:aws:wafv2:us-east-1:111122223333:global/webacl/example/00000000-0000-0000-0000-000000000000",
+});
+```
+
+In `SSG_ISR` mode AppTheory automatically adds:
+
+- an S3-primary / Lambda-fallback origin group for HTML routes;
+- generated viewer-request rewrite logic for extensionless SSG paths;
+- generated request-id propagation and viewer-response echo;
+- direct S3 routing for `/_facetheory/data/*` SSG hydration sidecars;
+- direct Lambda routing for `/_facetheory/ssr-data/*` SSR hydration sidecars;
+- `APPTHEORY_ASSETS_*`, `FACETHEORY_ISR_*`, and ISR metadata table aliases on the SSR Lambda when those resources are
+  supplied.
+
+## 4. Synthesize, deploy, curl
+
+Synthesize first:
+
+```bash
+npm run synth
+# or your app's CDK command, for example:
+npx cdk synth
+npx cdk diff
+```
+
+Deploy only from the intended AWS account/region with reviewed credentials:
+
+```bash
+npx cdk deploy FaceTheoryHelloWorld --outputs-file cdk-outputs.json
+```
+
+After deployment, read the output and verify through CloudFront:
+
+```bash
+CLOUDFRONT_DOMAIN=$(jq -r '.FaceTheoryHelloWorld.CloudFrontDomainName' cdk-outputs.json)
+
+curl -I "https://${CLOUDFRONT_DOMAIN}/"
+curl -sS "https://${CLOUDFRONT_DOMAIN}/" | grep "Hello FaceTheory"
+curl -I "https://${CLOUDFRONT_DOMAIN}/assets/entry.css"
+```
+
+For `SSG_ISR` stacks, add route-placement checks that match your app:
+
+```bash
+curl -I "https://${CLOUDFRONT_DOMAIN}/ssg-demo"      # expected S3/static cache headers when the SSG key exists
+curl -I "https://${CLOUDFRONT_DOMAIN}/isr-demo"      # expected FaceTheory ISR headers from Lambda
+curl -I "https://${CLOUDFRONT_DOMAIN}/_facetheory/data/index.json" # expected S3 strict-CSP SSG sidecar, if emitted
+```
+
+These commands are operator validation steps, not proof performed by this repository. A docs/stacks PR should report only
+local synth/tests/docs-build proof unless it actually deployed with authorized AWS credentials.
+
+## Reference stacks
+
+- `infra/apptheory-ssr-site/` — SSR-only CloudFront + S3 assets + Lambda Function URL using a real FaceApp handler.
+- `infra/apptheory-ssg-isr-site/` — `AppTheorySsrSiteMode.SSG_ISR`, S3-primary HTML origin group, Lambda fallback, and
+  TableTheory-backed ISR metadata wiring.
+

--- a/docs/cdk/aws-deployment.md
+++ b/docs/cdk/aws-deployment.md
@@ -57,6 +57,11 @@ Reference-stack stance:
 - attach strict CSP headers from the Face response; baseline CloudFront response headers do not substitute for a
   route-owned `content-security-policy`
 
+The SSR reference stack (`infra/apptheory-ssr-site/`) is the minimal copyable shape: it bundles a real Lambda handler
+from `src/handler.ts`, creates a `FaceApp` with `createFaceApp(...)`, adapts it through
+`createAppTheoryFaceHandler({ app })`, and lets `AppTheorySsrSite` own the CloudFront + S3 + Lambda Function URL
+topology. It is intentionally not an inline HTML-string Lambda example.
+
 ### Mutating Forms Behind Lambda Function URL OAC
 
 `AppTheorySsrSite` keeps the Lambda Function URL origin protected by `AWS_IAM` and CloudFront Lambda URL OAC. Browser

--- a/docs/cdk/aws-deployment.md
+++ b/docs/cdk/aws-deployment.md
@@ -62,6 +62,22 @@ from `src/handler.ts`, creates a `FaceApp` with `createFaceApp(...)`, adapts it 
 `createAppTheoryFaceHandler({ app })`, and lets `AppTheorySsrSite` own the CloudFront + S3 + Lambda Function URL
 topology. It is intentionally not an inline HTML-string Lambda example.
 
+The [CDK guide](./README.md) contains the hello-world-to-CloudFront walkthrough. The core `AppTheorySsrSite` property
+map is:
+
+| Need | Prop |
+|---|---|
+| SSR Lambda | `ssrFunction` |
+| CloudFront-signed Lambda URL | `ssrUrlAuthType: lambda.FunctionUrlAuthType.AWS_IAM` |
+| Static assets | `assetsBucket`, `assetsKeyPrefix`, `assetsManifestKey` |
+| SSG/ISR origin-group mode | `mode: AppTheorySsrSiteMode.SSG_ISR` |
+| SSG raw sidecar/object paths | `directS3PathPatterns` (AppTheory adds `/_facetheory/data/*` in `SSG_ISR`) |
+| Dynamic Lambda-only paths | `ssrPathPatterns` (AppTheory adds `/_facetheory/ssr-data/*` in `SSG_ISR`) |
+| ISR HTML storage | `htmlStoreBucket`, `htmlStoreKeyPrefix` |
+| ISR metadata/lease table | `isrMetadataTable` |
+| Custom domain | `domainName` plus `certificateArn` or `hostedZone` |
+| WAF | `webAclId` |
+
 ### Mutating Forms Behind Lambda Function URL OAC
 
 `AppTheorySsrSite` keeps the Lambda Function URL origin protected by `AWS_IAM` and CloudFront Lambda URL OAC. Browser

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,6 +138,90 @@ runtime.get("/{proxy+}", createAppTheoryFaceHandler({ app }));
 export const handler = createLambdaFunctionURLStreamingHandler(runtime);
 ```
 
+## Deploy With `AppTheorySsrSite`
+
+For AWS deployment, keep the same FaceTheory app and let AppTheory own the CloudFront + S3 + Lambda Function URL shape.
+The deploy reference is not a second render path: `createFaceApp(...)` still renders the document, and
+`createAppTheoryFaceHandler({ app })` still adapts it into AppTheory.
+
+Minimal SSR stack shape:
+
+```ts
+import { CfnOutput, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { AppTheorySsrSite } from "@theory-cloud/apptheory-cdk";
+
+const assetsBucket = new s3.Bucket(this, "AssetsBucket", {
+  blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+  encryption: s3.BucketEncryption.S3_MANAGED,
+  enforceSSL: true,
+  removalPolicy: RemovalPolicy.RETAIN,
+});
+
+const ssrFunction = new NodejsFunction(this, "SsrFunction", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  entry: "src/handler.ts",
+  handler: "handler",
+  timeout: Duration.seconds(10),
+});
+
+const site = new AppTheorySsrSite(this, "Site", {
+  ssrFunction,
+  ssrUrlAuthType: lambda.FunctionUrlAuthType.AWS_IAM,
+  assetsBucket,
+  assetsKeyPrefix: "assets",
+  assetsManifestKey: ".vite/manifest.json",
+  domainName: "app.example.com", // optional custom domain
+  certificateArn: "arn:aws:acm:us-east-1:111122223333:certificate/...", // optional, CloudFront requires us-east-1
+  webAclId: "arn:aws:wafv2:us-east-1:111122223333:global/webacl/...", // optional WAF
+});
+
+new CfnOutput(this, "CloudFrontDomainName", {
+  value: site.distribution.distributionDomainName,
+});
+```
+
+For SSG + blocking ISR, switch to `AppTheorySsrSiteMode.SSG_ISR` and pass ISR resources:
+
+```ts
+import { AppTheorySsrSiteMode } from "@theory-cloud/apptheory-cdk";
+
+new AppTheorySsrSite(this, "Site", {
+  mode: AppTheorySsrSiteMode.SSG_ISR,
+  ssrFunction,
+  ssrUrlAuthType: lambda.FunctionUrlAuthType.AWS_IAM,
+  assetsBucket,
+  assetsKeyPrefix: "assets",
+  assetsManifestKey: ".vite/manifest.json",
+  htmlStoreBucket: isrBucket,
+  htmlStoreKeyPrefix: "isr",
+  isrMetadataTable: cacheTable.table,
+  directS3PathPatterns: ["/.vite/*"],
+  ssrPathPatterns: ["/actions/*"],
+});
+```
+
+Validate locally before deploying:
+
+```bash
+cd infra/apptheory-ssr-site && npm ci && npm test
+cd ../apptheory-ssg-isr-site && npm ci && npm test
+```
+
+Then an AWS operator can run the app's CDK deploy and curl the CloudFront output:
+
+```bash
+npx cdk deploy FaceTheoryHelloWorld --outputs-file cdk-outputs.json
+CLOUDFRONT_DOMAIN=$(jq -r '.FaceTheoryHelloWorld.CloudFrontDomainName' cdk-outputs.json)
+curl -I "https://${CLOUDFRONT_DOMAIN}/"
+curl -sS "https://${CLOUDFRONT_DOMAIN}/" | grep "Hello FaceTheory"
+```
+
+Do not treat local synth/tests/docs builds as live deployment proof. The full walkthrough, including domain, WAF, ISR
+wiring, SSG sidecars, invalidation notes, and post-deploy curl checks, lives in [CDK And AWS Notes](./cdk/README.md).
+
 ## Add Strict No-Inline CSP Hydration
 
 Use this path when a route must run without inline scripts, inline styles, or raw head HTML. The server render still owns

--- a/infra/apptheory-ssg-isr-site/src/stack.ts
+++ b/infra/apptheory-ssg-isr-site/src/stack.ts
@@ -49,8 +49,6 @@ export class FaceTheoryAppTheorySsgIsrSiteStack extends Stack {
       runtime: lambda.Runtime.NODEJS_20_X,
       entry: path.resolve(__dirname, './ssr-handler.ts'),
       handler: 'handler',
-      // Don't rely on the Lambda runtime shipping AWS SDK v3 modules. Bundle them.
-      bundleAwsSDK: true,
       timeout: Duration.seconds(10),
       memorySize: 512,
       environment: {

--- a/infra/apptheory-ssg-isr-site/src/stack.ts
+++ b/infra/apptheory-ssg-isr-site/src/stack.ts
@@ -2,13 +2,15 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { CfnOutput, Duration, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
-import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
-import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
-import { AppTheoryDynamoTable } from '@theory-cloud/apptheory-cdk';
+import {
+  AppTheoryDynamoTable,
+  AppTheorySsrSite,
+  AppTheorySsrSiteMode,
+} from '@theory-cloud/apptheory-cdk';
 import { Construct } from 'constructs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -22,6 +24,8 @@ function requireDir(name: string, relativePath: string): string {
 }
 
 export class FaceTheoryAppTheorySsgIsrSiteStack extends Stack {
+  public readonly site: AppTheorySsrSite;
+
   constructor(scope: Construct, id: string, props: StackProps = {}) {
     super(scope, id, props);
 
@@ -72,20 +76,6 @@ export class FaceTheoryAppTheorySsgIsrSiteStack extends Stack {
       removalPolicy: RemovalPolicy.DESTROY,
     });
 
-    cacheTable.table.grantReadWriteData(ssrFunction);
-    isrBucket.grantReadWrite(ssrFunction);
-
-    // Mirror AppTheory's cache table env aliases for compatibility.
-    ssrFunction.addEnvironment('APPTHEORY_CACHE_TABLE_NAME', cacheTable.table.tableName);
-    ssrFunction.addEnvironment('FACETHEORY_CACHE_TABLE_NAME', cacheTable.table.tableName);
-    ssrFunction.addEnvironment('CACHE_TABLE_NAME', cacheTable.table.tableName);
-    ssrFunction.addEnvironment('CACHE_TABLE', cacheTable.table.tableName);
-
-    const ssrUrl = ssrFunction.addFunctionUrl({
-      authType: lambda.FunctionUrlAuthType.AWS_IAM,
-      invokeMode: lambda.InvokeMode.RESPONSE_STREAM,
-    });
-
     // Deploy assets + manifest + SSG output with explicit cache semantics.
     const immutableAssetsDir = requireDir('immutable assets', '../deploy/assets');
     new s3deploy.BucketDeployment(this, 'AssetsDeploymentImmutable', {
@@ -115,216 +105,29 @@ export class FaceTheoryAppTheorySsgIsrSiteStack extends Stack {
       cacheControl: [s3deploy.CacheControl.fromString('public,max-age=0,s-maxage=600')],
     });
 
-    // CloudFront:
-    // - S3 is the primary origin for HTML keys (SSG/static)
-    // - Lambda URL is the fallback origin for misses (SSR/ISR)
-    //
-    // This strategy scales for large SSG route sets because no per-route behaviors are required.
-    const s3Origin = origins.S3BucketOrigin.withOriginAccessControl(assetsBucket);
-    const ssrOrigin = origins.FunctionUrlOrigin.withOriginAccessControl(ssrUrl);
-
-    const ssgRewrite = new cloudfront.Function(this, 'SsgRewrite', {
-      code: cloudfront.FunctionCode.fromInline(`
-function handler(event) {
-  var req = event.request;
-  var uri = req.uri || '/';
-
-  // Request correlation:
-  // - Always set/propagate x-request-id so SSR logs and viewer responses can correlate with CloudFront.
-  // - Prefer an inbound x-request-id if present, otherwise use the CloudFront request ID.
-  if (!req.headers['x-request-id']) {
-    req.headers['x-request-id'] = { value: event.context.requestId };
-  }
-
-  // Preserve the original path so SSR can route correctly when S3 misses.
-  req.headers['x-facetheory-original-uri'] = { value: uri };
-
-  if (uri === '/assets' || uri.startsWith('/assets/')) return req;
-  if (uri === '/.vite' || uri.startsWith('/.vite/')) return req;
-  if (uri === '/_facetheory/data' || uri.startsWith('/_facetheory/data/')) return req;
-  if (uri === '/_facetheory/ssr-data' || uri.startsWith('/_facetheory/ssr-data/')) return req;
-
-  // If the final segment contains a dot, treat it as a file request.
-  var idx = uri.lastIndexOf('/');
-  var last = uri.substring(idx + 1);
-  if (last.indexOf('.') !== -1) return req;
-
-  if (uri.endsWith('/')) {
-    req.uri = uri + 'index.html';
-    return req;
-  }
-
-  req.uri = uri + '/index.html';
-  return req;
-}
-      `.trim()),
-    });
-
-    const requestIdResponseHeader = new cloudfront.Function(this, 'RequestIdResponseHeader', {
-      code: cloudfront.FunctionCode.fromInline(`
-function handler(event) {
-  var req = event.request;
-  var resp = event.response;
-
-  var requestId = '';
-  if (req.headers && req.headers['x-request-id']) {
-    requestId = String(req.headers['x-request-id'].value || '').trim();
-  }
-  if (!requestId) requestId = String(event.context.requestId || '').trim();
-
-  if (requestId) {
-    resp.headers = resp.headers || {};
-    if (!resp.headers['x-request-id']) {
-      resp.headers['x-request-id'] = { value: requestId };
-    }
-  }
-
-  return resp;
-}
-      `.trim()),
-    });
-
-    const originRequestPolicy = new cloudfront.OriginRequestPolicy(this, 'OriginRequestPolicy', {
-      comment: 'Forward enough for SSR/ISR, without exploding the static cache key',
-      headerBehavior: cloudfront.OriginRequestHeaderBehavior.allowList(
-        'x-request-id',
-        'x-facetheory-original-uri',
-      ),
-      queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.all(),
-      cookieBehavior: cloudfront.OriginRequestCookieBehavior.all(),
-    });
-
-    const htmlOriginGroup = new origins.OriginGroup({
-      primaryOrigin: s3Origin,
-      fallbackOrigin: ssrOrigin,
-      fallbackStatusCodes: [403, 404],
-    });
-
-    const logsBucket = new s3.Bucket(this, 'LogsBucket', {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      enforceSSL: true,
+    // AppTheory owns the CloudFront/Lambda URL/S3 edge topology. In SSG_ISR mode it
+    // uses S3 as the primary HTML origin and Lambda Function URL as the 403/404
+    // failover origin, while preserving FaceTheory's original-URI and request-id
+    // headers through generated CloudFront Functions.
+    this.site = new AppTheorySsrSite(this, 'Site', {
+      mode: AppTheorySsrSiteMode.SSG_ISR,
+      ssrFunction,
+      ssrUrlAuthType: lambda.FunctionUrlAuthType.AWS_IAM,
+      assetsBucket,
+      assetsKeyPrefix: 'assets',
+      // Vite commonly emits `.vite/manifest.json` in the client build output.
+      assetsManifestKey: '.vite/manifest.json',
+      htmlStoreBucket: isrBucket,
+      htmlStoreKeyPrefix: 'isr',
+      isrMetadataTable: cacheTable.table,
+      directS3PathPatterns: ['/.vite/*'],
+      enableLogging: true,
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
     });
 
-    // Note: avoid CSP here. Nonce-based CSP must be generated per SSR request and set by the SSR origin.
-    const responseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(this, 'ResponseHeadersPolicy', {
-      comment: 'FaceTheory example security headers (CSP is origin-defined)',
-      securityHeadersBehavior: {
-        strictTransportSecurity: {
-          accessControlMaxAge: Duration.days(365 * 2),
-          includeSubdomains: true,
-          preload: true,
-          override: true,
-        },
-        contentTypeOptions: { override: true },
-        frameOptions: { frameOption: cloudfront.HeadersFrameOption.DENY, override: true },
-        referrerPolicy: {
-          referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
-          override: true,
-        },
-        xssProtection: { protection: true, modeBlock: true, override: true },
-      },
-      customHeadersBehavior: {
-        customHeaders: [
-          {
-            header: 'permissions-policy',
-            value: 'camera=(), microphone=(), geolocation=()',
-            override: true,
-          },
-        ],
-      },
-    });
-
-    const distribution = new cloudfront.Distribution(this, 'Distribution', {
-      defaultRootObject: 'index.html',
-      enableLogging: true,
-      logBucket: logsBucket,
-      defaultBehavior: {
-        origin: htmlOriginGroup,
-        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
-        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        cachePolicy: cloudfront.CachePolicy.USE_ORIGIN_CACHE_CONTROL_HEADERS,
-        originRequestPolicy,
-        responseHeadersPolicy,
-        functionAssociations: [
-          {
-            function: ssgRewrite,
-            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-          },
-          {
-            function: requestIdResponseHeader,
-            eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
-          },
-        ],
-      },
-      additionalBehaviors: {
-        '/assets/*': {
-          origin: s3Origin,
-          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          cachePolicy: cloudfront.CachePolicy.USE_ORIGIN_CACHE_CONTROL_HEADERS,
-          responseHeadersPolicy,
-          functionAssociations: [
-            {
-              function: requestIdResponseHeader,
-              eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
-            },
-          ],
-        },
-        '/.vite/*': {
-          origin: s3Origin,
-          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          cachePolicy: cloudfront.CachePolicy.USE_ORIGIN_CACHE_CONTROL_HEADERS,
-          responseHeadersPolicy,
-          functionAssociations: [
-            {
-              function: requestIdResponseHeader,
-              eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
-            },
-          ],
-        },
-        '/_facetheory/data/*': {
-          origin: s3Origin,
-          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          cachePolicy: cloudfront.CachePolicy.USE_ORIGIN_CACHE_CONTROL_HEADERS,
-          responseHeadersPolicy,
-          functionAssociations: [
-            {
-              function: requestIdResponseHeader,
-              eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
-            },
-          ],
-        },
-        '/_facetheory/ssr-data/*': {
-          // SSR runtime hydration sidecars are framework-owned resource routes on the
-          // same Lambda/FaceApp handler that rendered the HTML. Keep them distinct from
-          // SSG sidecars under /_facetheory/data/*, which remain S3/static objects.
-          origin: ssrOrigin,
-          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-          originRequestPolicy,
-          responseHeadersPolicy,
-          functionAssociations: [
-            {
-              function: ssgRewrite,
-              eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-            },
-            {
-              function: requestIdResponseHeader,
-              eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
-            },
-          ],
-        },
-      },
-    });
-
     new CfnOutput(this, 'CloudFrontDomainName', {
-      value: distribution.distributionDomainName,
+      value: this.site.distribution.distributionDomainName,
     });
 
     new CfnOutput(this, 'AssetsBucketName', {
@@ -340,7 +143,7 @@ function handler(event) {
     });
 
     new CfnOutput(this, 'SsrFunctionUrl', {
-      value: ssrUrl.url,
+      value: this.site.ssrUrl.url,
     });
   }
 }

--- a/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
+++ b/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
@@ -139,7 +139,7 @@
                         },
                         ":distribution/",
                         {
-                          "Ref": "Distribution830FAC52"
+                          "Ref": "SiteDistribution390DED28"
                         }
                       ]
                     ]
@@ -355,6 +355,50 @@
                   ]
                 }
               ]
+            },
+            {
+              "Action": "s3:GetObject",
+              "Condition": {
+                "StringEquals": {
+                  "AWS:SourceArn": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":cloudfront::",
+                        {
+                          "Ref": "AWS::AccountId"
+                        },
+                        ":distribution/",
+                        {
+                          "Ref": "SiteDistribution390DED28"
+                        }
+                      ]
+                    ]
+                  }
+                }
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "cloudfront.amazonaws.com"
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "IsrBucketCAA25890",
+                        "Arn"
+                      ]
+                    },
+                    "/*"
+                  ]
+                ]
+              }
             }
           ],
           "Version": "2012-10-17"
@@ -418,6 +462,43 @@
           "Statement": [
             {
               "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "IsrBucketCAA25890",
+                    "Arn"
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "IsrBucketCAA25890",
+                          "Arn"
+                        ]
+                      },
+                      "/*"
+                    ]
+                  ]
+                }
+              ]
+            },
+            {
+              "Action": [
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
                 "dynamodb:GetItem",
@@ -458,20 +539,13 @@
               "Action": [
                 "s3:GetObject*",
                 "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
-                "s3:Abort*"
+                "s3:List*"
               ],
               "Effect": "Allow",
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "IsrBucketCAA25890",
+                    "AssetsBucket5CB76180",
                     "Arn"
                   ]
                 },
@@ -481,7 +555,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "IsrBucketCAA25890",
+                          "AssetsBucket5CB76180",
                           "Arn"
                         ]
                       },
@@ -509,7 +583,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "4fc381ead946b3d7b8c561a26106aa1b4fbf3ab421ab1ba7b74311ddafdfffd6.zip"
+          "S3Key": "208960de7e24f7a4b345337c371dd823a08dea243b5b6b16516c440fd8618a8c.zip"
         },
         "Environment": {
           "Variables": {
@@ -552,15 +626,35 @@
         "SsrFunctionServiceRoleF0484DAB"
       ]
     },
-    "SsrFunctionFunctionUrl8D4BC70B": {
-      "Type": "AWS::Lambda::Url",
+    "SsrFunctionAllowCloudFrontInvokeFunctionViaUrl8D4F8C8A": {
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "AuthType": "AWS_IAM",
-        "InvokeMode": "RESPONSE_STREAM",
-        "TargetFunctionArn": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
           "Fn::GetAtt": [
             "SsrFunctionD22C6F1E",
             "Arn"
+          ]
+        },
+        "InvokedViaFunctionUrl": true,
+        "Principal": "cloudfront.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":cloudfront::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":distribution/",
+              {
+                "Ref": "SiteDistribution390DED28"
+              }
+            ]
           ]
         }
       }
@@ -892,93 +986,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "SsgRewrite0C735A0F": {
-      "Type": "AWS::CloudFront::Function",
-      "Properties": {
-        "AutoPublish": true,
-        "FunctionCode": "function handler(event) {\n  var req = event.request;\n  var uri = req.uri || '/';\n\n  // Request correlation:\n  // - Always set/propagate x-request-id so SSR logs and viewer responses can correlate with CloudFront.\n  // - Prefer an inbound x-request-id if present, otherwise use the CloudFront request ID.\n  if (!req.headers['x-request-id']) {\n    req.headers['x-request-id'] = { value: event.context.requestId };\n  }\n\n  // Preserve the original path so SSR can route correctly when S3 misses.\n  req.headers['x-facetheory-original-uri'] = { value: uri };\n\n  if (uri === '/assets' || uri.startsWith('/assets/')) return req;\n  if (uri === '/.vite' || uri.startsWith('/.vite/')) return req;\n  if (uri === '/_facetheory/data' || uri.startsWith('/_facetheory/data/')) return req;\n  if (uri === '/_facetheory/ssr-data' || uri.startsWith('/_facetheory/ssr-data/')) return req;\n\n  // If the final segment contains a dot, treat it as a file request.\n  var idx = uri.lastIndexOf('/');\n  var last = uri.substring(idx + 1);\n  if (last.indexOf('.') !== -1) return req;\n\n  if (uri.endsWith('/')) {\n    req.uri = uri + 'index.html';\n    return req;\n  }\n\n  req.uri = uri + '/index.html';\n  return req;\n}",
-        "FunctionConfig": {
-          "Comment": {
-            "Fn::Join": [
-              "",
-              [
-                {
-                  "Ref": "AWS::Region"
-                },
-                "FaceTheoryAppThesrSiteSsgRewriteBCB96CBF"
-              ]
-            ]
-          },
-          "Runtime": "cloudfront-js-1.0"
-        },
-        "Name": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "AWS::Region"
-              },
-              "FaceTheoryAppThesrSiteSsgRewriteBCB96CBF"
-            ]
-          ]
-        }
-      }
-    },
-    "RequestIdResponseHeaderA32D1D61": {
-      "Type": "AWS::CloudFront::Function",
-      "Properties": {
-        "AutoPublish": true,
-        "FunctionCode": "function handler(event) {\n  var req = event.request;\n  var resp = event.response;\n\n  var requestId = '';\n  if (req.headers && req.headers['x-request-id']) {\n    requestId = String(req.headers['x-request-id'].value || '').trim();\n  }\n  if (!requestId) requestId = String(event.context.requestId || '').trim();\n\n  if (requestId) {\n    resp.headers = resp.headers || {};\n    if (!resp.headers['x-request-id']) {\n      resp.headers['x-request-id'] = { value: requestId };\n    }\n  }\n\n  return resp;\n}",
-        "FunctionConfig": {
-          "Comment": {
-            "Fn::Join": [
-              "",
-              [
-                {
-                  "Ref": "AWS::Region"
-                },
-                "FaceTheoryAppTheIdResponseHeaderAB4B1BF9"
-              ]
-            ]
-          },
-          "Runtime": "cloudfront-js-1.0"
-        },
-        "Name": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "AWS::Region"
-              },
-              "FaceTheoryAppTheIdResponseHeaderAB4B1BF9"
-            ]
-          ]
-        }
-      }
-    },
-    "OriginRequestPolicy3EFDB4FA": {
-      "Type": "AWS::CloudFront::OriginRequestPolicy",
-      "Properties": {
-        "OriginRequestPolicyConfig": {
-          "Comment": "Forward enough for SSR/ISR, without exploding the static cache key",
-          "CookiesConfig": {
-            "CookieBehavior": "all"
-          },
-          "HeadersConfig": {
-            "HeaderBehavior": "whitelist",
-            "Headers": [
-              "x-request-id",
-              "x-facetheory-original-uri"
-            ]
-          },
-          "Name": "FaceTheoryAppTheorySsgIsrSiteOriginRequestPolicy4B63D3F3",
-          "QueryStringsConfig": {
-            "QueryStringBehavior": "all"
-          }
-        }
-      }
-    },
-    "LogsBucket9C4D8843": {
+    "SiteCloudFrontLogsBucketF9C1CD02": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "BucketEncryption": {
@@ -987,6 +995,13 @@
               "ServerSideEncryptionByDefault": {
                 "SSEAlgorithm": "AES256"
               }
+            }
+          ]
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "ObjectWriter"
             }
           ]
         },
@@ -1006,11 +1021,11 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "LogsBucketPolicyD70D9252": {
+    "SiteCloudFrontLogsBucketPolicy816DFF56": {
       "Type": "AWS::S3::BucketPolicy",
       "Properties": {
         "Bucket": {
-          "Ref": "LogsBucket9C4D8843"
+          "Ref": "SiteCloudFrontLogsBucketF9C1CD02"
         },
         "PolicyDocument": {
           "Statement": [
@@ -1028,7 +1043,7 @@
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "LogsBucket9C4D8843",
+                    "SiteCloudFrontLogsBucketF9C1CD02",
                     "Arn"
                   ]
                 },
@@ -1038,7 +1053,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "LogsBucket9C4D8843",
+                          "SiteCloudFrontLogsBucketF9C1CD02",
                           "Arn"
                         ]
                       },
@@ -1067,7 +1082,7 @@
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "LogsBucket9C4D8843",
+                    "SiteCloudFrontLogsBucketF9C1CD02",
                     "Arn"
                   ]
                 },
@@ -1077,7 +1092,7 @@
                     [
                       {
                         "Fn::GetAtt": [
-                          "LogsBucket9C4D8843",
+                          "SiteCloudFrontLogsBucketF9C1CD02",
                           "Arn"
                         ]
                       },
@@ -1092,7 +1107,7 @@
         }
       }
     },
-    "LogsBucketAutoDeleteObjectsCustomResource7D54FB85": {
+    "SiteCloudFrontLogsBucketAutoDeleteObjectsCustomResource016FEC8F": {
       "Type": "Custom::S3AutoDeleteObjects",
       "Properties": {
         "ServiceToken": {
@@ -1102,20 +1117,203 @@
           ]
         },
         "BucketName": {
-          "Ref": "LogsBucket9C4D8843"
+          "Ref": "SiteCloudFrontLogsBucketF9C1CD02"
         }
       },
       "DependsOn": [
-        "LogsBucketPolicyD70D9252"
+        "SiteCloudFrontLogsBucketPolicy816DFF56"
       ],
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "ResponseHeadersPolicy13DBF9E0": {
+    "SiteSsrUrl2D74149D": {
+      "Type": "AWS::Lambda::Url",
+      "Properties": {
+        "AuthType": "AWS_IAM",
+        "InvokeMode": "RESPONSE_STREAM",
+        "TargetFunctionArn": {
+          "Fn::GetAtt": [
+            "SsrFunctionD22C6F1E",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "SiteSsrOriginRequestPolicyF6A13560": {
+      "Type": "AWS::CloudFront::OriginRequestPolicy",
+      "Properties": {
+        "OriginRequestPolicyConfig": {
+          "CookiesConfig": {
+            "CookieBehavior": "all"
+          },
+          "HeadersConfig": {
+            "HeaderBehavior": "whitelist",
+            "Headers": [
+              "cloudfront-forwarded-proto",
+              "cloudfront-viewer-address",
+              "x-apptheory-original-host",
+              "x-facetheory-original-host",
+              "x-apptheory-original-uri",
+              "x-facetheory-original-uri",
+              "x-request-id"
+            ]
+          },
+          "Name": "FaceTheoryAppTheorySsgIsrSiteSsrOriginRequestPolicy92B16B7E",
+          "QueryStringsConfig": {
+            "QueryStringBehavior": "all"
+          }
+        }
+      }
+    },
+    "SiteHtmlOriginRequestPolicy308D38C5": {
+      "Type": "AWS::CloudFront::OriginRequestPolicy",
+      "Properties": {
+        "OriginRequestPolicyConfig": {
+          "CookiesConfig": {
+            "CookieBehavior": "none"
+          },
+          "HeadersConfig": {
+            "HeaderBehavior": "whitelist",
+            "Headers": [
+              "cloudfront-forwarded-proto",
+              "cloudfront-viewer-address",
+              "x-apptheory-original-host",
+              "x-facetheory-original-host",
+              "x-apptheory-original-uri",
+              "x-facetheory-original-uri",
+              "x-request-id"
+            ]
+          },
+          "Name": "FaceTheoryAppTheorySsgIsrSiteHtmlOriginRequestPolicy2BB9018B",
+          "QueryStringsConfig": {
+            "QueryStringBehavior": "all"
+          }
+        }
+      }
+    },
+    "SiteStaticAssetsCachePolicy416A79D8": {
+      "Type": "AWS::CloudFront::CachePolicy",
+      "Properties": {
+        "CachePolicyConfig": {
+          "Comment": "AppTheory direct S3 asset/data cache policy: origin Cache-Control bounded by no viewer header forwarding",
+          "DefaultTTL": 86400,
+          "MaxTTL": 31536000,
+          "MinTTL": 0,
+          "Name": {
+            "Fn::Join": [
+              "",
+              [
+                "FaceTheoryAppTheorySsgIsrSiteStaticAssetsCachePolicy3C8CC3BD-",
+                {
+                  "Ref": "AWS::Region"
+                }
+              ]
+            ]
+          },
+          "ParametersInCacheKeyAndForwardedToOrigin": {
+            "CookiesConfig": {
+              "CookieBehavior": "none"
+            },
+            "EnableAcceptEncodingBrotli": true,
+            "EnableAcceptEncodingGzip": true,
+            "HeadersConfig": {
+              "HeaderBehavior": "none"
+            },
+            "QueryStringsConfig": {
+              "QueryStringBehavior": "none"
+            }
+          }
+        }
+      }
+    },
+    "SiteHtmlCachePolicy2B4843D5": {
+      "Type": "AWS::CloudFront::CachePolicy",
+      "Properties": {
+        "CachePolicyConfig": {
+          "Comment": "FaceTheory HTML cache policy keyed by query strings and stable public variant headers",
+          "DefaultTTL": 0,
+          "MaxTTL": 31536000,
+          "MinTTL": 0,
+          "Name": {
+            "Fn::Join": [
+              "",
+              [
+                "FaceTheoryAppTheorySsgIsrSiteHtmlCachePolicy13EF5DE2-",
+                {
+                  "Ref": "AWS::Region"
+                }
+              ]
+            ]
+          },
+          "ParametersInCacheKeyAndForwardedToOrigin": {
+            "CookiesConfig": {
+              "CookieBehavior": "none"
+            },
+            "EnableAcceptEncodingBrotli": true,
+            "EnableAcceptEncodingGzip": true,
+            "HeadersConfig": {
+              "HeaderBehavior": "whitelist",
+              "Headers": [
+                "x-apptheory-original-host",
+                "x-facetheory-original-host"
+              ]
+            },
+            "QueryStringsConfig": {
+              "QueryStringBehavior": "all"
+            }
+          }
+        }
+      }
+    },
+    "SiteSsrViewerRequestFunction103872E5": {
+      "Type": "AWS::CloudFront::Function",
+      "Properties": {
+        "AutoPublish": true,
+        "FunctionCode": "function handler(event) {\n\t  var request = event.request;\n\t  request.headers = request.headers || {};\n\t  var headers = request.headers;\n\t  var uri = request.uri || '/';\n\t  var blockedViewerTenantHeaders = [\n\t    'x-tenant-id'\n\t  ];\n\n\t  for (var blockedIndex = 0; blockedIndex < blockedViewerTenantHeaders.length; blockedIndex++) {\n\t    delete headers[blockedViewerTenantHeaders[blockedIndex]];\n\t  }\n\n\t  var requestIdHeader = headers['x-request-id'];\n\t  var requestId = requestIdHeader && requestIdHeader.value ? requestIdHeader.value.trim() : '';\n\n\t  if (!requestId) {\n\t    requestId = event.context && event.context.requestId ? String(event.context.requestId).trim() : '';\n\t  }\n\n\t  if (!requestId) {\n\t    requestId = 'req_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);\n\t  }\n\n\t  headers['x-request-id'] = { value: requestId };\n\t  headers['x-apptheory-original-uri'] = { value: uri };\n\t  headers['x-facetheory-original-uri'] = { value: uri };\n\n\t  if (headers.host && headers.host.value) {\n\t    headers['x-apptheory-original-host'] = { value: headers.host.value };\n\t    headers['x-facetheory-original-host'] = { value: headers.host.value };\n\t  }\n\n\t  if ('ssg-isr' === 'ssg-isr') {\n\t    var rawS3Prefixes = [\n\t      '/_facetheory/data',\n      '/assets',\n      '/.vite'\n\t    ];\n\t    var lambdaPassthroughPrefixes = [\n\t      '/_facetheory/ssr-data'\n\t    ];\n\t    var isLambdaPassthroughPath = false;\n\n\t    for (var i = 0; i < lambdaPassthroughPrefixes.length; i++) {\n\t      var prefix = lambdaPassthroughPrefixes[i];\n\t      if (uri === prefix || uri.startsWith(prefix + '/')) {\n\t        isLambdaPassthroughPath = true;\n\t        break;\n\t      }\n\t    }\n\n\t    if (!isLambdaPassthroughPath) {\n\t      var isRawS3Path = false;\n\n\t      for (var j = 0; j < rawS3Prefixes.length; j++) {\n\t        var rawPrefix = rawS3Prefixes[j];\n\t        if (uri === rawPrefix || uri.startsWith(rawPrefix + '/')) {\n\t          isRawS3Path = true;\n\t          break;\n\t        }\n\t      }\n\n\t      var lastSlash = uri.lastIndexOf('/');\n\t      var lastSegment = lastSlash >= 0 ? uri.substring(lastSlash + 1) : uri;\n\n\t      if (!isRawS3Path && lastSegment.indexOf('.') === -1) {\n\t        request.uri = uri.endsWith('/') ? uri + 'index.html' : uri + '/index.html';\n\t      }\n\t    }\n\t  }\n\n\t  return request;\n\t}",
+        "FunctionConfig": {
+          "Comment": "FaceTheory viewer-request edge context and HTML rewrite for SSR site",
+          "Runtime": "cloudfront-js-2.0"
+        },
+        "Name": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::Region"
+              },
+              "FaceTheoryAppTherRequestFunctionA4A8A767"
+            ]
+          ]
+        }
+      }
+    },
+    "SiteSsrViewerResponseFunction3CF15787": {
+      "Type": "AWS::CloudFront::Function",
+      "Properties": {
+        "AutoPublish": true,
+        "FunctionCode": "function handler(event) {\n\t  var request = event.request;\n\t  var response = event.response;\n\t  var requestIdHeader = request.headers['x-request-id'];\n\t  var requestId = requestIdHeader && requestIdHeader.value ? requestIdHeader.value.trim() : '';\n\n\t  if (!requestId) {\n\t    requestId = event.context && event.context.requestId ? String(event.context.requestId).trim() : '';\n\t  }\n\n\t  if (requestId) {\n\t    response.headers = response.headers || {};\n\t    if (!response.headers['x-request-id']) {\n\t      response.headers['x-request-id'] = { value: requestId };\n\t    }\n\t  }\n\n\t  return response;\n\t}",
+        "FunctionConfig": {
+          "Comment": "FaceTheory viewer-response request-id echo for SSR site",
+          "Runtime": "cloudfront-js-2.0"
+        },
+        "Name": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "AWS::Region"
+              },
+              "FaceTheoryAppTheResponseFunction697D5730"
+            ]
+          ]
+        }
+      }
+    },
+    "SiteResponseHeadersPolicy5F343E8C": {
       "Type": "AWS::CloudFront::ResponseHeadersPolicy",
       "Properties": {
         "ResponseHeadersPolicyConfig": {
-          "Comment": "FaceTheory example security headers (CSP is origin-defined)",
+          "Comment": "FaceTheory baseline security headers (CSP stays origin-defined)",
           "CustomHeadersConfig": {
             "Items": [
               {
@@ -1125,7 +1323,7 @@
               }
             ]
           },
-          "Name": "FaceTheoryAppTheorySsgIsrSiteResponseHeadersPolicy9923F5A6",
+          "Name": "FaceTheoryAppTheorySsgIsrSiteResponseHeadersPolicy859A163E",
           "SecurityHeadersConfig": {
             "ContentTypeOptions": {
               "Override": true
@@ -1153,35 +1351,35 @@
         }
       }
     },
-    "DistributionOrigin1S3OriginAccessControlEB606076": {
+    "SiteDistributionOrigin1S3OriginAccessControl4F95283E": {
       "Type": "AWS::CloudFront::OriginAccessControl",
       "Properties": {
         "OriginAccessControlConfig": {
-          "Name": "FaceTheoryAppTheorySsgIsrSitOrigin1S3OriginAccessControl4B9A4AE5",
+          "Name": "FaceTheoryAppTheorySsgIsrSitOrigin1S3OriginAccessControl7D45111B",
           "OriginAccessControlOriginType": "s3",
           "SigningBehavior": "always",
           "SigningProtocol": "sigv4"
         }
       }
     },
-    "DistributionOrigin2FunctionUrlOriginAccessControlAC8EE0B1": {
+    "SiteDistributionOrigin2FunctionUrlOriginAccessControl8BF64721": {
       "Type": "AWS::CloudFront::OriginAccessControl",
       "Properties": {
         "OriginAccessControlConfig": {
-          "Name": "FaceTheoryAppTheorySsgIsrSitnctionUrlOriginAccessControl17703696",
+          "Name": "FaceTheoryAppTheorySsgIsrSitnctionUrlOriginAccessControlFBA50110",
           "OriginAccessControlOriginType": "lambda",
           "SigningBehavior": "always",
           "SigningProtocol": "sigv4"
         }
       }
     },
-    "DistributionOrigin2InvokeFromApiForFaceTheoryAppTheorySsgIsrSiteDistributionOrigin29693F69F1F354135": {
+    "SiteDistributionOrigin2InvokeFromApiForFaceTheoryAppTheorySsgIsrSiteDistributionOrigin29095DE931B1D3CE0": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:InvokeFunctionUrl",
         "FunctionName": {
           "Fn::GetAtt": [
-            "SsrFunctionFunctionUrl8D4BC70B",
+            "SiteSsrUrl2D74149D",
             "FunctionArn"
           ]
         },
@@ -1200,14 +1398,25 @@
               },
               ":distribution/",
               {
-                "Ref": "Distribution830FAC52"
+                "Ref": "SiteDistribution390DED28"
               }
             ]
           ]
         }
       }
     },
-    "Distribution830FAC52": {
+    "SiteDistributionOrigin3S3OriginAccessControlF0F5F99A": {
+      "Type": "AWS::CloudFront::OriginAccessControl",
+      "Properties": {
+        "OriginAccessControlConfig": {
+          "Name": "FaceTheoryAppTheorySsgIsrSitOrigin3S3OriginAccessControlF5D0A596",
+          "OriginAccessControlOriginType": "s3",
+          "SigningBehavior": "always",
+          "SigningProtocol": "sigv4"
+        }
+      }
+    },
+    "SiteDistribution390DED28": {
       "Type": "AWS::CloudFront::Distribution",
       "Properties": {
         "DistributionConfig": {
@@ -1215,91 +1424,19 @@
             {
               "AllowedMethods": [
                 "GET",
-                "HEAD"
+                "HEAD",
+                "OPTIONS"
               ],
-              "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
-              "Compress": true,
-              "FunctionAssociations": [
-                {
-                  "EventType": "viewer-response",
-                  "FunctionARN": {
-                    "Fn::GetAtt": [
-                      "RequestIdResponseHeaderA32D1D61",
-                      "FunctionARN"
-                    ]
-                  }
-                }
-              ],
-              "PathPattern": "/assets/*",
-              "ResponseHeadersPolicyId": {
-                "Ref": "ResponseHeadersPolicy13DBF9E0"
+              "CachePolicyId": {
+                "Ref": "SiteStaticAssetsCachePolicy416A79D8"
               },
-              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30301D709",
-              "ViewerProtocolPolicy": "redirect-to-https"
-            },
-            {
-              "AllowedMethods": [
-                "GET",
-                "HEAD"
-              ],
-              "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
-              "Compress": true,
-              "FunctionAssociations": [
-                {
-                  "EventType": "viewer-response",
-                  "FunctionARN": {
-                    "Fn::GetAtt": [
-                      "RequestIdResponseHeaderA32D1D61",
-                      "FunctionARN"
-                    ]
-                  }
-                }
-              ],
-              "PathPattern": "/.vite/*",
-              "ResponseHeadersPolicyId": {
-                "Ref": "ResponseHeadersPolicy13DBF9E0"
-              },
-              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30301D709",
-              "ViewerProtocolPolicy": "redirect-to-https"
-            },
-            {
-              "AllowedMethods": [
-                "GET",
-                "HEAD"
-              ],
-              "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
-              "Compress": true,
-              "FunctionAssociations": [
-                {
-                  "EventType": "viewer-response",
-                  "FunctionARN": {
-                    "Fn::GetAtt": [
-                      "RequestIdResponseHeaderA32D1D61",
-                      "FunctionARN"
-                    ]
-                  }
-                }
-              ],
-              "PathPattern": "/_facetheory/data/*",
-              "ResponseHeadersPolicyId": {
-                "Ref": "ResponseHeadersPolicy13DBF9E0"
-              },
-              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30301D709",
-              "ViewerProtocolPolicy": "redirect-to-https"
-            },
-            {
-              "AllowedMethods": [
-                "GET",
-                "HEAD"
-              ],
-              "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
               "Compress": true,
               "FunctionAssociations": [
                 {
                   "EventType": "viewer-request",
                   "FunctionARN": {
                     "Fn::GetAtt": [
-                      "SsgRewrite0C735A0F",
+                      "SiteSsrViewerRequestFunction103872E5",
                       "FunctionARN"
                     ]
                   }
@@ -1308,36 +1445,305 @@
                   "EventType": "viewer-response",
                   "FunctionARN": {
                     "Fn::GetAtt": [
-                      "RequestIdResponseHeaderA32D1D61",
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
+              "PathPattern": "assets/*",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30BF9D92B",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "CachePolicyId": {
+                "Ref": "SiteStaticAssetsCachePolicy416A79D8"
+              },
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
+              "PathPattern": "assets",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30BF9D92B",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "CachePolicyId": {
+                "Ref": "SiteStaticAssetsCachePolicy416A79D8"
+              },
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
+              "PathPattern": "_facetheory/data/*",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30BF9D92B",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "CachePolicyId": {
+                "Ref": "SiteStaticAssetsCachePolicy416A79D8"
+              },
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
+              "PathPattern": "_facetheory/data",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30BF9D92B",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "CachePolicyId": {
+                "Ref": "SiteStaticAssetsCachePolicy416A79D8"
+              },
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
+              "PathPattern": ".vite/*",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30BF9D92B",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "CachePolicyId": {
+                "Ref": "SiteStaticAssetsCachePolicy416A79D8"
+              },
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
+              "PathPattern": ".vite",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30BF9D92B",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS",
+                "PUT",
+                "PATCH",
+                "POST",
+                "DELETE"
+              ],
+              "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
                       "FunctionARN"
                     ]
                   }
                 }
               ],
               "OriginRequestPolicyId": {
-                "Ref": "OriginRequestPolicy3EFDB4FA"
+                "Ref": "SiteSsrOriginRequestPolicyF6A13560"
               },
-              "PathPattern": "/_facetheory/ssr-data/*",
+              "PathPattern": "_facetheory/ssr-data/*",
               "ResponseHeadersPolicyId": {
-                "Ref": "ResponseHeadersPolicy13DBF9E0"
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
               },
-              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin29693F69F",
+              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin29095DE93",
+              "ViewerProtocolPolicy": "redirect-to-https"
+            },
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS",
+                "PUT",
+                "PATCH",
+                "POST",
+                "DELETE"
+              ],
+              "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+              "Compress": true,
+              "FunctionAssociations": [
+                {
+                  "EventType": "viewer-request",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerRequestFunction103872E5",
+                      "FunctionARN"
+                    ]
+                  }
+                },
+                {
+                  "EventType": "viewer-response",
+                  "FunctionARN": {
+                    "Fn::GetAtt": [
+                      "SiteSsrViewerResponseFunction3CF15787",
+                      "FunctionARN"
+                    ]
+                  }
+                }
+              ],
+              "OriginRequestPolicyId": {
+                "Ref": "SiteSsrOriginRequestPolicyF6A13560"
+              },
+              "PathPattern": "_facetheory/ssr-data",
+              "ResponseHeadersPolicyId": {
+                "Ref": "SiteResponseHeadersPolicy5F343E8C"
+              },
+              "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin29095DE93",
               "ViewerProtocolPolicy": "redirect-to-https"
             }
           ],
           "DefaultCacheBehavior": {
             "AllowedMethods": [
               "GET",
-              "HEAD"
+              "HEAD",
+              "OPTIONS"
             ],
-            "CachePolicyId": "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
+            "CachePolicyId": {
+              "Ref": "SiteHtmlCachePolicy2B4843D5"
+            },
             "Compress": true,
             "FunctionAssociations": [
               {
                 "EventType": "viewer-request",
                 "FunctionARN": {
                   "Fn::GetAtt": [
-                    "SsgRewrite0C735A0F",
+                    "SiteSsrViewerRequestFunction103872E5",
                     "FunctionARN"
                   ]
                 }
@@ -1346,32 +1752,32 @@
                 "EventType": "viewer-response",
                 "FunctionARN": {
                   "Fn::GetAtt": [
-                    "RequestIdResponseHeaderA32D1D61",
+                    "SiteSsrViewerResponseFunction3CF15787",
                     "FunctionARN"
                   ]
                 }
               }
             ],
             "OriginRequestPolicyId": {
-              "Ref": "OriginRequestPolicy3EFDB4FA"
+              "Ref": "SiteHtmlOriginRequestPolicy308D38C5"
             },
             "ResponseHeadersPolicyId": {
-              "Ref": "ResponseHeadersPolicy13DBF9E0"
+              "Ref": "SiteResponseHeadersPolicy5F343E8C"
             },
-            "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOriginGroup1DF0DDE71",
+            "TargetOriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOriginGroup1746AE2B5",
             "ViewerProtocolPolicy": "redirect-to-https"
           },
-          "DefaultRootObject": "index.html",
           "Enabled": true,
           "HttpVersion": "http2",
           "IPV6Enabled": true,
           "Logging": {
             "Bucket": {
               "Fn::GetAtt": [
-                "LogsBucket9C4D8843",
+                "SiteCloudFrontLogsBucketF9C1CD02",
                 "RegionalDomainName"
               ]
-            }
+            },
+            "Prefix": "cloudfront/"
           },
           "OriginGroups": {
             "Items": [
@@ -1385,14 +1791,14 @@
                     "Quantity": 2
                   }
                 },
-                "Id": "FaceTheoryAppTheorySsgIsrSiteDistributionOriginGroup1DF0DDE71",
+                "Id": "FaceTheoryAppTheorySsgIsrSiteDistributionOriginGroup1746AE2B5",
                 "Members": {
                   "Items": [
                     {
-                      "OriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin154FF04DC"
+                      "OriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin1F1ECEE12"
                     },
                     {
-                      "OriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin29693F69F"
+                      "OriginId": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin29095DE93"
                     }
                   ],
                   "Quantity": 2
@@ -1405,17 +1811,18 @@
             {
               "DomainName": {
                 "Fn::GetAtt": [
-                  "AssetsBucket5CB76180",
+                  "IsrBucketCAA25890",
                   "RegionalDomainName"
                 ]
               },
-              "Id": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin154FF04DC",
+              "Id": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin1F1ECEE12",
               "OriginAccessControlId": {
                 "Fn::GetAtt": [
-                  "DistributionOrigin1S3OriginAccessControlEB606076",
+                  "SiteDistributionOrigin1S3OriginAccessControl4F95283E",
                   "Id"
                 ]
               },
+              "OriginPath": "/isr",
               "S3OriginConfig": {
                 "OriginAccessIdentity": ""
               }
@@ -1435,7 +1842,7 @@
                       "/",
                       {
                         "Fn::GetAtt": [
-                          "SsrFunctionFunctionUrl8D4BC70B",
+                          "SiteSsrUrl2D74149D",
                           "FunctionUrl"
                         ]
                       }
@@ -1443,10 +1850,10 @@
                   }
                 ]
               },
-              "Id": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin29693F69F",
+              "Id": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin29095DE93",
               "OriginAccessControlId": {
                 "Fn::GetAtt": [
-                  "DistributionOrigin2FunctionUrlOriginAccessControlAC8EE0B1",
+                  "SiteDistributionOrigin2FunctionUrlOriginAccessControl8BF64721",
                   "Id"
                 ]
               }
@@ -1458,10 +1865,10 @@
                   "RegionalDomainName"
                 ]
               },
-              "Id": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30301D709",
+              "Id": "FaceTheoryAppTheorySsgIsrSiteDistributionOrigin30BF9D92B",
               "OriginAccessControlId": {
                 "Fn::GetAtt": [
-                  "DistributionOrigin1S3OriginAccessControlEB606076",
+                  "SiteDistributionOrigin3S3OriginAccessControlF0F5F99A",
                   "Id"
                 ]
               },
@@ -1478,7 +1885,7 @@
     "CloudFrontDomainName": {
       "Value": {
         "Fn::GetAtt": [
-          "Distribution830FAC52",
+          "SiteDistribution390DED28",
           "DomainName"
         ]
       }
@@ -1501,7 +1908,7 @@
     "SsrFunctionUrl": {
       "Value": {
         "Fn::GetAtt": [
-          "SsrFunctionFunctionUrl8D4BC70B",
+          "SiteSsrUrl2D74149D",
           "FunctionUrl"
         ]
       }

--- a/infra/apptheory-ssg-isr-site/test/unit/ssg-isr-site-stack.test.ts
+++ b/infra/apptheory-ssg-isr-site/test/unit/ssg-isr-site-stack.test.ts
@@ -23,9 +23,17 @@ interface OriginTemplate {
   readonly S3OriginConfig?: unknown;
 }
 
+interface OriginGroupTemplate {
+  readonly Id?: string;
+  readonly FailoverCriteria?: { readonly StatusCodes?: { readonly Items?: number[] } };
+  readonly Members?: { readonly Items?: Array<{ readonly OriginId?: string }> };
+}
+
 interface DistributionTemplate {
+  readonly DefaultCacheBehavior?: CacheBehaviorTemplate;
   readonly CacheBehaviors?: CacheBehaviorTemplate[];
   readonly Origins?: OriginTemplate[];
+  readonly OriginGroups?: { readonly Items?: OriginGroupTemplate[] };
 }
 
 async function readOrNull(filePath: string): Promise<string | null> {
@@ -58,9 +66,46 @@ function findBehavior(distribution: DistributionTemplate, pathPattern: string): 
 }
 
 function findOrigin(distribution: DistributionTemplate, behavior: CacheBehaviorTemplate): OriginTemplate {
-  const origin = distribution.Origins?.find((candidate) => candidate.Id === behavior.TargetOriginId);
+  const origin = findOriginById(distribution, behavior.TargetOriginId);
   assert.ok(origin, `missing CloudFront origin for ${behavior.PathPattern}`);
   return origin;
+}
+
+function findOriginById(
+  distribution: DistributionTemplate,
+  originId: string | undefined,
+): OriginTemplate | undefined {
+  return distribution.Origins?.find((candidate) => candidate.Id === originId);
+}
+
+function findFunctionCode(template: Record<string, unknown>, expectedSnippet: string): string {
+  const resources = template.Resources as
+    | Record<string, { Type?: string; Properties?: { FunctionCode?: unknown } }>
+    | undefined;
+  assert.ok(resources, 'template should include resources');
+
+  const code = Object.values(resources)
+    .filter((resource) => resource.Type === 'AWS::CloudFront::Function')
+    .map((resource) => String(resource.Properties?.FunctionCode ?? ''))
+    .find((candidate) => candidate.includes(expectedSnippet));
+
+  assert.ok(code, `missing CloudFront Function code containing: ${expectedSnippet}`);
+  return code;
+}
+
+function assertOldInlineFunctionsDeleted(template: Record<string, unknown>): void {
+  const resources = template.Resources as Record<string, { Type?: string }> | undefined;
+  assert.ok(resources, 'template should include resources');
+  const logicalIds = Object.keys(resources);
+
+  assert.ok(
+    !logicalIds.some((id) => id.includes('SsgRewrite')),
+    'legacy hand-rolled SsgRewrite CloudFront Function must be deleted',
+  );
+  assert.ok(
+    !logicalIds.some((id) => id.includes('RequestIdResponseHeader')),
+    'legacy hand-rolled RequestIdResponseHeader CloudFront Function must be deleted',
+  );
 }
 
 function buildFaceTheoryDist(): void {
@@ -79,14 +124,64 @@ test('H3: SSG+ISR stack synth is snapshotted', async () => {
   const stack = new FaceTheoryAppTheorySsgIsrSiteStack(app, 'FaceTheoryAppTheorySsgIsrSite');
 
   const template = Template.fromStack(stack).toJSON();
-  const distribution = findDistribution(template);
-  const ssgSidecarOrigin = findOrigin(distribution, findBehavior(distribution, '/_facetheory/data/*'));
-  const ssrSidecarOrigin = findOrigin(distribution, findBehavior(distribution, '/_facetheory/ssr-data/*'));
+  assertOldInlineFunctionsDeleted(template);
 
+  const distribution = findDistribution(template);
+  const defaultBehavior = distribution.DefaultCacheBehavior;
+  assert.ok(defaultBehavior, 'SSG_ISR mode should synthesize a default CloudFront behavior');
+  const originGroup = distribution.OriginGroups?.Items?.find(
+    (candidate) => candidate.Id === defaultBehavior.TargetOriginId,
+  );
+  assert.ok(originGroup, 'SSG_ISR default behavior must target an origin group');
+  assert.deepEqual(
+    originGroup.FailoverCriteria?.StatusCodes?.Items,
+    [403, 404],
+    'SSG_ISR origin group must fail over to Lambda on S3 403/404 misses',
+  );
+
+  const originGroupOrigins =
+    originGroup.Members?.Items?.map((member) => findOriginById(distribution, member.OriginId)) ?? [];
+  assert.ok(
+    originGroupOrigins.some((origin) => origin?.S3OriginConfig),
+    'SSG_ISR origin group must keep S3 as the static HTML origin',
+  );
+  assert.ok(
+    originGroupOrigins.some((origin) => origin?.CustomOriginConfig),
+    'SSG_ISR origin group must keep Lambda Function URL as the failover origin',
+  );
+
+  const viteManifestOrigin = findOrigin(distribution, findBehavior(distribution, '.vite/*'));
+  const ssgSidecarOrigin = findOrigin(distribution, findBehavior(distribution, '_facetheory/data/*'));
+  const ssrSidecarOrigin = findOrigin(distribution, findBehavior(distribution, '_facetheory/ssr-data/*'));
+
+  assert.ok(viteManifestOrigin.S3OriginConfig, 'Vite manifest paths must stay on the S3/static origin');
   assert.ok(ssgSidecarOrigin.S3OriginConfig, 'SSG sidecars must stay on the S3/static origin');
   assert.ok(
     ssrSidecarOrigin.CustomOriginConfig,
     'SSR hydration sidecars must route directly to the Lambda Function URL origin',
+  );
+
+  const viewerRequestCode = findFunctionCode(template, "headers['x-facetheory-original-uri']");
+  assert.ok(
+    viewerRequestCode.includes("headers['x-apptheory-original-uri']"),
+    'AppTheorySsrSite should preserve AppTheory original URI for SSR failover routing',
+  );
+  assert.ok(
+    viewerRequestCode.includes("headers['x-request-id']"),
+    'AppTheorySsrSite should set/propagate request IDs at the edge',
+  );
+  assert.ok(
+    viewerRequestCode.includes("request.uri = uri.endsWith('/') ? uri + 'index.html' : uri + '/index.html';"),
+    'AppTheorySsrSite SSG_ISR mode should rewrite extensionless routes to S3 index.html keys',
+  );
+  assert.ok(
+    viewerRequestCode.includes("'/_facetheory/data'") && viewerRequestCode.includes("'/_facetheory/ssr-data'"),
+    'AppTheorySsrSite should keep SSG sidecars on S3 and SSR sidecars on Lambda passthrough paths',
+  );
+  const viewerResponseCode = findFunctionCode(template, "response.headers['x-request-id']");
+  assert.ok(
+    viewerResponseCode.includes("response.headers['x-request-id']"),
+    'AppTheorySsrSite should echo request IDs on viewer responses',
   );
 
   const actual = `${JSON.stringify(template, null, 2)}\n`;

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,10 +7,12 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.13.2/theory-cloud-apptheory-1.13.2.tgz",
         "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.13.2/theory-cloud-apptheory-cdk-1.13.2.tgz",
         "@types/node": "^24.12.4",
         "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0",
+        "esbuild": "^0.28.1",
         "tsx": "^4.22.3",
         "typescript": "^5.9.3"
       },
@@ -69,6 +71,404 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1079.0.tgz",
+      "integrity": "sha512-kWHW1IeVj7TpVlsnLCNLQABME5tVg5Q/S6nooN04PDy+1J/NxxCnq7MRfB8UwZ2qTvMVjsIo2ILLbh7xCv0+CA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-node": "^3.972.62",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1079.0.tgz",
+      "integrity": "sha512-njnQvv5lqyzX42Af/Z3nuxm6eK9/OPDYkaIah3m2sJoudAKkvvJ5jOTAtw8zGhu5zviT4Sa9giYC1FHkabuAFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-node": "^3.972.62",
+        "@aws-sdk/dynamodb-codec": "^3.973.27",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.22",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1079.0.tgz",
+      "integrity": "sha512-1ptW3hfk437clc43QyWyCBk6D243h2t03zEWJ6KbTki/BTH3FpAWDp8dfElL9k7zisVtVQM8N7s8F5gHH9lIAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-node": "^3.972.62",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1079.0.tgz",
+      "integrity": "sha512-ycZDhMLf805leaBDQk0HnzvNJi293a0h++iG+hZtya5izd4Jyx022tV2owFc1u81c+Esdj6DchF5E9DAXxf8GQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-node": "^3.972.62",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.27.tgz",
+      "integrity": "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz",
+      "integrity": "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz",
+      "integrity": "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz",
+      "integrity": "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-login": "^3.972.59",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz",
+      "integrity": "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz",
+      "integrity": "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.53",
+        "@aws-sdk/credential-provider-http": "^3.972.55",
+        "@aws-sdk/credential-provider-ini": "^3.972.60",
+        "@aws-sdk/credential-provider-process": "^3.972.53",
+        "@aws-sdk/credential-provider-sso": "^3.972.59",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.59",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz",
+      "integrity": "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz",
+      "integrity": "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/token-providers": "3.1079.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz",
+      "integrity": "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.27.tgz",
+      "integrity": "sha512-eOTdNw3SwpkO/WOBFFY28Us9WcjBxejRw0vRD0eRqp6+aisHnBXiyQhSX2VIPHkCMFThhBRfSftdXBbgh95y8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.8.tgz",
+      "integrity": "sha512-bBmkG0Dnhfq0/T4Z0PpUr7HkncBVaWvvCbvafeaUM+yC9wa8GGjLJmonq0QL17REB9WivgGeYgWQ5A80Uw5UnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.22.tgz",
+      "integrity": "sha512-GMoLg4XAnkiwevqcOfgz0lOTYmIdM7MJK/BL9EAvsoMFqKIGRpyNIvuSNg5gdFzP57yB+EklMlK0+TwBqj1tCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.8",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz",
+      "integrity": "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1079.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz",
+      "integrity": "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.27",
+        "@aws-sdk/nested-clients": "^3.997.27",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -513,6 +913,107 @@
         "node": ">=18"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
+      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
+      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
+      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
+      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
+      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@theory-cloud/apptheory": {
+      "version": "1.13.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.13.2/theory-cloud-apptheory-1.13.2.tgz",
+      "integrity": "sha512-1E0eY8YGOi9hyeysKlkl/i66KV2zpPdG0PzLPxlixZGHCY2FcqLxoao+96iTGRqVRC/mSk95yf7FJqxwix/14A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.1015.0",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v1.10.1/theory-cloud-tabletheory-ts-1.10.1.tgz"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
     "node_modules/@theory-cloud/apptheory-cdk": {
       "version": "1.13.2",
       "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.13.2/theory-cloud-apptheory-cdk-1.13.2.tgz",
@@ -525,6 +1026,22 @@
       "peerDependencies": {
         "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
+      }
+    },
+    "node_modules/@theory-cloud/tabletheory-ts": {
+      "version": "1.10.1",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v1.10.1/theory-cloud-tabletheory-ts-1.10.1.tgz",
+      "integrity": "sha512-8S5HvnI3AHdMi5aEkoXZNHacO5GN7zfWpYlgfwo6ZMEjQTo/qx1iXWMI6W9vT1E0Ij7Q8RS53lb7VOy7BFHeqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1053.0",
+        "@aws-sdk/client-kms": "^3.1053.0",
+        "@aws-sdk/client-sts": "^3.1053.0",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@types/node": {
@@ -954,6 +1471,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/constructs": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
@@ -1018,6 +1542,30 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/tsx": {
       "version": "4.22.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
@@ -1057,6 +1605,22 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,10 +12,12 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v1.13.2/theory-cloud-apptheory-1.13.2.tgz",
     "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.13.2/theory-cloud-apptheory-cdk-1.13.2.tgz",
     "@types/node": "^24.12.4",
     "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0",
+    "esbuild": "^0.28.1",
     "tsx": "^4.22.3",
     "typescript": "^5.9.3"
   }

--- a/infra/apptheory-ssr-site/src/handler.ts
+++ b/infra/apptheory-ssr-site/src/handler.ts
@@ -1,0 +1,80 @@
+import { createApp, createLambdaFunctionURLStreamingHandler } from '@theory-cloud/apptheory';
+
+import { createFaceApp, type FaceRenderResult } from '../../../ts/dist/index.js';
+import { createAppTheoryFaceHandler } from '../../../ts/dist/apptheory/index.js';
+
+function cleanAssetPrefix(value: string | undefined): string {
+  const cleaned = String(value ?? 'assets')
+    .trim()
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+  return cleaned || 'assets';
+}
+
+function assetPath(fileName: string): string {
+  return `/${cleanAssetPrefix(process.env.APPTHEORY_ASSETS_PREFIX)}/${fileName}`;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function page(body: string, title = 'FaceTheory + AppTheorySsrSite'): FaceRenderResult {
+  return {
+    headers: { 'cache-control': 'private, no-store' },
+    head: {
+      title,
+    },
+    headTags: [
+      { type: 'meta', attrs: { name: 'viewport', content: 'width=device-width,initial-scale=1' } },
+      { type: 'link', attrs: { rel: 'stylesheet', href: assetPath('entry.css') } },
+    ],
+    html: `${body}\n<script type="module" src="${assetPath('entry.js')}"></script>`,
+  };
+}
+
+const faceApp = createFaceApp({
+  faces: [
+    {
+      route: '/',
+      mode: 'ssr',
+      render: () =>
+        page(`
+<main>
+  <h1>FaceTheory Infra Example</h1>
+  <p>This page is rendered by a real FaceTheory Face through AppTheorySsrSite.</p>
+  <p>The CloudFront distribution serves <code>/assets</code> from S3 and routes this SSR document to Lambda.</p>
+</main>
+        `.trim()),
+    },
+    {
+      route: '/{proxy+}',
+      mode: 'ssr',
+      render: (ctx) => ({
+        ...page(`
+<main>
+  <h1>Not Found</h1>
+  <p>No FaceTheory reference route matched <code>${escapeHtml(ctx.request.path)}</code>.</p>
+  <p><a href="/">Back to the reference page</a></p>
+</main>
+        `.trim(), 'FaceTheory Reference Not Found'),
+        status: 404,
+      }),
+    },
+  ],
+});
+
+const app = createApp();
+const faceHandler = createAppTheoryFaceHandler({ app: faceApp });
+
+app.get('/', faceHandler);
+app.get('/{proxy+}', faceHandler);
+app.handle('HEAD', '/', faceHandler);
+app.handle('HEAD', '/{proxy+}', faceHandler);
+
+export const handler = createLambdaFunctionURLStreamingHandler(app);

--- a/infra/apptheory-ssr-site/src/stack.ts
+++ b/infra/apptheory-ssr-site/src/stack.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { CfnOutput, Duration, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
-import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
 import { AppTheorySsrSite } from '@theory-cloud/apptheory-cdk';
@@ -33,41 +33,17 @@ export class FaceTheoryAppTheorySsrSiteStack extends Stack {
       autoDeleteObjects: true,
     });
 
-    const ssrFunction = new lambda.Function(this, 'SsrFunction', {
+    const ssrFunction = new NodejsFunction(this, 'SsrFunction', {
       runtime: lambda.Runtime.NODEJS_20_X,
-      handler: 'index.handler',
+      entry: path.resolve(__dirname, './handler.ts'),
+      handler: 'handler',
       timeout: Duration.seconds(10),
       memorySize: 512,
-      code: lambda.Code.fromInline(`
-exports.handler = awslambda.streamifyResponse(async (event, responseStream, context) => {
-  void event; void context;
-
-  const prefix = String(process.env.APPTHEORY_ASSETS_PREFIX || 'assets').replace(/^\\/+/, '').replace(/\\/+$/, '');
-  const cssHref = '/' + prefix + '/entry.css';
-  const jsSrc = '/' + prefix + '/entry.js';
-
-  const meta = {
-    statusCode: 200,
-    headers: {
-      'content-type': 'text/html; charset=utf-8',
-      'cache-control': 'private, no-store',
-    },
-    cookies: [],
-  };
-
-  const out = awslambda.HttpResponseStream.from(responseStream, meta);
-  out.write('<!doctype html><html lang="en"><head>');
-  out.write('<meta charset="utf-8">');
-  out.write('<meta name="viewport" content="width=device-width,initial-scale=1">');
-  out.write('<title>FaceTheory + AppTheorySsrSite</title>');
-  out.write('<link rel="stylesheet" href="' + cssHref + '">');
-  out.write('</head><body>');
-  out.write('<main><h1>FaceTheory Infra Example</h1><p>If you can see styled text, /assets is working.</p></main>');
-  out.write('<script type="module" src="' + jsSrc + '"></script>');
-  out.write('</body></html>');
-  out.end();
-});
-      `.trim()),
+      bundling: {
+        // Keep stack templates stable; minification changes hashes frequently.
+        minify: false,
+        sourceMap: false,
+      },
     });
 
     // Deploy assets with explicit cache semantics.
@@ -119,10 +95,6 @@ exports.handler = awslambda.streamifyResponse(async (event, responseStream, cont
       removalPolicy: RemovalPolicy.DESTROY,
       autoDeleteObjects: true,
     });
-
-    // Make the static behavior cache policy visible and stable in the template.
-    // This also documents the expected behavior for /assets and other static patterns.
-    void cloudfront.CachePolicy.CACHING_OPTIMIZED;
 
     new CfnOutput(this, 'CloudFrontDomainName', {
       value: this.site.distribution.distributionDomainName,

--- a/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
+++ b/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
@@ -328,7 +328,10 @@
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "ZipFile": "exports.handler = awslambda.streamifyResponse(async (event, responseStream, context) => {\n  void event; void context;\n\n  const prefix = String(process.env.APPTHEORY_ASSETS_PREFIX || 'assets').replace(/^\\/+/, '').replace(/\\/+$/, '');\n  const cssHref = '/' + prefix + '/entry.css';\n  const jsSrc = '/' + prefix + '/entry.js';\n\n  const meta = {\n    statusCode: 200,\n    headers: {\n      'content-type': 'text/html; charset=utf-8',\n      'cache-control': 'private, no-store',\n    },\n    cookies: [],\n  };\n\n  const out = awslambda.HttpResponseStream.from(responseStream, meta);\n  out.write('<!doctype html><html lang=\"en\"><head>');\n  out.write('<meta charset=\"utf-8\">');\n  out.write('<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">');\n  out.write('<title>FaceTheory + AppTheorySsrSite</title>');\n  out.write('<link rel=\"stylesheet\" href=\"' + cssHref + '\">');\n  out.write('</head><body>');\n  out.write('<main><h1>FaceTheory Infra Example</h1><p>If you can see styled text, /assets is working.</p></main>');\n  out.write('<script type=\"module\" src=\"' + jsSrc + '\"></script>');\n  out.write('</body></html>');\n  out.end();\n});"
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
+          },
+          "S3Key": "21a4833564bd2a93a805c962fb46e0ab0214692d311bae26be0f8319be4d7d81.zip"
         },
         "Environment": {
           "Variables": {

--- a/infra/apptheory-ssr-site/test/unit/ssr-site-stack.test.ts
+++ b/infra/apptheory-ssr-site/test/unit/ssr-site-stack.test.ts
@@ -1,12 +1,16 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 
 import { FaceTheoryAppTheorySsrSiteStack } from '../../src/stack.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 interface CacheBehaviorTemplate {
   readonly PathPattern?: string;
@@ -59,11 +63,49 @@ function findOrigin(distribution: DistributionTemplate, behavior: CacheBehaviorT
   return origin;
 }
 
+function buildFaceTheoryDist(): void {
+  const repoRoot = path.resolve(__dirname, '../../../..');
+  execFileSync('npm', ['--prefix', path.resolve(repoRoot, 'ts'), 'run', 'build'], {
+    stdio: 'inherit',
+  });
+}
+
+function findSsrFunction(template: Record<string, unknown>): {
+  readonly Properties?: { readonly Code?: Record<string, unknown>; readonly Handler?: string };
+} {
+  const resources = template.Resources as
+    | Record<string, { Type?: string; Properties?: { Code?: Record<string, unknown>; Handler?: string } }>
+    | undefined;
+  assert.ok(resources, 'template should include resources');
+
+  const entry = Object.entries(resources).find(
+    ([logicalId, resource]) =>
+      logicalId.includes('SsrFunction') && resource.Type === 'AWS::Lambda::Function',
+  );
+  assert.ok(entry, 'template should include the reference SSR Lambda function');
+  return entry[1];
+}
+
 test('H2: AppTheorySsrSite stack synth is snapshotted', async () => {
+  // NodejsFunction bundles the SSR handler, which imports FaceTheory from ts/dist.
+  // Ensure dist exists so synth is deterministic and succeeds in clean checkouts.
+  buildFaceTheoryDist();
+
+  const handlerSource = await readFile(path.resolve(__dirname, '../../src/handler.ts'), 'utf8');
+  assert.match(handlerSource, /createFaceApp/, 'SSR reference handler must build a real FaceTheory app');
+  assert.match(
+    handlerSource,
+    /createAppTheoryFaceHandler/,
+    'SSR reference handler must cross the FaceTheory/AppTheory adapter boundary',
+  );
+
   const app = new App();
   const stack = new FaceTheoryAppTheorySsrSiteStack(app, 'FaceTheoryAppTheorySsrSite');
 
   const template = Template.fromStack(stack).toJSON();
+  const ssrFunction = findSsrFunction(template);
+  assert.ok(!ssrFunction.Properties?.Code?.ZipFile, 'SSR Lambda must not be an inline HTML string');
+
   const distribution = findDistribution(template);
   const ssgSidecarOrigin = findOrigin(distribution, findBehavior(distribution, '_facetheory/data/*'));
   const ssrSidecarOrigin = findOrigin(distribution, findBehavior(distribution, '_facetheory/ssr-data/*'));


### PR DESCRIPTION
## Milestone
M12 deploy-convergence — complete THE-2487, THE-2488, THE-2489 only.

## Linear
Refs THE-2487
Refs THE-2488
Refs THE-2489

## Summary
- Migrates `infra/apptheory-ssg-isr-site` to `AppTheorySsrSiteMode.SSG_ISR` while preserving S3-primary HTML failover, request-id propagation, original-URI routing, SSG sidecar routing, SSR sidecar routing, and TableTheory-backed ISR env wiring.
- Replaces the SSR reference stack's inline HTML Lambda with a bundled real FaceTheory app using `createFaceApp(...)` + `createAppTheoryFaceHandler({ app })`.
- Rewrites deploy docs around the paved `AppTheorySsrSite` path, including scaffold → build → props (domain, WAF, ISR wiring) → deploy → curl, with explicit no-live-proof language.

## Render modes and adapters affected
- Render modes: SSR, SSG, ISR deployment topology/docs.
- Adapters: no adapter implementation changes.

## Determinism / security impact
- Preserves FaceTheory rendering through the existing FaceApp/head primitives.
- No real AWS deploy, no cloud mutation, no credentials, and no live deployment proof claimed.

## Validation
- `git diff --check` — passed.
- `git diff --check origin/theorymcp/theorycloud/facetheory/product-strengthening-plans-2026-07-02..HEAD` — passed.
- `scripts/verify-version-alignment.sh` — `version-alignment: PASS (3.8.1)`.
- `cd infra/apptheory-ssg-isr-site && npm ci && npm test` — passed, 1 test.
- `cd infra/apptheory-ssr-site && npm ci && npm test` — passed, 1 test.
- `cd infra/apptheory-ssg-isr-site && npx tsc -p tsconfig.json --noEmit` — passed.
- `cd infra/apptheory-ssr-site && npx tsc -p tsconfig.json --noEmit` — passed.
- `cd ts && npm run check` — passed, 649 tests / 648 pass / 1 skipped / 0 fail.
- `cd docs && BUNDLE_PATH=/tmp/facetheory-bundle BUNDLE_APP_CONFIG=/tmp/facetheory-bundle-config JEKYLL_ENV=production bundle exec jekyll build --source . --destination ./_site --baseurl ""` using `/home/aron/.local/share/gem/ruby/3.2.0/bin/bundle` — passed; custom-domain root-path grep passed; generated `_site`/`.jekyll-cache` removed.
- Relative markdown link check over changed docs — passed.

## Cross-repo coordination / follow-up
- AppTheory follow-up remains: expose per-BucketDeployment `distributionPaths` invalidation controls for the assets/manifest/SSG upload split. Documented in FaceTheory deploy docs; no AppTheory repo edits made.
