### PR TITLE
fix(deps): align AppTheory v3.0.2 and TableTheory v3.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ ts/*.tgz
 .mcp.json
 .claude
 .agents/
+.kimi-code/
 GEMINI.md
 
 # Jekyll docs build artifacts (GitHub Pages site under docs/)

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Packaging posture: FaceTheory is ESM-only, declares `sideEffects: false` after a
 
 Optional companion packages from pinned GitHub releases:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz`
-- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz`
+- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz`
 
 ## Quickstart
 

--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -31,7 +31,7 @@ your SSR Lambda function.
 FaceTheory's SSG/ISR reference stack (`infra/apptheory-ssg-isr-site/`) uses `AppTheorySsrSite` with
 `mode: AppTheorySsrSiteMode.SSG_ISR` for the CloudFront distribution, Lambda Function URL origin, generated edge
 rewrite/request-id functions, and ISR runtime env wiring. The stack keeps explicit FaceTheory-owned `BucketDeployment`
-resources for immutable assets, the Vite manifest, and SSG HTML because AppTheory v3.0.1 does not yet expose
+resources for immutable assets, the Vite manifest, and SSG HTML because AppTheory v3.0.2 does not yet expose
 per-deployment `distributionPaths` invalidation controls for those uploads. Treat that as the remaining AppTheory
 coordination item; it is not permission to hand-roll the CloudFront distribution or origin group in FaceTheory.
 

--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -7,13 +7,13 @@ This file records the currently pinned versions and the exact install strings we
 
 ## Pins
 
-- AppTheory (TypeScript): `v3.0.1`
-- AppTheory (CDK): `v3.0.1`
-- TableTheory (TypeScript): `v3.0.2`
+- AppTheory (TypeScript): `v3.0.2`
+- AppTheory (CDK): `v3.0.2`
+- TableTheory (TypeScript): `v3.0.4`
 
 ## Compatibility Impact
 
-The AppTheory `v3.0.1` runtime/CDK pins and the TableTheory `v3.0.2` TypeScript pin are a coordinated
+The AppTheory `v3.0.2` runtime/CDK pins and the TableTheory `v3.0.4` TypeScript pin are a coordinated
 FaceTheory compatibility baseline:
 
 - the AppTheory runtime pin keeps Lambda URL streaming and AppTheory integration examples on the same upstream release
@@ -36,9 +36,9 @@ and keep the single release lane intact.
 
 ## Release Asset SHA-256
 
-- AppTheory runtime tarball: `22fc460a422cca8721969c28ec5a97f037395b4f2e8e6cdcd3c125a1817939b3`
-- AppTheory CDK tarball: `15c8faad4f9f7becdc0ee5b79f8f44d1144a39171850aec492ec4cf81cc0ee20`
-- TableTheory TypeScript tarball: `2f0dbb2848e5985880a77ff1cdc1a59f888164f3a3c37e717ec36b2eb7985fe9`
+- AppTheory runtime tarball: `8251003a245470f9718e014ae4792761127ab1c1d9c89c75b4d85aa8302d41a4`
+- AppTheory CDK tarball: `201b0a2d4ac2145c71404d27532eb58c01eb46e5e170679bd52106d977f99381`
+- TableTheory TypeScript tarball: `ec622601a39c6068b47cf90aa08fff5eff7defc7ce2f47645e54fddbdd12ea1b`
 
 ## Known Audit Exceptions
 
@@ -51,7 +51,7 @@ audit exit fails the verifier.
 - **bundled `brace-expansion`** — `aws-cdk-lib@2.263.0` bundles fixed `brace-expansion@5.0.8`, so the temporary
   `GHSA-mh99-v99m-4gvg` audit exception has been retired across all three projects.
 - **top-level `brace-expansion`** — non-bundled dependency paths resolve to fixed `brace-expansion@5.0.9`.
-- **`fast-uri`** — AppTheory CDK `v3.0.1` requires `aws-cdk-lib@2.263.0`, and the infra example
+- **`fast-uri`** — AppTheory CDK `v3.0.2` requires `aws-cdk-lib@2.263.0`, and the infra example
   lockfiles now resolve the previous nested `fast-uri` audit finding to the patched AWS CDK dependency set.
 
 ## Infra Lockfile Note
@@ -65,15 +65,15 @@ locks so `npm ci` can validate the AWS CDK package tree under npm 11.
 ```bash
   # AppTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
 
   # TableTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
 
   # AppTheory CDK (only for infra projects)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz
 ```
 
 ## package.json Snippet (Pinned)
@@ -84,12 +84,12 @@ registry installs:
 ```json
 {
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz"
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
     }
   }
 }

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -99,9 +99,9 @@ patterns:
     solution: "Use exact release asset URLs documented in the compatibility pins."
     correct_example: |
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
       npm install --save-exact \
-        https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz
+        https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
     anti_patterns:
       - name: "Floating registry installs"
         why: "The repo validates against explicit pinned combinations."

--- a/docs/cdk/README.md
+++ b/docs/cdk/README.md
@@ -79,7 +79,7 @@ deploy/
 
 The FaceTheory reference stacks keep explicit `BucketDeployment` resources for immutable assets, the Vite manifest, and
 SSG HTML. This preserves cache-control differences while `AppTheorySsrSite` owns the CloudFront distribution. AppTheory
-v3.0.1 does not yet expose per-deployment `distributionPaths` invalidation controls for those uploads; invalidate changed
+v3.0.2 does not yet expose per-deployment `distributionPaths` invalidation controls for those uploads; invalidate changed
 HTML and hydration JSON paths in your deployment pipeline until that AppTheory gap is closed.
 
 Local reference validation before any deploy:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,10 +75,10 @@ These are only required if your application uses the corresponding integration s
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
 
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
 ```
 
 Use AppTheory when you want its Lambda Function URL runtime as the AWS entrypoint. Use TableTheory when you want the documented production ISR metadata store adapter.

--- a/docs/integrations/apptheory.md
+++ b/docs/integrations/apptheory.md
@@ -22,14 +22,14 @@ FaceTheory imports from AppTheory; AppTheory does not import from FaceTheory. Cr
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
 ```
 
 For CDK deployments add the CDK companion tarball:
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz
 ```
 
 ## The AppTheory entry point

--- a/docs/integrations/tabletheory.md
+++ b/docs/integrations/tabletheory.md
@@ -8,7 +8,7 @@ FaceTheory uses TableTheory for blocking ISR's cache metadata, regeneration leas
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
 ```
 
 ## The TableTheory entry point

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,12 +63,12 @@ For AppTheory/TableTheory alignment, make the app's `package.json` use the same 
 ```json
 {
   "dependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz"
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
     }
   }
 }

--- a/gov-infra/planning/docs-init-examples/_decisions.yaml
+++ b/gov-infra/planning/docs-init-examples/_decisions.yaml
@@ -54,7 +54,7 @@ decisions:
           reason: "The repo states GitHub releases are source-of-truth and npm registry drift is unsupported."
           example: |
             npm install --save-exact \
-              https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz
+              https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
         if_no:
           choice: "Do not publish docs claiming compatibility; add TODO and pin versions first."
           reason: "Unpinned installs can break runtime and infra examples."

--- a/gov-infra/planning/docs-init-examples/_patterns.yaml
+++ b/gov-infra/planning/docs-init-examples/_patterns.yaml
@@ -37,9 +37,9 @@ patterns:
     correct_example: |
       # CORRECT: install pinned release assets
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
       npm install --save-exact \
-        https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz
+        https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
     anti_patterns:
       - name: "Floating upstream versions"
         why: "FaceTheory docs and examples are validated against explicit upstream pins."

--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -9,9 +9,9 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1098.0",
         "@aws-sdk/client-s3": "^3.1098.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
         "@types/node": "^24.12.4",
         "aws-cdk-lib": "2.263.0",
         "constructs": "10.8.0",
@@ -2890,9 +2890,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "3.0.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-      "integrity": "sha512-XuHRHp89EKJvgleQlnYhWGWdjWhOPbLOKzKYBV1XAsgYhR+4cEZd/bbh4XwlI1GZLYTcQKgx8SDdrB8EZVm+Zw==",
+      "version": "3.0.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+      "integrity": "sha512-8YlpdUI47NGNZdo56I7rEuf5IbMuLrZYRi2AiiOv2OpYefeH7rLXw8NGrG8D+MpSVQjge/KkPW3aDsWPd0Xfag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2901,16 +2901,16 @@
         "@aws-sdk/client-lambda-microvms": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1015.0",
         "@aws-sdk/client-s3vectors": "^3.1081.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz#sha512-K+jT8P2m+8QHvM+Y1hZxThnQfumcMVVwb8BltkEI8vs7bOg8PbUFR5w92ihBQbiA1pCvxG3kz7vwFhqNT0VUtw=="
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz#sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw=="
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "3.0.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz",
-      "integrity": "sha512-FEUQ0aXC25gPTcTCCs5BB4LUd91lbMfX6DFVduTa6sr+JxcCi13VX9i+vMHAxEjASWSpeEkXtLc0mpdoHnWp5g==",
+      "version": "3.0.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
+      "integrity": "sha512-kk618HOBIs9+ovCmUpd9HKl/kB5idHF17AQiUVLBjfifgGf8oro+PZRuYwa3cQFBKslQZu8HfoHV9ll4nFfXFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2922,9 +2922,9 @@
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "3.0.2",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz",
-      "integrity": "sha512-K+jT8P2m+8QHvM+Y1hZxThnQfumcMVVwb8BltkEI8vs7bOg8PbUFR5w92ihBQbiA1pCvxG3kz7vwFhqNT0VUtw==",
+      "version": "3.0.4",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
+      "integrity": "sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/infra/apptheory-ssg-isr-site/package.json
+++ b/infra/apptheory-ssg-isr-site/package.json
@@ -14,9 +14,9 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1098.0",
     "@aws-sdk/client-s3": "^3.1098.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
     "@types/node": "^24.12.4",
     "aws-cdk-lib": "2.263.0",
     "constructs": "10.8.0",
@@ -26,7 +26,7 @@
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
     }
   }
 }

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,9 +7,9 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
         "@types/node": "^24.12.4",
         "aws-cdk-lib": "2.263.0",
         "constructs": "10.8.0",
@@ -1199,9 +1199,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "3.0.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-      "integrity": "sha512-XuHRHp89EKJvgleQlnYhWGWdjWhOPbLOKzKYBV1XAsgYhR+4cEZd/bbh4XwlI1GZLYTcQKgx8SDdrB8EZVm+Zw==",
+      "version": "3.0.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+      "integrity": "sha512-8YlpdUI47NGNZdo56I7rEuf5IbMuLrZYRi2AiiOv2OpYefeH7rLXw8NGrG8D+MpSVQjge/KkPW3aDsWPd0Xfag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1210,16 +1210,16 @@
         "@aws-sdk/client-lambda-microvms": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1015.0",
         "@aws-sdk/client-s3vectors": "^3.1081.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz#sha512-K+jT8P2m+8QHvM+Y1hZxThnQfumcMVVwb8BltkEI8vs7bOg8PbUFR5w92ihBQbiA1pCvxG3kz7vwFhqNT0VUtw=="
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz#sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw=="
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "3.0.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz",
-      "integrity": "sha512-FEUQ0aXC25gPTcTCCs5BB4LUd91lbMfX6DFVduTa6sr+JxcCi13VX9i+vMHAxEjASWSpeEkXtLc0mpdoHnWp5g==",
+      "version": "3.0.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
+      "integrity": "sha512-kk618HOBIs9+ovCmUpd9HKl/kB5idHF17AQiUVLBjfifgGf8oro+PZRuYwa3cQFBKslQZu8HfoHV9ll4nFfXFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1231,9 +1231,9 @@
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "3.0.2",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz",
-      "integrity": "sha512-K+jT8P2m+8QHvM+Y1hZxThnQfumcMVVwb8BltkEI8vs7bOg8PbUFR5w92ihBQbiA1pCvxG3kz7vwFhqNT0VUtw==",
+      "version": "3.0.4",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
+      "integrity": "sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,9 +12,9 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
     "@types/node": "^24.12.4",
     "aws-cdk-lib": "2.263.0",
     "constructs": "10.8.0",
@@ -24,7 +24,7 @@
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
     }
   }
 }

--- a/ts/README.md
+++ b/ts/README.md
@@ -33,9 +33,9 @@ The Svelte peer range is `>=5.55.7`. FaceTheory v4.0.0 dropped Svelte 4 support 
 
 Optional companion packages:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz`
-- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz`
+- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz`
 
 ## Minimal App
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -21,9 +21,9 @@
         "@emotion/server": "^11.11.0",
         "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
         "@types/jsdom": "^28.0.3",
         "@types/node": "^24.12.4",
         "@types/react": "^19.2.15",
@@ -4941,9 +4941,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "3.0.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-      "integrity": "sha512-XuHRHp89EKJvgleQlnYhWGWdjWhOPbLOKzKYBV1XAsgYhR+4cEZd/bbh4XwlI1GZLYTcQKgx8SDdrB8EZVm+Zw==",
+      "version": "3.0.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+      "integrity": "sha512-8YlpdUI47NGNZdo56I7rEuf5IbMuLrZYRi2AiiOv2OpYefeH7rLXw8NGrG8D+MpSVQjge/KkPW3aDsWPd0Xfag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4952,16 +4952,16 @@
         "@aws-sdk/client-lambda-microvms": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1015.0",
         "@aws-sdk/client-s3vectors": "^3.1081.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz#sha512-K+jT8P2m+8QHvM+Y1hZxThnQfumcMVVwb8BltkEI8vs7bOg8PbUFR5w92ihBQbiA1pCvxG3kz7vwFhqNT0VUtw=="
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz#sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw=="
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "3.0.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz",
-      "integrity": "sha512-FEUQ0aXC25gPTcTCCs5BB4LUd91lbMfX6DFVduTa6sr+JxcCi13VX9i+vMHAxEjASWSpeEkXtLc0mpdoHnWp5g==",
+      "version": "3.0.2",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
+      "integrity": "sha512-kk618HOBIs9+ovCmUpd9HKl/kB5idHF17AQiUVLBjfifgGf8oro+PZRuYwa3cQFBKslQZu8HfoHV9ll4nFfXFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4973,9 +4973,9 @@
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "3.0.2",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz",
-      "integrity": "sha512-K+jT8P2m+8QHvM+Y1hZxThnQfumcMVVwb8BltkEI8vs7bOg8PbUFR5w92ihBQbiA1pCvxG3kz7vwFhqNT0VUtw==",
+      "version": "3.0.4",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
+      "integrity": "sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -277,9 +277,9 @@
     "@emotion/server": "^11.11.0",
     "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-cdk-3.0.1.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
     "@types/jsdom": "^28.0.3",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",
@@ -306,7 +306,7 @@
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
     },
     "brace-expansion": "5.0.9",
     "postcss": "8.5.25"

--- a/ts/test/unit/doctor-cli.test.ts
+++ b/ts/test/unit/doctor-cli.test.ts
@@ -24,9 +24,9 @@ const FACE_PACKAGE = {
 };
 
 const APP_THEORY =
-  'https://github.com/theory-cloud/AppTheory/releases/download/v3.0.1/theory-cloud-apptheory-3.0.1.tgz';
+  'https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz';
 const TABLE_THEORY =
-  'https://github.com/theory-cloud/TableTheory/releases/download/v3.0.2/theory-cloud-tabletheory-ts-3.0.2.tgz';
+  'https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz';
 
 class CaptureStream extends Writable {
   public text = '';
@@ -199,7 +199,7 @@ test('facetheory doctor reports AppTheory/TableTheory override drift with a fix'
     assert.equal(exitCode, 1);
     assert.match(stdout.text, /AppTheory\/TableTheory override alignment is drifted/);
     assert.match(stdout.text, /Set overrides\["@theory-cloud\/apptheory"\]/);
-    assert.match(stdout.text, /theory-cloud-tabletheory-ts-3\.0\.2\.tgz/);
+    assert.match(stdout.text, /theory-cloud-tabletheory-ts-3\.0\.4\.tgz/);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- pin the AppTheory runtime and CDK release assets to `v3.0.2`
- pin TableTheory TypeScript to `v3.0.4` across FaceTheory and both reference stacks
- align AppTheory's transitive TableTheory dependency with the direct pin and override
- refresh immutable release checksums, lockfile integrities, consumer docs, and doctor coverage
- ignore host-materialized `.kimi-code/` content alongside the existing `GEMINI.md` rule

## Why

AppTheory `v3.0.2` now depends on the immutable TableTheory `v3.0.4` TypeScript asset. FaceTheory's direct dependency, transitive override, reference infrastructure, and published guidance need to resolve the same upstream baseline rather than retain the older AppTheory `v3.0.1` / TableTheory `v3.0.2` combination.

The AppTheory CDK peer baseline remains unchanged and aligned at `aws-cdk-lib@2.263.0` and `constructs@10.8.0`.

## Impact

This is a dependency compatibility update with no FaceTheory public API or render-mode contract change. Consumers following the documented GitHub Release installation path will receive the new immutable upstream assets. React, Vue, and Svelte rendering behavior remains unchanged.

## Validation

- `scripts/verify-version-alignment.sh`
- `cd ts && npm run check`
- `cd ts && npm run format:check`
- `NPM_CONFIG_ALLOW_REMOTE=all make infra-snapshot-test`
- `scripts/verify-npm-audit.sh` (passes with the existing exact advisory allowlist; no new exception)
- `npm ci` and dependency-tree alignment checks in `ts`, `infra/apptheory-ssr-site`, and `infra/apptheory-ssg-isr-site`
