### PR TITLE
fix(head): flatten host fallback + symmetric trailing-dot normalization (THE-2815)

### DIFF
--- a/docs/features/head.md
+++ b/docs/features/head.md
@@ -53,12 +53,13 @@ in this precedence order:
 
 The AppTheory-specific headers use the first comma-delimited value because the
 reference edge owns and emits a singleton viewer value. The generic
-`x-forwarded-*` fallback uses the rightmost comma-delimited value, assuming a
-trusted proxy strips or overwrites client values or appends its authoritative
-value at the right. Repeated header array elements are flattened with the same
-comma-join semantics as Lambda URL events before that rightmost value is
-selected. **Do not treat generic forwarded headers from a direct or untrusted
-client as a security input.** Configure `canonicalOrigin` instead.
+`x-forwarded-*`/`host` fallback uses the rightmost comma-delimited value,
+assuming a trusted proxy strips or overwrites client values or appends its
+authoritative value at the right. Repeated header array elements, including
+`host`, are flattened with the same comma-join semantics as Lambda URL events
+before that rightmost value is selected. **Do not treat generic forwarded
+headers from a direct or untrusted client as a security input.** Configure
+`canonicalOrigin` instead.
 
 The selected source fails closed: malformed protocols, userinfo, paths,
 queries, fragments, or incomplete header pairs produce no allowed origin; a
@@ -66,14 +67,18 @@ lower-precedence header cannot rescue a malformed AppTheory-specific source.
 Absolute same-origin links then remain rejected rather than being validated
 against a doubtful origin. Relative head URLs are unchanged.
 
-FaceTheory normalizes one trailing DNS root dot from the selected host before
-strict same-origin comparison, so `real.example.` and `real.example` derive the
-same `https://real.example` origin. This is an explicit availability decision:
-the names are DNS-equivalent, and retaining the dot let a valid dotless
-canonical URL self-DoS with a 500. Before normalization this was not a
-shared-cache poisoning path because the original-host headers participate in
-the reference ISR cache key and FaceTheory rejects 5xx regeneration results
-before storing them.
+FaceTheory normalizes exactly one trailing DNS root dot from both the selected
+host and the compared head URL hostname before strict same-origin comparison,
+so dotted and dotless forms of `real.example` resolve symmetrically. A lone
+root label or multiple trailing dots remain invalid. This is an explicit
+availability decision: the valid dotted and dotless names are DNS-equivalent,
+and retaining the dot let a canonical URL self-DoS with a 500. Before
+normalization, this was not a shared-cache poisoning path in the reference
+deployment because the
+original-host headers participate in the reference CloudFront HTML cache
+policy's cache key and FaceTheory rejects 5xx regeneration results before
+storing them. This is the CloudFront cache key, not FaceTheory's
+`defaultIsrCacheKey`, which does not include original-host headers.
 
 SSG has no viewer request from which to derive an origin. Pass the same option
 to `buildSsgSite({ canonicalOrigin })` when an SSG Face emits an absolute

--- a/ts/src/app.ts
+++ b/ts/src/app.ts
@@ -27,6 +27,7 @@ import {
   type FaceRequestCompletedLogRecord,
   type FaceStreamErrorLogRecord,
 } from './ops.js';
