### PR TITLE
gov-infra: rubric verifier reconciliation (template parity propagation)

### DIFF
--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -73,6 +73,17 @@ require_cmd_or_blocked() {
   fi
 }
 
+require_intended_git_worktree_or_blocked() {
+  require_cmd_or_blocked git || return $?
+
+  local git_toplevel
+  git_toplevel="$(git -C "${REPO_ROOT}" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -z "${git_toplevel}" || "${git_toplevel}" != "${REPO_ROOT}" ]]; then
+    echo "BLOCKED: repository root is not the intended Git worktree root" >&2
+    return 2
+  fi
+}
+
 file_sha256() {
   local file_path="$1"
   if command -v sha256sum >/dev/null 2>&1; then
@@ -370,6 +381,7 @@ gov_check_quality() {
 gov_check_consistency() {
   local failures=0
   local materialized_surface
+  require_intended_git_worktree_or_blocked || return $?
   require_cmd_or_blocked python3 || return $?
   scripts/verify-version-alignment.sh
   run_with_pinned_go_toolchain scripts/verify-go-version-pin.sh

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -5,6 +5,11 @@
 #
 # Usage from repository root:
 #   bash gov-infra/verifiers/gov-verify-rubric.sh
+#
+# Provenance note: git_head is emitted only when this repository is the resolved
+# Git worktree root and HEAD is a 40-hex SHA-1 object ID. It is omitted when
+# git/the intended Git tree is unavailable and in SHA-256 object-format
+# repositories, whose longer object IDs are not yet in the schema.
 
 set -euo pipefail
 
@@ -35,50 +40,6 @@ repo_relative_path() {
     printf '%s' "${path#"${REPO_ROOT}/"}"
   else
     printf '%s' "${path}"
-  fi
-}
-
-is_valid_report_timestamp() {
-  local value="$1"
-  [[ "${value}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || return 1
-  python3 - "${value}" <<'PY'
-from datetime import datetime
-import sys
-value = sys.argv[1]
-try:
-    parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
-except ValueError:
-    sys.exit(1)
-if parsed.strftime("%Y-%m-%dT%H:%M:%SZ") != value:
-    sys.exit(1)
-PY
-}
-
-read_existing_report_timestamp() {
-  [[ -f "${REPORT_PATH}" ]] || return 0
-  python3 - "${REPORT_PATH}" <<'PY'
-import json
-import sys
-from pathlib import Path
-try:
-    value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")).get("timestamp", "")
-except Exception:
-    value = ""
-if isinstance(value, str):
-    print(value)
-PY
-}
-
-select_report_timestamp() {
-  local supplied="${GOV_REPORT_TIMESTAMP:-}"
-  local existing=""
-  existing="$(read_existing_report_timestamp 2>/dev/null || true)"
-  if is_valid_report_timestamp "${supplied}" 2>/dev/null; then
-    printf '%s' "${supplied}"
-  elif is_valid_report_timestamp "${existing}" 2>/dev/null; then
-    printf '%s' "${existing}"
-  else
-    date -u +%Y-%m-%dT%H:%M:%SZ
   fi
 }
 
@@ -463,7 +424,19 @@ FAIL_COUNT=0
 BLOCKED_COUNT=0
 PACK_VERSION="$(read_pack_field packVersion)"
 PACK_DIGEST="$(read_pack_field packDigest)"
-REPORT_TIMESTAMP="$(select_report_timestamp)"
+REPORT_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+REPORT_GIT_HEAD=""
+if command -v git >/dev/null 2>&1; then
+  REPORT_GIT_HEAD_CANDIDATE="$(git rev-parse --verify HEAD 2>/dev/null || true)"
+  REPORT_GIT_TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ "${REPORT_GIT_TOPLEVEL}" == "${REPO_ROOT}" && "${REPORT_GIT_HEAD_CANDIDATE}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    REPORT_GIT_HEAD="${REPORT_GIT_HEAD_CANDIDATE}"
+  fi
+fi
+REPORT_GIT_HEAD_JSON=""
+if [[ -n "${REPORT_GIT_HEAD}" ]]; then
+  printf -v REPORT_GIT_HEAD_JSON '  "git_head": "%s",\n' "${REPORT_GIT_HEAD}"
+fi
 declare -a RESULTS=()
 
 record_result() {
@@ -534,6 +507,7 @@ write_report() {
     printf '  "$schema": "%s",\n' "$(json_escape "${REPORT_SCHEMA_URI}")"
     printf '  "schemaVersion": "%s",\n' "$(json_escape "${REPORT_SCHEMA_VERSION}")"
     printf '  "timestamp": "%s",\n' "$(json_escape "${REPORT_TIMESTAMP}")"
+    printf '%s' "${REPORT_GIT_HEAD_JSON}"
     printf '  "pack": {"version": "%s", "digest": "%s"},\n' "$(json_escape "${PACK_VERSION}")" "$(json_escape "${PACK_DIGEST}")"
     printf '  "project": {"name": "FaceTheory", "slug": "facetheory"},\n'
     printf '  "summary": {"status": "%s", "pass": %d, "fail": %d, "blocked": %d},\n' "${status}" "${PASS_COUNT}" "${FAIL_COUNT}" "${BLOCKED_COUNT}"
@@ -564,20 +538,25 @@ schema_uri = sys.argv[2]
 report = json.loads(report_path.read_text(encoding="utf-8"))
 errors = []
 
-allowed_top = {"$schema", "schemaVersion", "timestamp", "pack", "project", "summary", "results"}
+required_top = {"$schema", "schemaVersion", "timestamp", "pack", "project", "summary", "results"}
+allowed_top = required_top | {"git_head"}
 allowed_result = {"id", "category", "status", "message", "evidencePath"}
 allowed_categories = {
     "Quality", "Consistency", "Completeness", "Security", "Compliance", "Maintainability", "Docs"
 }
 expected_ids = ["QUA-1", "CON-1", "COM-1", "SEC-1", "CMP-1", "MAI-1", "DOC-1"]
-if set(report) != allowed_top:
-    errors.append(f"top-level keys must be exactly {sorted(allowed_top)}, got {sorted(report)}")
+if not required_top.issubset(report) or not set(report).issubset(allowed_top):
+    errors.append(
+        f"top-level keys must include {sorted(required_top)} and may include git_head; got {sorted(report)}"
+    )
 if report.get("$schema") != schema_uri:
     errors.append("$schema mismatch")
 if report.get("schemaVersion") != "gov_rubric_report.v1":
     errors.append("schemaVersion must be gov_rubric_report.v1")
 if not re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z", str(report.get("timestamp", ""))):
     errors.append("timestamp must be UTC seconds precision")
+if "git_head" in report and not re.fullmatch(r"[0-9a-fA-F]{40}", str(report["git_head"])):
+    errors.append("git_head must be a 40-hex SHA-1 object ID when present")
 pack = report.get("pack")
 if not isinstance(pack, dict) or set(pack) != {"version", "digest"}:
     errors.append("pack must contain exactly version and digest")

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -6,6 +6,11 @@
 # Usage from repository root:
 #   bash gov-infra/verifiers/gov-verify-rubric.sh
 #
+# Exit codes:
+#   0 - All rubric items PASS
+#   1 - One or more rubric items FAIL or BLOCKED
+#   2 - Script error (missing dependencies, invalid config, etc.)
+#
 # Provenance note: git_head is emitted only when this repository is the resolved
 # Git worktree root and HEAD is a 40-hex SHA-1 object ID. It is omitted when
 # git/the intended Git tree is unavailable and in SHA-256 object-format

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -433,6 +433,7 @@ gov_check_maintainability() {
 }
 
 gov_check_docs() {
+  require_intended_git_worktree_or_blocked || return $?
   check_gov_docs
 }
 


### PR DESCRIPTION
## Factory assignment

A-track debrief 2026-08-18 §3 rubric-hygiene propagation, round 1.

## Per-item dispositions

1. **Rubric/template reconciliation — changed** (`dd0fcd4`). Replaced timestamp reuse/override behavior with a fresh UTC timestamp on every run; added optional `git_head` emission only when HEAD is a 40-hex SHA-1 and `git rev-parse --show-toplevel` resolves exactly to FaceTheory's verifier root; aligned the repo-local `gov_rubric_report.v1` validator with the optional field. FaceTheory project identity, rubric IDs, categories, and repo-local commands are preserved.
2. **Exit-code header parity — changed** (`993661a`). Ported the current served template's byte-identical 0/1/2 comment block without changing behavior: PASS exits 0, result FAIL/BLOCKED exits 1, and internal script/config errors use 2.
3. **Negative-assertion precision — no code change required.** `gov-infra/verifiers/` contains one verifier and zero verifier test scripts. A focused grep for `expect_fail`, “unexpectedly passed/succeeded”, expected failure/exit-1 helpers, and captured `status`/`exit_code == 0` inversions returned exit 1 (zero matches). Manual review of all six `if !` / `ec == 0` candidates found only tool/command guards, direct policy assertions, result classification, and optional diagnostic printing—not negative test assertions. No any-nonzero expected-failure assertion exists in the scoped verifier surface.
4. **Toolchain pin surface — inventory only; no version changes.** See the complete inventory below.
5. **Non-git BLOCKED semantics — changed** (`27fc1e3`). Added an intended-root guard before Git-dependent materialization assertions. Missing Git, a non-Git copy, or an enclosing worktree now returns 2 from `gov_check_consistency`, which the rubric records as `CON-1: BLOCKED`, with Git diagnostics suppressed. (Extended by `## Round 1 rework`: `9700d9c5` routes `gov_check_docs` through the same guard, so DOC-1 also fails closed.)
6. **Demonstrations — complete.** Fresh timestamps, in-repo provenance, enclosing-root omission, and plain non-Git behavior are quoted below. The scratch copy excluded `.git` from FaceTheory, was outside the repository, and was deleted after the proofs.
7. **Validation — green.** Two full rubric runs were PASS with 7/7 items, zero failures, zero BLOCKED items, and zero carve-outs. Version alignment and the TypeScript check/build suite are green.

## Toolchain pin-surface inventory

Current pin: `1.26.5`.

Hard pin / exact tracked-version references from `git grep -n -F '1.26.5'`:

- `.go-version:1` — canonical hard pin (`1.26.5`).
- `gov-infra/evidence/CON-1-output.log:6` — tracked generated proof (`go-version-pin: PASS (go1.26.5)`); wave F2 must regenerate it with the pin change.

Consumers/enforcement surface:

- `.github/workflows/ci.yml:216` — `go-version-file: ".go-version"`.
- `.github/workflows/prerelease.yml:270` — same.
- `.github/workflows/release.yml:175,662` — same in both Go-using jobs.
- `Makefile:46-47` — `verify-go-version-pin` target delegates to the verifier script.
- `gov-infra/verifiers/gov-verify-rubric.sh:120-121,387` — reads `.go-version`, exports `GOTOOLCHAIN="go${pin}"`, and invokes `scripts/verify-go-version-pin.sh`.
- `scripts/verify-go-version-pin.sh` — owns pin-file format and installed-toolchain equality checks.
- `gov-infra/planning/facetheory-10of10-rubric.md:8` — documents the `.go-version` consistency gate without quoting an exact version.

Absent surfaces: no tracked root `go.mod`, no `cdk/go.mod`, and no README/planning document quotes the exact `1.26.5` pin. Therefore wave F2's atomic old-version cleanup checklist is `.go-version` plus regenerated `gov-infra/evidence/CON-1-output.log`; the dynamic consumers above must remain aligned and green.

## Demonstrations

### Two runs: fresh timestamps and correct in-repo `git_head`

```text
first_timestamp=2026-08-20T20:04:03Z
second_timestamp=2026-08-20T20:07:44Z
timestamps_distinct=true
git_head=27fc1e335edce6b9b6d7abb8dc09148a5b10389b
summary={"blocked": 0, "fail": 0, "pass": 7, "status": "PASS"}
```

The recorded head equals the pushed branch head used for the runs. (Superseded by `## Round 1 rework`: head later moved to `9700d9c5`; see that section for current evidence.)

### Enclosing non-root worktree

(Superseded by `## Round 1 rework` — DOC-1 now also BLOCKs in this condition; current numbers there.)

```text
resolved_toplevel=/tmp/facetheory-gov-round1-scratch.wP2Oev
FaceTheory/.git=<absent>
rubric_exit=1
git_head=<omitted>
summary={"blocked": 1, "fail": 0, "pass": 6, "status": "BLOCKED"}
CON-1 message=gov_check_consistency blocked with exit code 2
raw_fatal_lines=0
```

### Plain non-Git scratch copy

(Superseded by `## Round 1 rework` — DOC-1 now also BLOCKs in this condition; current numbers there.)

```text
rev_parse_status=128
rubric_exit=1
git_head=<omitted>
summary={"blocked": 1, "fail": 0, "pass": 6, "status": "BLOCKED"}
CON-1 message=gov_check_consistency blocked with exit code 2
raw_fatal_lines=0
scratch_deleted=true
```

The rubric entrypoint aggregates any BLOCKED result to process exit 1 per the served header; the Git-dependent check itself preserves the intended exit 2, recorded verbatim in `CON-1`.

## Validation

```text
$ bash gov-infra/verifiers/gov-verify-rubric.sh
infra-synth-snapshots: PASS (43s)
gov-rubric-report: schema-valid
gov-rubric: PASS (.../gov-infra/evidence/gov-rubric-report.json)
summary={"blocked": 0, "fail": 0, "pass": 7, "status": "PASS"}
```

```text
$ scripts/verify-version-alignment.sh
version-alignment: PASS (4.0.6)
VERSION=4.0.6
stable_manifest=4.0.6
premain_manifest=4.0.6
```

```text
$ cd ts && npm run check
ℹ tests 703
ℹ pass 702
ℹ fail 0
ℹ skipped 1
```

The single skip is the existing optional external portal-reference fixture; there are no failures. The check also passed lint, typecheck, Svelte-runes verification, and all 26 example README checks.

```text
$ cd ts && npm run build
npm notice run tsc -p tsconfig.build.json && node scripts/copy-svelte-sources.mjs
(exit 0)
```

## Scope and signing

- Only `gov-infra/verifiers/gov-verify-rubric.sh` changed.
- No dependency, `go.mod`, `go.sum`, threshold, release-train, production, sibling-repo, or materialized-file changes.
- signing: SSH/ED25519


## Round 1 rework

Finding 1 is resolved by commit `9700d9c5aae11f1df1e6fb0761a3ca974c76eb07` (`fix(gov-infra): block DOC-1 outside intended worktree`, signed (SSH/ED25519)). `gov_check_docs` now enters through the same `require_intended_git_worktree_or_blocked` guard as CON-1. This is a one-line wrapper change: intended-worktree DOC-1 output remains byte-identical, while missing or enclosing Git provenance now produces a clean DOC-1 `BLOCKED` rather than a vacuous tracked-state PASS.

Finding 2 remains intentionally unchanged locally because the logical/physical path behavior was propagated from the mcpserver reference idiom and is being corrected upstream for a later parity wave. Finding 3 remains deferred to F2 evidence regeneration; no evidence artifact is part of this commit.

### Validation

Version alignment:

```text
version-alignment: PASS (4.0.6)
VERSION=4.0.6
package=4.0.6
package-lock=4.0.6
stable manifest=4.0.6
premain manifest=4.0.6
```

In the intended Git worktree:

```text
infra-synth-snapshots: PASS (18s)
gov-rubric-report: schema-valid
gov-rubric: PASS
in_git_summary={"blocked":0,"fail":0,"pass":7,"status":"PASS"}
in_git_results=QUA-1=PASS,CON-1=PASS,COM-1=PASS,SEC-1=PASS,CMP-1=PASS,MAI-1=PASS,DOC-1=PASS
DOC-1-before-sha256=08f1e9609dfa0e5b59120efb04a1a644c8f0397ac84281770f3c1e9a62675e13
DOC-1-after-sha256=08f1e9609dfa0e5b59120efb04a1a644c8f0397ac84281770f3c1e9a62675e13
DOC-1-byte-unchanged=PASS
```

Tracked-only non-Git scratch (`.git` excluded), deleted after proof:

```text
non_git_rubric_exit=1
gov-rubric-report: schema-valid
gov-rubric: BLOCKED
non_git_git_head_present=false
non_git_summary={"blocked":2,"fail":0,"pass":5,"status":"BLOCKED"}
non_git_CON-1=BLOCKED
non_git_DOC-1=BLOCKED
non_git_raw_fatal_lines=0
DOC-1: BLOCKED: repository root is not the intended Git worktree root
CON-1: BLOCKED: repository root is not the intended Git worktree root
scratch_deleted=PASS
```

Nested copy inside an enclosing Git worktree, deleted after proof:

```text
enclosing_rubric_exit=1
gov-rubric-report: schema-valid
gov-rubric: BLOCKED
enclosing_git_head_present=false
enclosing_summary={"blocked":2,"fail":0,"pass":5,"status":"BLOCKED"}
enclosing_CON-1=BLOCKED
enclosing_DOC-1=BLOCKED
enclosing_raw_fatal_lines=0
DOC-1: BLOCKED: repository root is not the intended Git worktree root
scratch_deleted=PASS
```

Tracked-GEMINI mutation in an intended scratch Git tree, deleted after proof:

```text
mutation_rubric_exit=1
gov-rubric-report: schema-valid
gov-rubric: FAIL
mutation_summary={"blocked":0,"fail":1,"pass":6,"status":"FAIL"}
mutation_DOC-1=FAIL
FAIL: docs/profile consistency drift
- GEMINI.md must remain untracked; the absence from tracked state is the documented decision
scratch_deleted=PASS
```

TypeScript checks and build:

```text
npm_run_check_exit=0
ℹ tests 703
ℹ pass 702
ℹ fail 0
ℹ skipped 1
﹣ portal reference: SSR + hydration renders real portal components # missing portal reference

npm notice run @theory-cloud/facetheory@4.0.6 build
npm notice run tsc -p tsconfig.build.json && node scripts/copy-svelte-sources.mjs
npm_run_build_exit=0
```

