### PR TITLE
fix(head): origin-derivation residual review lows (THE-2806)

### DIFF
--- a/docs/features/head.md
+++ b/docs/features/head.md
@@ -55,14 +55,25 @@ The AppTheory-specific headers use the first comma-delimited value because the
 reference edge owns and emits a singleton viewer value. The generic
 `x-forwarded-*` fallback uses the rightmost comma-delimited value, assuming a
 trusted proxy strips or overwrites client values or appends its authoritative
-value at the right. **Do not treat generic forwarded headers from a direct or
-untrusted client as a security input.** Configure `canonicalOrigin` instead.
+value at the right. Repeated header array elements are flattened with the same
+comma-join semantics as Lambda URL events before that rightmost value is
+selected. **Do not treat generic forwarded headers from a direct or untrusted
+client as a security input.** Configure `canonicalOrigin` instead.
 
 The selected source fails closed: malformed protocols, userinfo, paths,
 queries, fragments, or incomplete header pairs produce no allowed origin; a
 lower-precedence header cannot rescue a malformed AppTheory-specific source.
 Absolute same-origin links then remain rejected rather than being validated
 against a doubtful origin. Relative head URLs are unchanged.
+
+FaceTheory normalizes one trailing DNS root dot from the selected host before
+strict same-origin comparison, so `real.example.` and `real.example` derive the
+same `https://real.example` origin. This is an explicit availability decision:
+the names are DNS-equivalent, and retaining the dot let a valid dotless
+canonical URL self-DoS with a 500. Before normalization this was not a
+shared-cache poisoning path because the original-host headers participate in
+the reference ISR cache key and FaceTheory rejects 5xx regeneration results
+before storing them.
 
 SSG has no viewer request from which to derive an origin. Pass the same option
 to `buildSsgSite({ canonicalOrigin })` when an SSG Face emits an absolute

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
 import { utf8 } from './bytes.js';
-import { renderFaceHead } from './head.js';
+import {
+  renderFaceHead,
+  StrictCspAllowedOriginRequiredError,
+} from './head.js';
 import {
   renderHTMLDocument,
   streamHTMLDocument,
@@ -726,11 +729,18 @@ function normalizeRequest(req: FaceRequest): Required<FaceRequest> {
   };
 }
 
