### PR TITLE
Promote staging to premain

### DIFF
--- a/ts/test/unit/create-cli.test.ts
+++ b/ts/test/unit/create-cli.test.ts
@@ -45,6 +45,15 @@ async function readGeneratedJson<T>(
   ) as T;
 }
 
+async function currentFaceTheoryVersion(): Promise<string> {
+  const packageJson = await readGeneratedJson<{ version: string }>(
+    packageRoot,
+    'package.json',
+  );
+  assert.match(packageJson.version, /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/);
+  return packageJson.version;
+}
+
 async function symlinkPackage(
   appDir: string,
   name: string,
@@ -194,10 +203,12 @@ test('facetheory create emits a React starter that typechecks', async () => {
       devDependencies: Record<string, string>;
       overrides: Record<string, Record<string, string>>;
     }>(appDir, 'package.json');
+    const faceTheoryVersion = await currentFaceTheoryVersion();
+    const expectedFaceTheoryTarball = `https://github.com/theory-cloud/FaceTheory/releases/download/v${faceTheoryVersion}/theory-cloud-facetheory-${faceTheoryVersion}.tgz`;
 
-    assert.match(
+    assert.equal(
       packageJson.dependencies['@theory-cloud/facetheory'] ?? '',
-      /^https:\/\/github\.com\/theory-cloud\/FaceTheory\/releases\/download\/v3\.8\.1\/theory-cloud-facetheory-3\.8\.1\.tgz$/,
+      expectedFaceTheoryTarball,
     );
     assert.equal(packageJson.dependencies.react, '^19.2.6');
     assert.equal(packageJson.dependencies['react-dom'], '^19.2.6');
@@ -223,7 +234,9 @@ test('facetheory create emits a React starter that typechecks', async () => {
 
     const readme = await readFile(path.resolve(appDir, 'README.md'), 'utf8');
     assert.match(readme, /npm install --save-exact/);
-    assert.match(readme, /theory-cloud-facetheory-3\.8\.1\.tgz/);
+    assert.ok(
+      readme.includes(`theory-cloud-facetheory-${faceTheoryVersion}.tgz`),
+    );
 
     await linkTypecheckDependencies(appDir);
     await runGeneratedTypecheck(appDir);


### PR DESCRIPTION
## Summary
- Promote `staging` into `premain` after the prerelease CI fix merged through staging.
- Carries PR #382 (`fix(test): accept prerelease create tarballs`) so the premain Release Please RC PR can validate `4.0.0-rc` tarball URLs without stale `3.8.1` expectations.

## Validation
- Fetched and compared `origin/main`, `origin/premain`, and `origin/staging`.
- `origin/main` is contained in both `origin/staging` and `origin/premain`.
- `origin/staging...origin/premain` is `2 ahead / 1 behind`; merge base is the prior staging promotion commit `40dfd53`.
- `./scripts/verify-version-alignment.sh` on `origin/staging`: PASS (`3.8.1`).
- `scripts/verify-release-readiness.sh origin/premain origin/staging prerelease`: OK.
- `scripts/verify-release-train-promotion.sh --base premain --head staging --head-sha $(git rev-parse origin/staging) ...`: PASS.

## Follow-up
After this lands, Release Please should update/rerun PR #381 (`chore(premain): release 4.0.0-rc`) against a premain that includes the test fix.
