### PR TITLE
test(examples): import M15 smokes through public surface

### DIFF
--- a/ts/test/unit/examples-spa-navigation.test.ts
+++ b/ts/test/unit/examples-spa-navigation.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import { JSDOM } from 'jsdom';
 
-import { DEFAULT_FACE_VIEW_SELECTOR } from '../../src/spa.js';
+import { DEFAULT_FACE_VIEW_SELECTOR } from '@theory-cloud/facetheory/spa';
 
 import { createSpaNavigationExampleApp } from '../../examples/spa-navigation/server.js';
 

--- a/ts/test/unit/examples-strict-csp-react.test.ts
+++ b/ts/test/unit/examples-strict-csp-react.test.ts
@@ -9,7 +9,7 @@ import { promisify } from 'node:util';
 
 import { JSDOM } from 'jsdom';
 
-import type { ViteManifest } from '../../src/vite.js';
+import type { ViteManifest } from '@theory-cloud/facetheory';
 import { assertStrictCspDocument } from '../helpers/strict-csp.js';
 
 const execFileAsync = promisify(execFile);

--- a/ts/test/unit/examples-strict-csp-vue.test.ts
+++ b/ts/test/unit/examples-strict-csp-vue.test.ts
@@ -9,7 +9,7 @@ import { promisify } from 'node:util';
 
 import { JSDOM } from 'jsdom';
 
-import type { ViteManifest } from '../../src/vite.js';
+import type { ViteManifest } from '@theory-cloud/facetheory';
 import { assertStrictCspDocument } from '../helpers/strict-csp.js';
 
 const execFileAsync = promisify(execFile);


### PR DESCRIPTION
## Summary
- Moves the M15 strict-CSP React/Vue smoke test `ViteManifest` imports to the public root package surface.
- Moves the SPA navigation smoke test `DEFAULT_FACE_VIEW_SELECTOR` import to the public `/spa` package surface.
- Keeps the change to package-boundary test hygiene only; no runtime, example, docs, release, cloud, or sibling-repo changes.

## Validation
- `cd ts && npm run build && node --import tsx --test --test-concurrency=1 test/unit/examples-strict-csp-react.test.ts test/unit/examples-strict-csp-vue.test.ts test/unit/examples-spa-navigation.test.ts` — pass (3/3)
- `cd ts && npm run test:unit` — pass (673 tests, 672 pass, 1 pre-existing skip)
- `cd ts && npm run check` — pass (lint, typecheck/build, example README verification, unit suite: 673 tests, 672 pass, 1 pre-existing skip)
- `git diff --check` — clean

Closes THE-2541