### PR TITLE
fix(deps): align AppTheory v3.1.0 and TableTheory v3.0.5 pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Packaging posture: FaceTheory is ESM-only, declares `sideEffects: false` after a
 
 Optional companion packages from pinned GitHub releases:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz`
-- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz`
+- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz`
 
 ## Quickstart
 

--- a/docs/AWS_DEPLOYMENT_SHAPE.md
+++ b/docs/AWS_DEPLOYMENT_SHAPE.md
@@ -31,7 +31,7 @@ your SSR Lambda function.
 FaceTheory's SSG/ISR reference stack (`infra/apptheory-ssg-isr-site/`) uses `AppTheorySsrSite` with
 `mode: AppTheorySsrSiteMode.SSG_ISR` for the CloudFront distribution, Lambda Function URL origin, generated edge
 rewrite/request-id functions, and ISR runtime env wiring. The stack keeps explicit FaceTheory-owned `BucketDeployment`
-resources for immutable assets, the Vite manifest, and SSG HTML because AppTheory v3.0.2 does not yet expose
+resources for immutable assets, the Vite manifest, and SSG HTML because AppTheory v3.1.0 does not yet expose
 per-deployment `distributionPaths` invalidation controls for those uploads. Treat that as the remaining AppTheory
 coordination item; it is not permission to hand-roll the CloudFront distribution or origin group in FaceTheory.
 

--- a/docs/UPSTREAM_RELEASE_PINS.md
+++ b/docs/UPSTREAM_RELEASE_PINS.md
@@ -7,13 +7,13 @@ This file records the currently pinned versions and the exact install strings we
 
 ## Pins
 
-- AppTheory (TypeScript): `v3.0.2`
-- AppTheory (CDK): `v3.0.2`
-- TableTheory (TypeScript): `v3.0.4`
+- AppTheory (TypeScript): `v3.1.0`
+- AppTheory (CDK): `v3.1.0`
+- TableTheory (TypeScript): `v3.0.5`
 
 ## Compatibility Impact
 
-The AppTheory `v3.0.2` runtime/CDK pins and the TableTheory `v3.0.4` TypeScript pin are a coordinated
+The AppTheory `v3.1.0` runtime/CDK pins and the TableTheory `v3.0.5` TypeScript pin are a coordinated
 FaceTheory compatibility baseline:
 
 - the AppTheory runtime pin keeps Lambda URL streaming and AppTheory integration examples on the same upstream release
@@ -36,9 +36,9 @@ and keep the single release lane intact.
 
 ## Release Asset SHA-256
 
-- AppTheory runtime tarball: `8251003a245470f9718e014ae4792761127ab1c1d9c89c75b4d85aa8302d41a4`
-- AppTheory CDK tarball: `201b0a2d4ac2145c71404d27532eb58c01eb46e5e170679bd52106d977f99381`
-- TableTheory TypeScript tarball: `ec622601a39c6068b47cf90aa08fff5eff7defc7ce2f47645e54fddbdd12ea1b`
+- AppTheory runtime tarball: `9c6d73f1734f4080f2241ce6549045fe55a2a585ea834988d10fcbf6c6b5cac3`
+- AppTheory CDK tarball: `21a5cddcf3d55a123f22f77fc2c153d32e3397225ac136ed12b1f51ca52fd740`
+- TableTheory TypeScript tarball: `dfe97bc7931962c4df33b96bbfb89531123b81d723c4860c68704c3b6954b8a6`
 
 ## Known Audit Exceptions
 
@@ -48,10 +48,10 @@ audit exit fails the verifier.
 
 ### Recently cleared
 
-- **bundled `brace-expansion`** — `aws-cdk-lib@2.263.0` bundles fixed `brace-expansion@5.0.8`, so the temporary
+- **bundled `brace-expansion`** — `aws-cdk-lib@2.265.0` bundles fixed `brace-expansion@5.0.9`, so the temporary
   `GHSA-mh99-v99m-4gvg` audit exception has been retired across all three projects.
 - **top-level `brace-expansion`** — non-bundled dependency paths resolve to fixed `brace-expansion@5.0.9`.
-- **`fast-uri`** — AppTheory CDK `v3.0.2` requires `aws-cdk-lib@2.263.0`, and the infra example
+- **`fast-uri`** — AppTheory CDK `v3.1.0` requires `aws-cdk-lib@2.265.0`, and the infra example
   lockfiles now resolve the previous nested `fast-uri` audit finding to the patched AWS CDK dependency set.
 
 ## Infra Lockfile Note
@@ -65,15 +65,15 @@ locks so `npm ci` can validate the AWS CDK package tree under npm 11.
 ```bash
   # AppTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz
 
   # TableTheory (TS)
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz
 
   # AppTheory CDK (only for infra projects)
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz
 ```
 
 ## package.json Snippet (Pinned)
@@ -84,12 +84,12 @@ registry installs:
 ```json
 {
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz"
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz"
     }
   }
 }

--- a/docs/_patterns.yaml
+++ b/docs/_patterns.yaml
@@ -99,9 +99,9 @@ patterns:
     solution: "Use exact release asset URLs documented in the compatibility pins."
     correct_example: |
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz
       npm install --save-exact \
