### PR TITLE
fix(head): normalizeAllowedOrigin trailing-dot symmetry + guard regression test

### DIFF
--- a/ts/src/head.ts
+++ b/ts/src/head.ts
@@ -152,7 +152,9 @@ function isExternalHydration(
 
 function normalizeAllowedOrigin(origin: string | URL | undefined): string | null {
   if (origin === undefined) return null;
-  return new URL(String(origin)).origin;
+  const parsed = new URL(String(origin));
+  normalizeTrailingDnsRootDotHostname(parsed);
+  return parsed.origin;
 }
 
 function isAbsoluteOrProtocolRelativeUrl(value: string): boolean {

--- a/ts/test/unit/head.test.ts
+++ b/ts/test/unit/head.test.ts
@@ -471,6 +471,55 @@ test('head: strict CSP allows same-origin relative and absolute script src/link 
   assert.ok(absoluteHead.includes('href="https://app.example/assets/app.css"'));
 });
 
+test('head: strict CSP normalizes a dotted allowed origin for dotted and dotless URLs', () => {
+  for (const href of [
+    'https://real.example./articles/canonical',
+    'https://real.example/articles/canonical',
+  ]) {
+    const head = renderFaceHead(
+      {
+        html: '<div>ok</div>',
+        csp: {
+          inlineScripts: false,
+          inlineStyles: false,
+          rawHead: false,
+        },
+        headTags: [{ type: 'link', attrs: { rel: 'canonical', href } }],
+      },
+      { allowedOrigin: 'https://real.example.' },
+    );
+
+    assert.ok(head.includes(`href="${href}"`));
+  }
+});
+
+test('head: strict CSP rejects a second trailing DNS root dot on both origins', () => {
+  assert.throws(
+    () =>
+      renderFaceHead(
+        {
+          html: '<div>ok</div>',
+          csp: {
+            inlineScripts: false,
+            inlineStyles: false,
+            rawHead: false,
+          },
+          headTags: [
+            {
+              type: 'link',
+              attrs: {
+                rel: 'canonical',
+                href: 'https://real.example../x',
+              },
+            },
+          ],
+        },
+        { allowedOrigin: 'https://real.example..' },
+      ),
+    /link href URL is invalid/,
+  );
+});
+
 test('head: strict CSP rejects unsafe and canonical cross-origin script src/link href URLs', () => {
   const csp = {
     inlineScripts: false,


### PR DESCRIPTION
## Summary
- normalize direct `renderFaceHead` allowed origins with the shared trailing DNS root-dot helper
- cover dotted allowed origins against both dotted and dotless canonical hrefs
- pin the double-trailing-dot guard with the exact `real.example..` allowed-origin / `https://real.example../x` canonical pair

## Validation
- `NPM_CONFIG_ALLOW_REMOTE=all npm test` — PASS (702 tests: 701 pass, 1 pre-existing environment-conditional skip, 0 fail)
- `NPM_CONFIG_ALLOW_REMOTE=all npm run check` — PASS (lint, Svelte runes gates, typecheck/build, 26 example README verification, 702 tests)
- `scripts/verify-version-alignment.sh` — PASS (4.0.4)
- scratch-copy mutation proof — removing only `|| url.hostname.endsWith('..')` makes the new double-dot regression RED (`Missing expected exception`; 1 test, 0 pass, 1 fail; exit 1)
