### PR TITLE
fix(deps): bump nanoid 3.3.16 → 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -7527,9 +7527,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
SEC-1 npm-audit high: nanoid custom generators can loop indefinitely when size is zero. Transitive via `vite → postcss (overridden)`; patch-level, lockfile-only bump (3 lines), no manifest changes.

The remaining audit high (`brace-expansion` bundled inside `aws-cdk-lib`) is already SEC-1 allow-listed and cannot be auto-fixed.

Validated locally: `npm audit` clean of nanoid; rubric **SEC-1 PASS**. The local DOC-1 failure on this staging-based branch is the pre-patch materialization divergence (GEMINI.md present on disk locally, absent in CI checkouts) — addressed separately by #433; the two PRs touch disjoint files (`ts/package-lock.json` vs `gov-infra/verifiers/gov-verify-rubric.sh`).

Once this lands, #432 and #433 can go fully green.