-        https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
+        https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz
     anti_patterns:
       - name: "Floating registry installs"
         why: "The repo validates against explicit pinned combinations."

--- a/docs/cdk/README.md
+++ b/docs/cdk/README.md
@@ -79,7 +79,7 @@ deploy/
 
 The FaceTheory reference stacks keep explicit `BucketDeployment` resources for immutable assets, the Vite manifest, and
 SSG HTML. This preserves cache-control differences while `AppTheorySsrSite` owns the CloudFront distribution. AppTheory
-v3.0.2 does not yet expose per-deployment `distributionPaths` invalidation controls for those uploads; invalidate changed
+v3.1.0 does not yet expose per-deployment `distributionPaths` invalidation controls for those uploads; invalidate changed
 HTML and hydration JSON paths in your deployment pipeline until that AppTheory gap is closed.
 
 Local reference validation before any deploy:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,10 +75,10 @@ These are only required if your application uses the corresponding integration s
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz
 
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz
 ```
 
 Use AppTheory when you want its Lambda Function URL runtime as the AWS entrypoint. Use TableTheory when you want the documented production ISR metadata store adapter.

--- a/docs/integrations/apptheory.md
+++ b/docs/integrations/apptheory.md
@@ -22,14 +22,14 @@ FaceTheory imports from AppTheory; AppTheory does not import from FaceTheory. Cr
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz
 ```
 
 For CDK deployments add the CDK companion tarball:
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz
+  https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz
 ```
 
 ## The AppTheory entry point

--- a/docs/integrations/tabletheory.md
+++ b/docs/integrations/tabletheory.md
@@ -8,7 +8,7 @@ FaceTheory uses TableTheory for blocking ISR's cache metadata, regeneration leas
 
 ```bash
 npm install --save-exact \
-  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
+  https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz
 ```
 
 ## The TableTheory entry point

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,12 +63,12 @@ For AppTheory/TableTheory alignment, make the app's `package.json` use the same 
 ```json
 {
   "dependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz"
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz"
     }
   }
 }

--- a/gov-infra/planning/docs-init-examples/_decisions.yaml
+++ b/gov-infra/planning/docs-init-examples/_decisions.yaml
@@ -54,7 +54,7 @@ decisions:
           reason: "The repo states GitHub releases are source-of-truth and npm registry drift is unsupported."
           example: |
             npm install --save-exact \
-              https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
+              https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz
         if_no:
           choice: "Do not publish docs claiming compatibility; add TODO and pin versions first."
           reason: "Unpinned installs can break runtime and infra examples."

--- a/gov-infra/planning/docs-init-examples/_patterns.yaml
+++ b/gov-infra/planning/docs-init-examples/_patterns.yaml
@@ -37,9 +37,9 @@ patterns:
     correct_example: |
       # CORRECT: install pinned release assets
       npm install --save-exact \
-        https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz
+        https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz
       npm install --save-exact \
-        https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz
+        https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz
     anti_patterns:
       - name: "Floating upstream versions"
         why: "FaceTheory docs and examples are validated against explicit upstream pins."

--- a/infra/apptheory-ssg-isr-site/package-lock.json
+++ b/infra/apptheory-ssg-isr-site/package-lock.json
@@ -9,11 +9,11 @@
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "^3.1098.0",
         "@aws-sdk/client-s3": "^3.1098.0",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz",
         "@types/node": "^24.12.4",
-        "aws-cdk-lib": "2.263.0",
+        "aws-cdk-lib": "2.265.0",
         "constructs": "10.8.0",
         "esbuild": "^0.28.1",
         "tsx": "^4.22.3",
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.282",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
-      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -38,9 +38,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.15.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.15.0.tgz",
-      "integrity": "sha512-eWdbH+SRmxeTSyECibUdP4MkRqhoXJ7GMFiHJgIt5081sU4D42tsNmwe8rPHQHyFXRTwauxdLNdhJeykOv8+Cg==",
+      "version": "54.20.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.20.0.tgz",
+      "integrity": "sha512-ts2dVBi0VUXOLKcqyLYsHUWYpwGPFd+xm4q+6Y4jjP8orwodjRi2mJrmpy9b0gHnbv8e/hFnmEbqrD0bBJOnPA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -681,16 +681,16 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.1101.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1101.0.tgz",
-      "integrity": "sha512-qczxakJlFYG9E6nE2yWIJ2nXq0HbMzHxMSWIsyubPZqx1TANHd2CSJWDTkg+IsNKq+94tG+e+EJo3uADwZ6cdw==",
+      "version": "3.1114.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1114.0.tgz",
+      "integrity": "sha512-yXshoKNqG20sAqXAM0bKBFLQ2MAO3K8W39fheO0i0k2NKckfa0/K8W9PHpYXx0XwiDi460B6e/7B+uilecO12w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-node": "^3.972.76",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -1120,17 +1120,17 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.1101.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1101.0.tgz",
-      "integrity": "sha512-g/xmDwNRsObFM8WnYCvMOYipHRL2B+C18eRw5KzB3wiqF/BtDuscq8lIUVK9sU6bpCIqrDHVuHoUyKNaS9OWkg==",
+      "version": "3.1114.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1114.0.tgz",
+      "integrity": "sha512-BMhx1eNX1KuPmnhVfN3C4pFTmDamWeI9EGd1PcIh+t92V530bVVbU98g9nYblYQbXDVk5zoJC7PRyMSQybeBsQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-node": "^3.972.76",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -1142,14 +1142,14 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
-      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
         "@aws/lambda-invoke-store": "^0.3.0",
         "@smithy/core": "^3.31.1",
         "@smithy/signature-v4": "^5.6.12",