+import { normalizeTrailingDnsRootDotHostname } from './origin.js';
 import {
   buildStrictCspHeader,
   requiresStrictCspDocumentValidation,
@@ -791,7 +792,8 @@ function allowedOriginForRequest(
     req,
     'x-forwarded-host',
   );
-  const host = forwardedHost || String(req.headers.host?.[0] ?? '').trim();
+  const host =
+    forwardedHost || rightmostCommaSeparatedHeaderValue(req, 'host');
   const origin = httpOriginFromParts(forwardedProto, host);
   return origin
     ? { origin, missingHint: '' }
@@ -855,9 +857,7 @@ function httpOriginFromUrl(value: string): string | undefined {
     ) {
       return undefined;
     }
-    if (url.hostname.endsWith('.') && url.hostname !== '.') {
-      url.hostname = url.hostname.slice(0, -1);
-    }
+    if (!normalizeTrailingDnsRootDotHostname(url)) return undefined;
     return url.origin;
   } catch {
     return undefined;

--- a/ts/src/head.ts
+++ b/ts/src/head.ts
@@ -1,4 +1,5 @@
 import { escapeHTML, renderAttributes, safeJson } from './html.js';
+import { normalizeTrailingDnsRootDotHostname } from './origin.js';
 import type {
   FaceAttributes,
   FaceCspPolicy,
@@ -191,6 +192,10 @@ function assertStrictSameOriginUrl(
     throw new Error(
       `FaceTheory strict CSP ${label} URL must be http(s) or same-origin: ${trimmed}`,
     );
+  }
+
+  if (!normalizeTrailingDnsRootDotHostname(parsed)) {
+    throw new Error(`FaceTheory strict CSP ${label} URL is invalid: ${trimmed}`);
   }
 
   if (!allowedOrigin) {

--- a/ts/src/origin.ts
+++ b/ts/src/origin.ts
@@ -1,0 +1,12 @@
+/**
+ * Removes exactly one trailing DNS root dot from a URL hostname. A lone root
+ * label or multiple trailing dots are not valid application hosts and are
+ * rejected rather than collapsed into a different hostname.
+ */
+export function normalizeTrailingDnsRootDotHostname(url: URL): boolean {
+  if (url.hostname === '.' || url.hostname.endsWith('..')) return false;
+  if (url.hostname.endsWith('.')) {
+    url.hostname = url.hostname.slice(0, -1);
+  }
+  return true;
+}

--- a/ts/test/unit/app.test.ts
+++ b/ts/test/unit/app.test.ts
@@ -298,6 +298,111 @@ test('FaceApp: normalizes a trailing DNS root dot in the trusted original host',
   assert.equal(resp.status, 200);
 });
 
+test('FaceApp: normalizes a trailing DNS root dot in both host and canonical URL', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/articles/symmetric-trailing-dot',
+        mode: 'ssr',
+        render: () => ({
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          headTags: [
+            {
+              type: 'link',
+              attrs: {
+                rel: 'canonical',
+                href: 'https://real.example./articles/symmetric-trailing-dot',
+              },
+            },
+          ],
+          html: '<main>Symmetric trailing DNS root dot</main>',
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/articles/symmetric-trailing-dot',
+    headers: {
+      'cloudfront-forwarded-proto': ['https'],
+      'x-facetheory-original-host': ['real.example.'],
+    },
+  });
+
+  assert.equal(resp.status, 200);
+});
+
+test('FaceApp: rejects a second trailing DNS root dot in a canonical URL', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/articles/double-trailing-dot',
+        mode: 'ssr',
+        render: () => ({
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          headTags: [
+            {
+              type: 'link',
+              attrs: {
+                rel: 'canonical',
+                href: 'https://real.example../articles/double-trailing-dot',
+              },
+            },
+          ],
+          html: '<main>Double trailing DNS root dot</main>',
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/articles/double-trailing-dot',
+    headers: {
+      'cloudfront-forwarded-proto': ['https'],
+      'x-facetheory-original-host': ['real.example.'],
+    },
+  });
+
+  assert.equal(resp.status, 500);
+});
+
+test('FaceApp: trailing-dot normalization still rejects a cross-host canonical URL', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/articles/trailing-dot-cross-host',
+        mode: 'ssr',
+        render: () => ({
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          headTags: [
+            {
+              type: 'link',
+              attrs: {
+                rel: 'canonical',
+                href: 'https://other.example./articles/trailing-dot-cross-host',
+              },
+            },
+          ],
+          html: '<main>Trailing dot cross-host</main>',
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/articles/trailing-dot-cross-host',
+    headers: {
+      'cloudfront-forwarded-proto': ['https'],
+      'x-facetheory-original-host': ['real.example.'],
+    },
+  });
+
+  assert.equal(resp.status, 500);
+});
+
 test('FaceApp: AppTheory path rejects a spoofed generic origin', async () => {
   const app = createFaceApp({
     faces: [
@@ -442,6 +547,50 @@ test('FaceApp: trusted generic proxy uses rightmost values across header array e
   });
 
   assert.equal(resp.status, 200);
+});
+
+test('FaceApp: host fallback uses rightmost values across flattened header shapes', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/articles/host-fallback-array',
+        mode: 'ssr',
+        render: () => ({
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          headTags: [
+            {
+              type: 'link',
+              attrs: {
+                rel: 'canonical',
+                href: 'https://right.example/articles/host-fallback-array',
+              },
+            },
+          ],
+          html: '<main>Host fallback array</main>',
+        }),
+      },
+    ],
+  });
+
+  const arrayResp = await app.handle({
+    method: 'GET',
+    path: '/articles/host-fallback-array',
+    headers: {
+      host: ['left.example', 'right.example'],
+      'x-forwarded-proto': ['https'],
+    },
+  });
+  const commaJoinedResp = await app.handle({
+    method: 'GET',
+    path: '/articles/host-fallback-array',
+    headers: {
+      host: ['left.example,right.example'],
+      'x-forwarded-proto': ['https'],
+    },
+  });
+
+  assert.equal(arrayResp.status, 200);
+  assert.equal(commaJoinedResp.status, 200);
 });
 
 test('FaceApp: canonicalOrigin overrides all request-derived headers', async () => {
@@ -593,11 +742,19 @@ test('FaceApp: missing CloudFront protocol reports the trusted header-pair cause
   );
 });
 
-test('FaceApp: canonicalOrigin rejects non-origin URL components', () => {
+test('FaceApp: canonicalOrigin rejects non-origin URLs and a lone DNS root', () => {
   assert.throws(
     () =>
       createFaceApp({
         canonicalOrigin: 'https://reader.example/not-an-origin',
+        faces: [],
+      }),
+    /canonicalOrigin must be an absolute http\(s\) origin/,
+  );
+  assert.throws(
+    () =>
+      createFaceApp({
+        canonicalOrigin: 'https://.',
         faces: [],
       }),
     /canonicalOrigin must be an absolute http\(s\) origin/,


### PR DESCRIPTION
## Summary

- flatten the generic `host` fallback through `rightmostCommaSeparatedHeaderValue`, keeping multi-element and comma-joined header shapes rightmost-wins
- normalize exactly one DNS root dot symmetrically for derived origins and strict-CSP head URLs, while rejecting lone-root/multiple-dot hosts and preserving cross-host rejection
- clarify that original-host partitioning belongs to the reference CloudFront HTML cache policy (not `defaultIsrCacheKey`) and document `host` flattening
- add regressions for array/comma `host` parity, dotted canonical URLs, invalid double dots, lone-root origins, and cross-host enforcement

## Validation

- `NPM_CONFIG_ALLOW_REMOTE=all npm test` — PASS: 700 tests, 699 pass, 0 fail, 1 expected environment-conditional skip
- `NPM_CONFIG_ALLOW_REMOTE=all npm run check` — PASS: ESLint, Svelte runes self-test/gate, build/typecheck, 26 example READMEs, 700 tests (699 pass, 0 fail, 1 expected skip)
- `scripts/verify-version-alignment.sh` — PASS (4.0.4)
- `git diff --check origin/staging...HEAD` — PASS

Linear: THE-2815
