### PR TITLE
test(head): pin framework-path 500 for double-dot host

### DIFF
--- a/ts/test/unit/app.test.ts
+++ b/ts/test/unit/app.test.ts
@@ -368,6 +368,41 @@ test('FaceApp: rejects a second trailing DNS root dot in a canonical URL', async
   assert.equal(resp.status, 500);
 });
 
+test('FaceApp: rejects a second trailing DNS root dot in the request host', async () => {
+  const app = createFaceApp({
+    faces: [
+      {
+        route: '/x',
+        mode: 'ssr',
+        render: () => ({
+          csp: { inlineScripts: false, inlineStyles: false, rawHead: false },
+          headTags: [
+            {
+              type: 'link',
+              attrs: {
+                rel: 'canonical',
+                href: 'https://real.example./x',
+              },
+            },
+          ],
+          html: '<main>Double trailing DNS root dot in request host</main>',
+        }),
+      },
+    ],
+  });
+
+  const resp = await app.handle({
+    method: 'GET',
+    path: '/x',
+    headers: {
+      'cloudfront-forwarded-proto': ['https'],
+      'x-facetheory-original-host': ['real.example..'],
+    },
+  });
+
+  assert.equal(resp.status, 500);
+});
+
 test('FaceApp: trailing-dot normalization still rejects a cross-host canonical URL', async () => {
   const app = createFaceApp({
     faces: [


### PR DESCRIPTION
## Summary
- add the PR #415 adversarial-review residual at the `createFaceApp` framework path
- pin `x-facetheory-original-host: real.example..` with canonical `https://real.example./x` to a fail-closed 500 response
- leave runtime behavior and version 4.0.4 unchanged

## Validation
- RED mutation proof: in a scratch copy, removing only `|| url.hostname.endsWith('..')` from `ts/src/origin.ts` made the focused test fail with `200 !== 500` (1 test, 0 pass, 1 fail; exit 1)
- GREEN focused test at real head: 1 test, 1 pass, 0 fail
- `NPM_CONFIG_ALLOW_REMOTE=all npm test`: 703 tests, 702 pass, 1 skip, 0 fail
- `NPM_CONFIG_ALLOW_REMOTE=all npm run check`: PASS (703 tests, 702 pass, 1 skip, 0 fail)
- `scripts/verify-version-alignment.sh`: `version-alignment: PASS (4.0.4)`