@@ -1172,14 +1172,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
-      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1189,14 +1189,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
-      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -1208,21 +1208,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
-      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-login": "^3.972.72",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -1233,15 +1233,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
-      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1251,19 +1251,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
-      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-ini": "^3.973.10",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -1274,14 +1274,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
-      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1291,16 +1291,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
-      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/token-providers": "3.1100.0",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1310,15 +1310,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
-      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1709,15 +1709,15 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
-      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -1746,13 +1746,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
-      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1762,15 +1762,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1100.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
-      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1780,9 +1780,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1863,9 +1863,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
-      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2890,9 +2890,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "3.0.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-      "integrity": "sha512-8YlpdUI47NGNZdo56I7rEuf5IbMuLrZYRi2AiiOv2OpYefeH7rLXw8NGrG8D+MpSVQjge/KkPW3aDsWPd0Xfag==",
+      "version": "3.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+      "integrity": "sha512-Z6qriYp3VScfRHJ6s1BfNKB3wh0qXlO8oquNeZRUHWEzcFUC6qukHxcbnS1xPO1Jq6y4C/fNYn24rciT1/hmeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2901,30 +2901,30 @@
         "@aws-sdk/client-lambda-microvms": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1015.0",
         "@aws-sdk/client-s3vectors": "^3.1081.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz#sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw=="
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz#sha512-wt468Cwdu4OnGcKpGTcczf7//kdaemDZwkntVzL5LPhjEtRqh/Ge5qiwBxn5AC0AglM2kISYB3E8gBi5BVpQlQ=="
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "3.0.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
-      "integrity": "sha512-kk618HOBIs9+ovCmUpd9HKl/kB5idHF17AQiUVLBjfifgGf8oro+PZRuYwa3cQFBKslQZu8HfoHV9ll4nFfXFQ==",
+      "version": "3.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz",
+      "integrity": "sha512-L3FjDA6BgwjEY1+SrheHlqLesUsFkP3RHwQbWg0ckZMxPPljf6h9n0a3xakAYvUqySfY1qOqkqMtZfMwAgbIaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.263.0",
+        "aws-cdk-lib": "2.265.0",
         "constructs": "10.8.0"
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "3.0.4",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
-      "integrity": "sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw==",
+      "version": "3.0.5",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz",
+      "integrity": "sha512-wt468Cwdu4OnGcKpGTcczf7//kdaemDZwkntVzL5LPhjEtRqh/Ge5qiwBxn5AC0AglM2kISYB3E8gBi5BVpQlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2950,9 +2950,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.263.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
-      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
+      "version": "2.265.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.265.0.tgz",
+      "integrity": "sha512-Ur96d/ZW+gqAW4XtqKQp//D9O/jQvyRoXhAqoHGybpV03qjckGIQcLcGkLV68+jv03TX/rOXHCsa2IEFcCXa4w==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -2970,11 +2970,11 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.6.0-beta",
+        "@aws/cloudformation-validate": "1.7.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -3010,7 +3010,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.6.0-beta",
+      "version": "1.7.0-beta",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -3034,7 +3034,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.8",
+      "version": "5.0.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",

--- a/infra/apptheory-ssg-isr-site/package.json
+++ b/infra/apptheory-ssg-isr-site/package.json
@@ -14,11 +14,11 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.1098.0",
     "@aws-sdk/client-s3": "^3.1098.0",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz",
     "@types/node": "^24.12.4",
-    "aws-cdk-lib": "2.263.0",
+    "aws-cdk-lib": "2.265.0",
     "constructs": "10.8.0",
     "esbuild": "^0.28.1",
     "tsx": "^4.22.3",
@@ -26,7 +26,7 @@
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz"
     }
   }
 }

--- a/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
+++ b/infra/apptheory-ssg-isr-site/test/__snapshots__/ssg-isr-site-stack.template.json
@@ -583,7 +583,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "9df0db1d68d134dcb38846e2d8c6140457f750a7e3c21c5fade7e2bdeafa2b8d.zip"
+          "S3Key": "27db768f0161b3abaea506f7d5ad6a20ca95b537eeafadcda4e29ebae8d20dd0.zip"
         },
         "Environment": {
           "Variables": {
@@ -705,7 +705,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "a72522445441e9b66c2f16956c54d4786af8c61c156b80c48a6e7c32fcc49023.zip"
+          "S3Key": "98f62bef9320f8c0a0a7be21d7c746f069131f196f51ffe3008a6bb730b368ec.zip"
         },
         "Description": "/opt/awscli/aws"
       }
@@ -907,7 +907,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "a72522445441e9b66c2f16956c54d4786af8c61c156b80c48a6e7c32fcc49023.zip"
+          "S3Key": "98f62bef9320f8c0a0a7be21d7c746f069131f196f51ffe3008a6bb730b368ec.zip"
         },
         "Description": "/opt/awscli/aws"
       }