+interface RequestAllowedOrigin {
+  origin?: string;
+  missingHint: string;
+}
+
 function allowedOriginForRequest(
   req: Readonly<Required<FaceRequest>>,
   canonicalOrigin: string | undefined,
-): string | undefined {
-  if (canonicalOrigin !== undefined) return canonicalOrigin;
+): RequestAllowedOrigin {
+  if (canonicalOrigin !== undefined) {
+    return { origin: canonicalOrigin, missingHint: '' };
+  }
 
   const cloudFrontProto = firstCommaSeparatedHeaderValue(
     req,
@@ -741,7 +751,17 @@ function allowedOriginForRequest(
     'x-facetheory-original-host',
   );
   if (faceTheoryOriginalHost) {
-    return httpOriginFromParts(cloudFrontProto, faceTheoryOriginalHost);
+    const origin = httpOriginFromParts(
+      cloudFrontProto,
+      faceTheoryOriginalHost,
+    );
+    return origin
+      ? { origin, missingHint: '' }
+      : {
+          missingHint: cloudFrontProto
+            ? 'The trusted x-facetheory-original-host and cloudfront-forwarded-proto headers did not form a valid http(s) origin; configure canonicalOrigin or correct the trusted header pair.'
+            : 'The trusted x-facetheory-original-host header is present, but cloudfront-forwarded-proto is missing; configure canonicalOrigin or restore the complete trusted header pair.',
+        };
   }
 
   const appTheoryOriginalHost = firstCommaSeparatedHeaderValue(
@@ -749,7 +769,14 @@ function allowedOriginForRequest(
     'x-apptheory-original-host',
   );
   if (appTheoryOriginalHost) {
-    return httpOriginFromParts(cloudFrontProto, appTheoryOriginalHost);
+    const origin = httpOriginFromParts(cloudFrontProto, appTheoryOriginalHost);
+    return origin
+      ? { origin, missingHint: '' }
+      : {
+          missingHint: cloudFrontProto
+            ? 'The trusted x-apptheory-original-host and cloudfront-forwarded-proto headers did not form a valid http(s) origin; configure canonicalOrigin or correct the trusted header pair.'
+            : 'The trusted x-apptheory-original-host header is present, but cloudfront-forwarded-proto is missing; configure canonicalOrigin or restore the complete trusted header pair.',
+        };
   }
 
   // Generic forwarding headers are safe only when a trusted proxy strips or
@@ -765,8 +792,13 @@ function allowedOriginForRequest(
     'x-forwarded-host',
   );
   const host = forwardedHost || String(req.headers.host?.[0] ?? '').trim();
-
-  return httpOriginFromParts(forwardedProto, host);
+  const origin = httpOriginFromParts(forwardedProto, host);
+  return origin
+    ? { origin, missingHint: '' }
+    : {
+        missingHint:
+          'No trusted request origin could be derived; configure canonicalOrigin or provide a complete trusted host/protocol header pair.',
+      };
 }
 
 function firstCommaSeparatedHeaderValue(
@@ -780,7 +812,8 @@ function rightmostCommaSeparatedHeaderValue(
   req: Readonly<Required<FaceRequest>>,
   name: string,
 ): string {
-  return String(req.headers[name]?.[0] ?? '').split(',').at(-1)?.trim() ?? '';
+  const flattened = (req.headers[name] ?? []).map(String).join(',');
+  return flattened.split(',').at(-1)?.trim() ?? '';
 }
 
 function normalizeCanonicalOrigin(
@@ -821,6 +854,9 @@ function httpOriginFromUrl(value: string): string | undefined {
       url.hash
     ) {
       return undefined;
+    }
+    if (url.hostname.endsWith('.') && url.hostname !== '.') {
+      url.hostname = url.hostname.slice(0, -1);
     }
     return url.origin;
   } catch {
@@ -1117,10 +1153,25 @@ async function toHTTPResponse(
   applyStrictCspResponseHeader(headers, out.csp, req.cspNonce);
 
   const allowedOrigin = allowedOriginForRequest(req, canonicalOrigin);
-  const head = renderFaceHead(out, {
-    cspNonce: req.cspNonce,
-    ...(allowedOrigin ? { allowedOrigin } : {}),
-  });
+  let head: string;
+  try {
+    head = renderFaceHead(out, {
+      cspNonce: req.cspNonce,
+      ...(allowedOrigin.origin
+        ? { allowedOrigin: allowedOrigin.origin }
+        : {}),
+    });
+  } catch (error) {
+    if (
+      error instanceof StrictCspAllowedOriginRequiredError &&
+      !allowedOrigin.origin
+    ) {
+      throw new StrictCspAllowedOriginRequiredError(
+        `${error.message}. ${allowedOrigin.missingHint}`,
+      );
+    }
+    throw error;
+  }
   const documentParts = withDocumentShell(out);
 
   if (typeof out.html === 'string') {

--- a/ts/src/head.ts
+++ b/ts/src/head.ts
@@ -160,6 +160,13 @@ function isAbsoluteOrProtocolRelativeUrl(value: string): boolean {
 
 const STRICT_CSP_SAME_ORIGIN_SENTINEL = 'https://facetheory.invalid';
 
+export class StrictCspAllowedOriginRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StrictCspAllowedOriginRequiredError';
+  }
+}
+
 function assertStrictSameOriginUrl(
   value: string,
   label: string,
@@ -194,7 +201,7 @@ function assertStrictSameOriginUrl(
       return;
     }
 
-    throw new Error(
+    throw new StrictCspAllowedOriginRequiredError(
       `FaceTheory strict CSP ${label} URL must be same-origin or relative: ${trimmed}`,
     );
   }

--- a/ts/src/ssg.ts
+++ b/ts/src/ssg.ts
@@ -170,6 +170,7 @@ export async function buildSsgSite(
   await mkdir(outDir, { recursive: true });
 
   const strictHydrationSidecars = new Map<string, SsgHydrationSidecar>();
+  const renderErrorsByPath = new Map<string, unknown>();
   const app = createFaceApp({
     faces: withSsgStrictHydrationSidecars(
       options.faces,
@@ -178,6 +179,13 @@ export async function buildSsgSite(
     ...(options.canonicalOrigin !== undefined
       ? { canonicalOrigin: options.canonicalOrigin }
       : {}),
+    observability: {
+      onError: (error, context) => {
+        if (context.mode === 'ssg' && context.phase === 'render') {
+          renderErrorsByPath.set(context.path, error);
+        }
+      },
+    },
   });
   const plannedPages = await planSsgPages(options.faces);
 
@@ -205,6 +213,11 @@ export async function buildSsgSite(
           ...(previousEntry !== undefined ? { previousEntry } : {}),
           allowNetwork,
           hasFetchOverride: fetchImpl !== undefined,
+          takeRenderError: () => {
+            const error = renderErrorsByPath.get(page.path);
+            renderErrorsByPath.delete(page.path);
+            return error;
+          },
         });
       }),
   );
@@ -350,6 +363,7 @@ async function buildSsgPage(options: {
   previousEntry?: SsgPageEntry;
   allowNetwork: boolean;
   hasFetchOverride: boolean;
+  takeRenderError: () => unknown;
 }): Promise<SsgPageBuildOutcome> {
   const {
     app,
@@ -362,11 +376,19 @@ async function buildSsgPage(options: {
     previousEntry,
     allowNetwork,
     hasFetchOverride,
+    takeRenderError,
   } = options;
 
   try {
     const response = await app.handle({ method: 'GET', path: page.path });
     if (response.status >= 500) {
+      const renderError = takeRenderError();
+      if (renderError !== undefined) {
+        throw new SsgRouteBuildError(
+          `SSG route "${page.path}" failed during render: ${errorMessage(renderError)}`,
+          response.status,
+        );
+      }
       const networkHint =
         !allowNetwork && !hasFetchOverride
           ? ' Network access is disabled by default during SSG; mock fetch or set allowNetwork:true.'

--- a/ts/test/unit/app.test.ts
+++ b/ts/test/unit/app.test.ts
@@ -263,6 +263,41 @@ test('FaceApp: FaceTheory original host wins over AppTheory and spoofed generic 
   );
 });
 
+test('FaceApp: normalizes a trailing DNS root dot in the trusted original host', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/articles/trailing-dot',
+        mode: 'ssr',
+        render: () => ({
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          headTags: [
+            {
+              type: 'link',
+              attrs: {
+                rel: 'canonical',
+                href: 'https://real.example/articles/trailing-dot',
+              },
+            },
+          ],
+          html: '<main>Trailing DNS root dot</main>',
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/articles/trailing-dot',
+    headers: {
+      'cloudfront-forwarded-proto': ['https'],
+      'x-facetheory-original-host': ['real.example.'],
+    },
+  });
+
+  assert.equal(resp.status, 200);
+});
+
 test('FaceApp: AppTheory path rejects a spoofed generic origin', async () => {
   const app = createFaceApp({
     faces: [
@@ -373,6 +408,42 @@ test('FaceApp: trusted generic proxy uses rightmost forwarded values', async () 
   assert.equal(resp.status, 200);
 });
 
+test('FaceApp: trusted generic proxy uses rightmost values across header array elements', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/articles/generic-proxy-array',
+        mode: 'ssr',
+        render: () => ({
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          headTags: [
+            {
+              type: 'link',
+              attrs: {
+                rel: 'canonical',
+                href: 'https://trusted-proxy.example/articles/generic-proxy-array',
+              },
+            },
+          ],
+          html: '<main>Generic trusted proxy array</main>',
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/articles/generic-proxy-array',
+    headers: {
+      host: ['abc123xyz.lambda-url.us-east-1.on.aws'],
+      'x-forwarded-host': ['attacker.example', 'trusted-proxy.example'],
+      'x-forwarded-proto': ['http', 'https'],
+    },
+  });
+
+  assert.equal(resp.status, 200);
+});
+
 test('FaceApp: canonicalOrigin overrides all request-derived headers', async () => {
   const app = createFaceApp({
     canonicalOrigin: new URL('https://configured.example/'),
@@ -469,6 +540,57 @@ test('FaceApp: malformed AppTheory origin headers fail closed without generic fa
       assert.equal(resp.status, 500);
     });
   }
+});
+
+test('FaceApp: missing CloudFront protocol reports the trusted header-pair cause', async () => {
+  let observedError: unknown;
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/articles/missing-cloudfront-proto',
+        mode: 'ssr',
+        render: () => ({
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          headTags: [
+            {
+              type: 'link',
+              attrs: {
+                rel: 'canonical',
+                href: 'https://reader.example/articles/missing-cloudfront-proto',
+              },
+            },
+          ],
+          html: '<main>Missing CloudFront protocol</main>',
+        }),
+      },
+    ],
+    observability: {
+      onError: (error) => {
+        observedError = error;
+      },
+    },
+  });
+
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/articles/missing-cloudfront-proto',
+    headers: {
+      'x-facetheory-original-host': ['reader.example'],
+      'x-forwarded-host': ['reader.example'],
+      'x-forwarded-proto': ['https'],
+    },
+  });
+
+  assert.equal(resp.status, 500);
+  const message = observedError instanceof Error ? observedError.message : '';
+  assert.match(
+    message,
+    /x-facetheory-original-host header is present, but cloudfront-forwarded-proto is missing/,
+  );
+  assert.match(
+    message,
+    /configure canonicalOrigin or restore the complete trusted header pair/,
+  );
 });
 
 test('FaceApp: canonicalOrigin rejects non-origin URL components', () => {

--- a/ts/test/unit/ssg.test.ts
+++ b/ts/test/unit/ssg.test.ts
@@ -261,6 +261,52 @@ test('ssg: canonicalOrigin validates absolute canonical links during prerender',
   }
 });
 
+test('ssg: missing canonicalOrigin identifies the prerender origin cause', async () => {
+  const tempRoot = await mkdtemp(
+    path.join(tmpdir(), 'facetheory-ssg-missing-canonical-origin-'),
+  );
+  const outDir = path.resolve(tempRoot, 'out');
+
+  try {
+    await assert.rejects(
+      buildSsgSite({
+        faces: [
+          {
+            route: '/',
+            mode: 'ssg',
+            render: () => ({
+              csp: {
+                inlineScripts: false,
+                inlineStyles: false,
+                rawHead: false,
+              },
+              headTags: [
+                {
+                  type: 'link',
+                  attrs: {
+                    rel: 'canonical',
+                    href: 'https://static.example/',
+                  },
+                },
+              ],
+              html: '<main>Static canonical</main>',
+            }),
+          },
+        ],
+        outDir,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof SsgBuildFailedError);
+        assert.match(error.message, /configure canonicalOrigin/);
+        assert.doesNotMatch(error.message, /Network access is disabled/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('ssg: incremental builds skip unchanged route outputs', async () => {
   const tempRoot = await mkdtemp(path.join(tmpdir(), 'facetheory-ssg-incremental-'));
   const outDir = path.resolve(tempRoot, 'out');


### PR DESCRIPTION
## Summary
- flatten every repeated/comma-delimited generic forwarded-header value before selecting the trusted rightmost origin component
- normalize one trailing DNS root dot before strict same-origin comparison
- surface origin-derivation causes for incomplete trusted CloudFront header pairs and preserve the original SSG render error so a missing `canonicalOrigin` is diagnosed directly
- add regressions for multi-element forwarded-header arrays, trailing-dot normalization, missing CloudFront protocol diagnostics, and the missing-`canonicalOrigin` SSG path

## Trailing-dot decision
Normalize one trailing DNS root dot. `real.example.` and `real.example` are DNS-equivalent, so retaining the dot only allowed a valid dotless canonical URL to self-DoS with a 500. The prior behavior was not a shared-cache poisoning path: the original-host headers participate in the reference ISR cache key, and FaceTheory rejects 5xx regeneration results before storing them. This decision and rationale are documented in `docs/features/head.md`.

## Validation
- `NPM_CONFIG_ALLOW_REMOTE=all npm ci` — PASS (517 packages installed, 0 vulnerabilities)
- focused app/head/SSG tests — PASS (82/82)
- `NPM_CONFIG_ALLOW_REMOTE=all npm run check` — PASS (lint, Svelte runes gates, typecheck/build, 26 example README checks, 696 tests: 695 passed, 1 expected skip, 0 failed)
- `NPM_CONFIG_ALLOW_REMOTE=all npm test` — PASS (696 tests: 695 passed, 1 expected skip, 0 failed)
- `scripts/verify-version-alignment.sh` — PASS (4.0.4; stable and premain manifests aligned)
- `git diff --check` — PASS
