### PR TITLE
chore: commit allow-remote=root npmrc for npm 12 (THE-2805)

### DIFF
--- a/infra/apptheory-ssg-isr-site/.npmrc
+++ b/infra/apptheory-ssg-isr-site/.npmrc
@@ -1,0 +1,4 @@
+# npm 12 defaults allow-remote=none. This package intentionally consumes the
+# pinned AppTheory and TableTheory release tarballs. Keep the narrow root
+# policy: npm may fetch only URL dependencies declared by this package.json.
+allow-remote=root

--- a/infra/apptheory-ssg-isr-site/README.md
+++ b/infra/apptheory-ssg-isr-site/README.md
@@ -35,6 +35,12 @@ npm test
 npm run synth
 ```
 
+`./.npmrc` sets npm's `allow-remote=root` policy for npm 12 compatibility
+(npm 12 defaults to `allow-remote=none` and refuses the pinned
+AppTheory/TableTheory release-tarball dependencies with EALLOWREMOTE).
+That is intentionally narrower than `all`: only the URL dependencies
+declared by this package's `package.json` may be fetched.
+
 ## Deployment Notes
 
 - Use the canonical AWS deployment and operations docs for routing, cache, and smoke-test expectations.

--- a/infra/apptheory-ssr-site/.npmrc
+++ b/infra/apptheory-ssr-site/.npmrc
@@ -1,0 +1,4 @@
+# npm 12 defaults allow-remote=none. This package intentionally consumes the
+# pinned AppTheory and TableTheory release tarballs. Keep the narrow root
+# policy: npm may fetch only URL dependencies declared by this package.json.
+allow-remote=root

--- a/infra/apptheory-ssr-site/README.md
+++ b/infra/apptheory-ssr-site/README.md
@@ -18,6 +18,12 @@ npm ci
 npm test
 ```
 
+`./.npmrc` sets npm's `allow-remote=root` policy for npm 12 compatibility
+(npm 12 defaults to `allow-remote=none` and refuses the pinned
+AppTheory/TableTheory release-tarball dependencies with EALLOWREMOTE).
+That is intentionally narrower than `all`: only the URL dependencies
+declared by this package's `package.json` may be fetched.
+
 Update the template snapshot:
 
 ```bash

--- a/ts/.npmrc
+++ b/ts/.npmrc
@@ -1,0 +1,4 @@
+# npm 12 defaults allow-remote=none. This package intentionally consumes the
+# pinned AppTheory and TableTheory release tarballs. Keep the narrow root
+# policy: npm may fetch only URL dependencies declared by ts/package.json.
+allow-remote=root

--- a/ts/README.md
+++ b/ts/README.md
@@ -17,6 +17,12 @@ Install the peers that match your adapter surface:
 - Vue: `npm install vue @vue/server-renderer`
 - Svelte: `npm install svelte@^5.55.7`
 
+Contributors working in this repo: `ts/.npmrc` sets npm's `allow-remote=root`
+policy for npm 12 compatibility (npm 12 defaults to `allow-remote=none` and
+refuses the pinned AppTheory/TableTheory release-tarball dependencies with
+EALLOWREMOTE). That is intentionally narrower than `all`: only the URL
+dependencies declared by `ts/package.json` may be fetched.
+
 ## Packaging Posture
 
 FaceTheory is ESM-only. Import it from ESM Lambda handlers, Vite SSR entries, or bundlers; CommonJS `require()` callers should expect `ERR_REQUIRE_ESM` and should migrate to ESM or use dynamic `import()` at the boundary.


### PR DESCRIPTION
Adds `.npmrc` with `allow-remote=root` (narrower than `all`: only root-declared URL deps) to the three packages that pin GitHub release tarballs: `ts`, `infra/apptheory-ssr-site`, `infra/apptheory-ssg-isr-site`. npm 12 defaults to `allow-remote=none` and refuses these pins with EALLOWREMOTE. README notes added in all three. Verified locally on npm 12.0.1: `npm ci` succeeds in all three packages with no env override. This completes the fleet-wide coverage recorded on THE-2805.