@@ -950,7 +950,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "a72522445441e9b66c2f16956c54d4786af8c61c156b80c48a6e7c32fcc49023.zip"
+          "S3Key": "98f62bef9320f8c0a0a7be21d7c746f069131f196f51ffe3008a6bb730b368ec.zip"
         },
         "Description": "/opt/awscli/aws"
       }

--- a/infra/apptheory-ssr-site/package-lock.json
+++ b/infra/apptheory-ssr-site/package-lock.json
@@ -7,11 +7,11 @@
       "name": "@theory-cloud/facetheory-infra-apptheory-ssr-site",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz",
         "@types/node": "^24.12.4",
-        "aws-cdk-lib": "2.263.0",
+        "aws-cdk-lib": "2.265.0",
         "constructs": "10.8.0",
         "esbuild": "^0.28.1",
         "tsx": "^4.22.3",
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.282",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
-      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -36,9 +36,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.15.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.15.0.tgz",
-      "integrity": "sha512-eWdbH+SRmxeTSyECibUdP4MkRqhoXJ7GMFiHJgIt5081sU4D42tsNmwe8rPHQHyFXRTwauxdLNdhJeykOv8+Cg==",
+      "version": "54.20.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.20.0.tgz",
+      "integrity": "sha512-ts2dVBi0VUXOLKcqyLYsHUWYpwGPFd+xm4q+6Y4jjP8orwodjRi2mJrmpy9b0gHnbv8e/hFnmEbqrD0bBJOnPA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -136,18 +136,18 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1101.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1101.0.tgz",
-      "integrity": "sha512-3tlBfiRdksyqFggcMsN3AOA9uaqEbt5OK6Ym0MfUxKqLIOwdAlfCKL2GvE8qC0xa2dwPegIDs+grTRpBtzNILQ==",
+      "version": "3.1114.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1114.0.tgz",
+      "integrity": "sha512-0oHSQWBZvjwcTuWOiyIemuGsXMwMvl2hqPiIoCvxiOOpgzIOqN/lcatygW3VGe9iDfHgcyqJfXC8B+XbKHpftA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-node": "^3.972.76",
-        "@aws-sdk/dynamodb-codec": "^3.973.39",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.27",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/dynamodb-codec": "^3.973.43",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.29",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -159,16 +159,16 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.1101.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1101.0.tgz",
-      "integrity": "sha512-qczxakJlFYG9E6nE2yWIJ2nXq0HbMzHxMSWIsyubPZqx1TANHd2CSJWDTkg+IsNKq+94tG+e+EJo3uADwZ6cdw==",
+      "version": "3.1114.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1114.0.tgz",
+      "integrity": "sha512-yXshoKNqG20sAqXAM0bKBFLQ2MAO3K8W39fheO0i0k2NKckfa0/K8W9PHpYXx0XwiDi460B6e/7B+uilecO12w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-node": "^3.972.76",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -243,17 +243,17 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.1101.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1101.0.tgz",
-      "integrity": "sha512-g/xmDwNRsObFM8WnYCvMOYipHRL2B+C18eRw5KzB3wiqF/BtDuscq8lIUVK9sU6bpCIqrDHVuHoUyKNaS9OWkg==",
+      "version": "3.1114.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1114.0.tgz",
+      "integrity": "sha512-BMhx1eNX1KuPmnhVfN3C4pFTmDamWeI9EGd1PcIh+t92V530bVVbU98g9nYblYQbXDVk5zoJC7PRyMSQybeBsQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-node": "^3.972.76",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -265,14 +265,14 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
-      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
         "@aws/lambda-invoke-store": "^0.3.0",
         "@smithy/core": "^3.31.1",
         "@smithy/signature-v4": "^5.6.12",
@@ -285,14 +285,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
-      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -302,14 +302,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
-      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -321,21 +321,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
-      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-login": "^3.972.72",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -346,15 +346,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
-      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -364,19 +364,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
-      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-ini": "^3.973.10",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -387,14 +387,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
-      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -404,16 +404,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
-      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/token-providers": "3.1100.0",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -423,15 +423,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1100.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
-      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -441,15 +441,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
-      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -459,14 +459,14 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.39.tgz",
-      "integrity": "sha512-6n1ER8qEvfruOfVFHVYrAtfSOk0ELudJDWyUMMb+M+tiP4rWSU44zd9ilQcM2/ESlRPyzxc2h7dU3R+UT+sVEg==",
+      "version": "3.973.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.43.tgz",
+      "integrity": "sha512-5nw01fhFJEKM68n0R65S1DijiSAQWZVbvH7IxTIJpFFbggg816jBVYvhK7W+XISjvtdg0rMkF/gQmuLGH713mg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.8",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.9.tgz",
-      "integrity": "sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.11.tgz",
+      "integrity": "sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -507,15 +507,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.27.tgz",
-      "integrity": "sha512-5AJlxrsg27IGGiQauWOdVyqK55EN0EMIwXndkVHhBiPT4CtdSaz89/sAENSw+GP4KF+BOWcgycZFNjkOLmfo1A==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.29.tgz",
+      "integrity": "sha512-cXW7QNIOhUSfccZmwJEjn9EdCAjzdOtt/+MtO5HWgxIZdhzyC1kNuQKIgGEDkgabxiXymWw0/VFWdqxqeLbgMA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "^3.972.9",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/endpoint-cache": "^3.972.11",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -578,15 +578,15 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
-      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -598,13 +598,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
-      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -632,9 +632,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -646,9 +646,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
-      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1112,13 +1112,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
-      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1126,14 +1126,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
-      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
-      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1199,9 +1199,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "3.0.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-      "integrity": "sha512-8YlpdUI47NGNZdo56I7rEuf5IbMuLrZYRi2AiiOv2OpYefeH7rLXw8NGrG8D+MpSVQjge/KkPW3aDsWPd0Xfag==",
+      "version": "3.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+      "integrity": "sha512-Z6qriYp3VScfRHJ6s1BfNKB3wh0qXlO8oquNeZRUHWEzcFUC6qukHxcbnS1xPO1Jq6y4C/fNYn24rciT1/hmeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1210,30 +1210,30 @@
         "@aws-sdk/client-lambda-microvms": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1015.0",
         "@aws-sdk/client-s3vectors": "^3.1081.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz#sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw=="
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz#sha512-wt468Cwdu4OnGcKpGTcczf7//kdaemDZwkntVzL5LPhjEtRqh/Ge5qiwBxn5AC0AglM2kISYB3E8gBi5BVpQlQ=="
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "3.0.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
-      "integrity": "sha512-kk618HOBIs9+ovCmUpd9HKl/kB5idHF17AQiUVLBjfifgGf8oro+PZRuYwa3cQFBKslQZu8HfoHV9ll4nFfXFQ==",
+      "version": "3.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz",
+      "integrity": "sha512-L3FjDA6BgwjEY1+SrheHlqLesUsFkP3RHwQbWg0ckZMxPPljf6h9n0a3xakAYvUqySfY1qOqkqMtZfMwAgbIaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.263.0",
+        "aws-cdk-lib": "2.265.0",
         "constructs": "10.8.0"
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "3.0.4",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
-      "integrity": "sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw==",
+      "version": "3.0.5",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz",
+      "integrity": "sha512-wt468Cwdu4OnGcKpGTcczf7//kdaemDZwkntVzL5LPhjEtRqh/Ge5qiwBxn5AC0AglM2kISYB3E8gBi5BVpQlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1259,9 +1259,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.263.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
-      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
+      "version": "2.265.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.265.0.tgz",
+      "integrity": "sha512-Ur96d/ZW+gqAW4XtqKQp//D9O/jQvyRoXhAqoHGybpV03qjckGIQcLcGkLV68+jv03TX/rOXHCsa2IEFcCXa4w==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -1279,11 +1279,11 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.6.0-beta",
+        "@aws/cloudformation-validate": "1.7.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -1319,7 +1319,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.6.0-beta",
+      "version": "1.7.0-beta",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -1343,7 +1343,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.8",
+      "version": "5.0.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",

--- a/infra/apptheory-ssr-site/package.json
+++ b/infra/apptheory-ssr-site/package.json
@@ -12,11 +12,11 @@
     "synth": "tsx scripts/synth.ts"
   },
   "devDependencies": {
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz",
     "@types/node": "^24.12.4",
-    "aws-cdk-lib": "2.263.0",
+    "aws-cdk-lib": "2.265.0",
     "constructs": "10.8.0",
     "esbuild": "^0.28.1",
     "tsx": "^4.22.3",
@@ -24,7 +24,7 @@
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz"
     }
   }
 }

--- a/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
+++ b/infra/apptheory-ssr-site/test/__snapshots__/ssr-site-stack.template.json
@@ -331,7 +331,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "25b55f97e1cbe4c60095ab1b52ad6c22dad7224f4d9dba42cae2abb12df08006.zip"
+          "S3Key": "f82e1f24e618a101662702d5f67d56f89a251294cdca6551c54bcde09b895cf0.zip"
         },
         "Environment": {
           "Variables": {
@@ -398,7 +398,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "a72522445441e9b66c2f16956c54d4786af8c61c156b80c48a6e7c32fcc49023.zip"
+          "S3Key": "98f62bef9320f8c0a0a7be21d7c746f069131f196f51ffe3008a6bb730b368ec.zip"
         },
         "Description": "/opt/awscli/aws"
       }
@@ -600,7 +600,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "a72522445441e9b66c2f16956c54d4786af8c61c156b80c48a6e7c32fcc49023.zip"
+          "S3Key": "98f62bef9320f8c0a0a7be21d7c746f069131f196f51ffe3008a6bb730b368ec.zip"
         },
         "Description": "/opt/awscli/aws"
       }
@@ -643,7 +643,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "a72522445441e9b66c2f16956c54d4786af8c61c156b80c48a6e7c32fcc49023.zip"
+          "S3Key": "98f62bef9320f8c0a0a7be21d7c746f069131f196f51ffe3008a6bb730b368ec.zip"
         },
         "Description": "/opt/awscli/aws"
       }

--- a/ts/README.md
+++ b/ts/README.md
@@ -33,9 +33,9 @@ The Svelte peer range is `>=5.55.7`. FaceTheory v4.0.0 dropped Svelte 4 support 
 
 Optional companion packages:
 
-- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz`
-- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz`
-- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz`
+- AppTheory runtime: `https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz`
+- AppTheory CDK: `https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz`
+- TableTheory runtime: `https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz`
 
 ## Minimal App
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -21,9 +21,9 @@
         "@emotion/server": "^11.11.0",
         "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
-        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
+        "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz",
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz",
         "@types/jsdom": "^28.0.3",
         "@types/node": "^24.12.4",
         "@types/react": "^19.2.15",
@@ -32,7 +32,7 @@
         "@typescript-eslint/parser": "^8.60.0",
         "@vue/server-renderer": "^3.5.34",
         "antd": "^6.4.3",
-        "aws-cdk-lib": "2.263.0",
+        "aws-cdk-lib": "2.265.0",
         "c8": "^11.0.0",
         "constructs": "10.8.0",
         "esbuild": "^0.28.1",
@@ -253,9 +253,9 @@
       "license": "MIT"
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.282",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
-      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -267,9 +267,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.15.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.15.0.tgz",
-      "integrity": "sha512-eWdbH+SRmxeTSyECibUdP4MkRqhoXJ7GMFiHJgIt5081sU4D42tsNmwe8rPHQHyFXRTwauxdLNdhJeykOv8+Cg==",
+      "version": "54.20.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.20.0.tgz",
+      "integrity": "sha512-ts2dVBi0VUXOLKcqyLYsHUWYpwGPFd+xm4q+6Y4jjP8orwodjRi2mJrmpy9b0gHnbv8e/hFnmEbqrD0bBJOnPA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -888,18 +888,18 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.1101.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1101.0.tgz",
-      "integrity": "sha512-3tlBfiRdksyqFggcMsN3AOA9uaqEbt5OK6Ym0MfUxKqLIOwdAlfCKL2GvE8qC0xa2dwPegIDs+grTRpBtzNILQ==",
+      "version": "3.1114.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1114.0.tgz",
+      "integrity": "sha512-0oHSQWBZvjwcTuWOiyIemuGsXMwMvl2hqPiIoCvxiOOpgzIOqN/lcatygW3VGe9iDfHgcyqJfXC8B+XbKHpftA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-node": "^3.972.76",
-        "@aws-sdk/dynamodb-codec": "^3.973.39",
-        "@aws-sdk/middleware-endpoint-discovery": "^3.972.27",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/dynamodb-codec": "^3.973.43",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.29",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -911,16 +911,16 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.1101.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1101.0.tgz",
-      "integrity": "sha512-qczxakJlFYG9E6nE2yWIJ2nXq0HbMzHxMSWIsyubPZqx1TANHd2CSJWDTkg+IsNKq+94tG+e+EJo3uADwZ6cdw==",
+      "version": "3.1114.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1114.0.tgz",
+      "integrity": "sha512-yXshoKNqG20sAqXAM0bKBFLQ2MAO3K8W39fheO0i0k2NKckfa0/K8W9PHpYXx0XwiDi460B6e/7B+uilecO12w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-node": "^3.972.76",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -1350,17 +1350,17 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.1101.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1101.0.tgz",
-      "integrity": "sha512-g/xmDwNRsObFM8WnYCvMOYipHRL2B+C18eRw5KzB3wiqF/BtDuscq8lIUVK9sU6bpCIqrDHVuHoUyKNaS9OWkg==",
+      "version": "3.1114.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.1114.0.tgz",
+      "integrity": "sha512-BMhx1eNX1KuPmnhVfN3C4pFTmDamWeI9EGd1PcIh+t92V530bVVbU98g9nYblYQbXDVk5zoJC7PRyMSQybeBsQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-node": "^3.972.76",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-node": "^3.972.80",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -1372,14 +1372,14 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
-      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
-        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
         "@aws/lambda-invoke-store": "^0.3.0",
         "@smithy/core": "^3.31.1",
         "@smithy/signature-v4": "^5.6.12",
@@ -1402,14 +1402,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
-      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1419,14 +1419,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
-      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -1438,21 +1438,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
-      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-login": "^3.972.72",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -1463,15 +1463,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
-      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1481,19 +1481,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.76",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
-      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.65",
-        "@aws-sdk/credential-provider-http": "^3.972.67",
-        "@aws-sdk/credential-provider-ini": "^3.973.10",
-        "@aws-sdk/credential-provider-process": "^3.972.65",
-        "@aws-sdk/credential-provider-sso": "^3.973.9",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -1504,14 +1504,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
-      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1521,16 +1521,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
-      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/token-providers": "3.1100.0",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1540,15 +1540,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
-      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1558,14 +1558,14 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.39.tgz",
-      "integrity": "sha512-6n1ER8qEvfruOfVFHVYrAtfSOk0ELudJDWyUMMb+M+tiP4rWSU44zd9ilQcM2/ESlRPyzxc2h7dU3R+UT+sVEg==",
+      "version": "3.973.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.43.tgz",
+      "integrity": "sha512-5nw01fhFJEKM68n0R65S1DijiSAQWZVbvH7IxTIJpFFbggg816jBVYvhK7W+XISjvtdg0rMkF/gQmuLGH713mg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/core": "^3.977.8",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1575,9 +1575,9 @@
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.9.tgz",
-      "integrity": "sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.11.tgz",
+      "integrity": "sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1647,15 +1647,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.27.tgz",
-      "integrity": "sha512-5AJlxrsg27IGGiQauWOdVyqK55EN0EMIwXndkVHhBiPT4CtdSaz89/sAENSw+GP4KF+BOWcgycZFNjkOLmfo1A==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.29.tgz",
+      "integrity": "sha512-cXW7QNIOhUSfccZmwJEjn9EdCAjzdOtt/+MtO5HWgxIZdhzyC1kNuQKIgGEDkgabxiXymWw0/VFWdqxqeLbgMA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "^3.972.9",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/endpoint-cache": "^3.972.11",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1942,15 +1942,15 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
-      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -1979,13 +1979,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
-      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1995,15 +1995,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1100.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
-      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.4",
-        "@aws-sdk/nested-clients": "^3.997.39",
-        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
-      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2096,9 +2096,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
-      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4941,9 +4941,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory": {
-      "version": "3.0.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-      "integrity": "sha512-8YlpdUI47NGNZdo56I7rEuf5IbMuLrZYRi2AiiOv2OpYefeH7rLXw8NGrG8D+MpSVQjge/KkPW3aDsWPd0Xfag==",
+      "version": "3.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+      "integrity": "sha512-Z6qriYp3VScfRHJ6s1BfNKB3wh0qXlO8oquNeZRUHWEzcFUC6qukHxcbnS1xPO1Jq6y4C/fNYn24rciT1/hmeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4952,30 +4952,30 @@
         "@aws-sdk/client-lambda-microvms": "^3.1075.0",
         "@aws-sdk/client-s3": "^3.1015.0",
         "@aws-sdk/client-s3vectors": "^3.1081.0",
-        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz#sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw=="
+        "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz#sha512-wt468Cwdu4OnGcKpGTcczf7//kdaemDZwkntVzL5LPhjEtRqh/Ge5qiwBxn5AC0AglM2kISYB3E8gBi5BVpQlQ=="
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "3.0.2",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
-      "integrity": "sha512-kk618HOBIs9+ovCmUpd9HKl/kB5idHF17AQiUVLBjfifgGf8oro+PZRuYwa3cQFBKslQZu8HfoHV9ll4nFfXFQ==",
+      "version": "3.1.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz",
+      "integrity": "sha512-L3FjDA6BgwjEY1+SrheHlqLesUsFkP3RHwQbWg0ckZMxPPljf6h9n0a3xakAYvUqySfY1qOqkqMtZfMwAgbIaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.263.0",
+        "aws-cdk-lib": "2.265.0",
         "constructs": "10.8.0"
       }
     },
     "node_modules/@theory-cloud/tabletheory-ts": {
-      "version": "3.0.4",
-      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
-      "integrity": "sha512-mso+vAlNLGZVj3DtsxuSVXMpvacwd1dTdX4IUHoNCIpPSLrp9Y+JWP0EgONDgfmaqrlE1sDgKYGftpP7JeqrRw==",
+      "version": "3.0.5",
+      "resolved": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz",
+      "integrity": "sha512-wt468Cwdu4OnGcKpGTcczf7//kdaemDZwkntVzL5LPhjEtRqh/Ge5qiwBxn5AC0AglM2kISYB3E8gBi5BVpQlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5593,9 +5593,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.263.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
-      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
+      "version": "2.265.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.265.0.tgz",
+      "integrity": "sha512-Ur96d/ZW+gqAW4XtqKQp//D9O/jQvyRoXhAqoHGybpV03qjckGIQcLcGkLV68+jv03TX/rOXHCsa2IEFcCXa4w==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -5613,11 +5613,11 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.6.0-beta",
+        "@aws/cloudformation-validate": "1.7.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -5653,7 +5653,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.6.0-beta",
+      "version": "1.7.0-beta",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -5677,7 +5677,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.8",
+      "version": "5.0.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",

--- a/ts/package.json
+++ b/ts/package.json
@@ -277,9 +277,9 @@
     "@emotion/server": "^11.11.0",
     "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-3.0.2.tgz",
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.0.2/theory-cloud-apptheory-cdk-3.0.2.tgz",
-    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz",
+    "@theory-cloud/apptheory": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-3.1.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v3.1.0/theory-cloud-apptheory-cdk-3.1.0.tgz",
+    "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz",
     "@types/jsdom": "^28.0.3",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",
@@ -288,7 +288,7 @@
     "@typescript-eslint/parser": "^8.60.0",
     "@vue/server-renderer": "^3.5.34",
     "antd": "^6.4.3",
-    "aws-cdk-lib": "2.263.0",
+    "aws-cdk-lib": "2.265.0",
     "c8": "^11.0.0",
     "constructs": "10.8.0",
     "esbuild": "^0.28.1",
@@ -306,7 +306,7 @@
   },
   "overrides": {
     "@theory-cloud/apptheory": {
-      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.4/theory-cloud-tabletheory-ts-3.0.4.tgz"
+      "@theory-cloud/tabletheory-ts": "https://github.com/theory-cloud/TableTheory/releases/download/v3.0.5/theory-cloud-tabletheory-ts-3.0.5.tgz"
     },
     "brace-expansion": "5.0.9",
     "postcss": "8.5.25"


### PR DESCRIPTION
## Summary
- `@theory-cloud/apptheory`: v3.0.2 → v3.1.0
- `@theory-cloud/apptheory-cdk`: v3.0.2 → v3.1.0
- `@theory-cloud/tabletheory-ts`: v3.0.4 → v3.0.5
- `aws-cdk-lib`: 2.263.0 → 2.265.0, matching the exact peer required by AppTheory CDK v3.1.0
- regenerated all three npm lockfiles from the published tarballs and refreshed the two synthesized asset-hash snapshots required by the dependency changes
- disclosed lockfile scope: full regeneration floated about 25 existing `@aws-sdk/*` / `@smithy/*` transitive packages within existing caret ranges; no packages were added or removed and no package.json ranges changed
- mirrored the consumer-facing/documentation-adjacent pin set from precedent #426 while leaving `VERSION`, package version, and both Release Please manifests unchanged at 4.0.6

## Documentation mirror

Precedent #426 folded its documentation into `fix(deps)`; this round adds one separately reviewable `docs(deps)` commit because the dependency commit was already published to this branch.

Updated the 12 documentation/documentation-adjacent files from #426 that carry live consumer pins or compatibility labels:

- `README.md`
- `ts/README.md`
- `docs/UPSTREAM_RELEASE_PINS.md`
- `docs/AWS_DEPLOYMENT_SHAPE.md`
- `docs/cdk/README.md`
- `docs/getting-started.md`
- `docs/troubleshooting.md`
- `docs/integrations/apptheory.md`
- `docs/integrations/tabletheory.md`
- `docs/_patterns.yaml`
- `gov-infra/planning/docs-init-examples/_decisions.yaml`
- `gov-infra/planning/docs-init-examples/_patterns.yaml`

The two AppTheory v3.1.0 deployment-caveat edits are label-only: `distributionPaths` remains absent, so the caveat's substance is unchanged. The six package manifests/lockfiles that #426 also touched were already aligned by `ff500178`; this PR additionally requires the two regenerated synthesis snapshots. The remaining #426 doctor-test file is intentionally not mirrored because its old URLs are inert drift-detection fixtures.

## Release asset SHA-256

Re-derived with `sha256sum` against freshly downloaded published assets:

- AppTheory runtime: `8251003a245470f9718e014ae4792761127ab1c1d9c89c75b4d85aa8302d41a4` → `9c6d73f1734f4080f2241ce6549045fe55a2a585ea834988d10fcbf6c6b5cac3`
- AppTheory CDK: `201b0a2d4ac2145c71404d27532eb58c01eb46e5e170679bd52106d977f99381` → `21a5cddcf3d55a123f22f77fc2c153d32e3397225ac136ed12b1f51ca52fd740`
- TableTheory TypeScript: `ec622601a39c6068b47cf90aa08fff5eff7defc7ce2f47645e54fddbdd12ea1b` → `dfe97bc7931962c4df33b96bbfb89531123b81d723c4860c68704c3b6954b8a6`

## Stale-pin sweep

The required grep has zero unadjudicated stale upstream pins. Its four remaining matches are intentionally unchanged:

- `ts/test/unit/doctor-cli.test.ts:27,29`: review-cleared inert fixtures used to exercise drift diagnosis.
- `ts/src/create-templates/index.ts:62`: review-cleared dead fallback; `create-cli.ts:246` supplies the shipped manifest's `2.265.0` through `ctx.dependencyVersions`.
- `docs/Gemfile.lock:141`: unrelated `terminal-table (3.0.2)` Ruby dependency, not a Theory Cloud release pin.

## Validation

- clean `npm ci` PASS in `ts`, `infra/apptheory-ssg-isr-site`, and `infra/apptheory-ssr-site`; each reported `found 0 vulnerabilities`
- `make ts-build ts-typecheck ts-lint ts-format-check ts-test ts-coverage infra-snapshot-test verify-version-alignment verify-ts-pack verify-npm-audit verify-go-version-pin verify-ci-rubric-enforced verify-deterministic-builds` PASS
  - `tests 703`, `pass 702`, `fail 0`, `skipped 1`
  - coverage `All files | 73.63 | 65.84 | 60.8 | 73.63`
  - `H2: AppTheorySsrSite stack synth is snapshotted` PASS
  - `H3: SSG+ISR stack synth is snapshotted` PASS
  - `version-alignment: PASS (4.0.6)`
  - `ts-pack: PASS (theory-cloud-facetheory-4.0.6.tgz)`
  - `npm-audit: PASS` for all three package surfaces
  - `go-version-pin: PASS (go1.26.5)`
  - `ci-rubric: PASS`
  - `deterministic-builds: PASS (4.0.6)`
- `make rubric` PASS
  - `infra-synth-snapshots: PASS (20s)`
  - `gov-rubric-report: schema-valid`
  - `gov-rubric: PASS`
- `scripts/build-release-assets.sh 4.0.6` PASS
  - npm tarball ships `ts/README.md` (byte-identical to the repo `ts/README.md`) with the updated pins
  - reference bundle contains both READMEs and the updated `docs/` pin/compatibility set, including all three new SHA-256 records

## Factory framework-currency wave

This is wave F1. After the resulting FaceTheory release is available, `theory-mcp-server/control-plane`, `theorycloud-ai/control-plane`, and `autheory/hub-admin-portal` cycle it in during wave F2.

Commits signed (SSH/ED25519).
